### PR TITLE
Use service for writing operations

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/repository/OcppTagWriteRepository.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/OcppTagWriteRepository.java
@@ -18,29 +18,16 @@
  */
 package de.rwth.idsg.steve.repository;
 
-import de.rwth.idsg.steve.repository.dto.OcppTag;
-import de.rwth.idsg.steve.web.dto.OcppTagQueryForm;
-import jooq.steve.db.tables.records.OcppTagActivityRecord;
-import org.jooq.Result;
-
+import de.rwth.idsg.steve.web.dto.OcppTagForm;
 import java.util.List;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 19.08.2014
  */
-public interface OcppTagRepository {
-    List<OcppTag.Overview> getOverview(OcppTagQueryForm form);
-
-    Result<OcppTagActivityRecord> getRecords();
-    Result<OcppTagActivityRecord> getRecords(List<String> idTagList);
-
-    OcppTagActivityRecord getRecord(String idTag);
-    OcppTagActivityRecord getRecord(int ocppTagPk);
-
-    List<String> getIdTags();
-    List<String> getActiveIdTags();
-
-    List<String> getParentIdTags();
-    String getParentIdtag(String idTag);
+public interface OcppTagWriteRepository {
+    void addOcppTagList(List<String> idTagList);
+    int addOcppTag(OcppTagForm form);
+    void updateOcppTag(OcppTagForm form);
+    void deleteOcppTag(int ocppTagPk);
 }

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImpl.java
@@ -20,6 +20,7 @@ package de.rwth.idsg.steve.repository.impl;
 
 import de.rwth.idsg.steve.SteveException;
 import de.rwth.idsg.steve.repository.OcppTagRepository;
+import de.rwth.idsg.steve.repository.OcppTagWriteRepository;
 import de.rwth.idsg.steve.repository.dto.OcppTag.Overview;
 import de.rwth.idsg.steve.web.dto.OcppTagForm;
 import de.rwth.idsg.steve.web.dto.OcppTagQueryForm;
@@ -31,7 +32,6 @@ import org.joda.time.DateTime;
 import org.jooq.DSLContext;
 import org.jooq.JoinType;
 import org.jooq.Record10;
-import org.jooq.Record7;
 import org.jooq.RecordMapper;
 import org.jooq.Result;
 import org.jooq.SelectQuery;
@@ -55,7 +55,7 @@ import static jooq.steve.db.tables.OcppTagActivity.OCPP_TAG_ACTIVITY;
  */
 @Slf4j
 @Repository
-public class OcppTagRepositoryImpl implements OcppTagRepository {
+public class OcppTagRepositoryImpl implements OcppTagRepository, OcppTagWriteRepository {
 
     private final DSLContext ctx;
 


### PR DESCRIPTION
With the new API controllers, the business logic of writing operations should be shared and the service layer is a good place for that.