### PR TITLE
Fix the objectMapper bug and refactor properties for k8s

### DIFF
--- a/k8s/yaml/Deployment.yaml
+++ b/k8s/yaml/Deployment.yaml
@@ -32,3 +32,7 @@ spec:
           value: ""
         - name: ADMIN_PASSWORD
           value: ""
+        - name: WEBAPI_KEY
+          value: "STEVE-API-KEY"
+        - name: WEBAPI_VALUE
+          value: ""

--- a/src/main/java/de/rwth/idsg/steve/config/SecurityConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/SecurityConfiguration.java
@@ -19,6 +19,7 @@
 package de.rwth.idsg.steve.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.common.base.Strings;
 import de.rwth.idsg.steve.SteveProdCondition;
 import de.rwth.idsg.steve.web.api.ApiControllerAdvice;
@@ -185,7 +186,8 @@ public class SecurityConfiguration {
 
     public static class ApiKeyAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-        private final ObjectMapper mapper = new ObjectMapper();
+        private final ObjectMapper mapper = new ObjectMapper()
+                .registerModule(new JodaModule());
 
         @Override
         public void commence(HttpServletRequest request, HttpServletResponse response,

--- a/src/main/java/de/rwth/idsg/steve/service/GithubReleaseCheckService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/GithubReleaseCheckService.java
@@ -21,6 +21,7 @@ package de.rwth.idsg.steve.service;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.github.zafarkhaja.semver.Version;
 import de.rwth.idsg.steve.SteveConfiguration;
 import de.rwth.idsg.steve.web.dto.ReleaseReport;
@@ -62,7 +63,8 @@ public class GithubReleaseCheckService implements ReleaseCheckService {
         factory.setReadTimeout(API_TIMEOUT_IN_MILLIS);
         factory.setConnectTimeout(API_TIMEOUT_IN_MILLIS);
 
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = new ObjectMapper()
+                .registerModule(new JodaModule());
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         mapper.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
 

--- a/src/main/resources/config/kubernetes/main.properties
+++ b/src/main/resources/config/kubernetes/main.properties
@@ -20,8 +20,8 @@ auth.password=$ADMIN_PASSWORD
 # The header key and value for Web API access using API key authorization.
 # Both must be set for Web APIs to be enabled. Otherwise, we will block all calls.
 #
-webapi.key = STEVE-API-KEY
-webapi.value =
+webapi.key=$WEBAPI_KEY
+webapi.value=$WEBAPI_VALUE
 
 # Jetty configuration
 #


### PR DESCRIPTION
Hi steve teams!
Thank you for creating good open-source.

I would like to fix the bug and also refactor properties for kubernetes.

You can reproduce the bug like below.

1. Run the application with `webapi.value` for exposing api endpoints.
2. Send the get request with invalid key value in header.
3. You will get the 500 error instead of 401 error.

The reason why it happened is that the jackson library doesn't support joda module as default. So I registered joda module as manually when the Object mapper was created.

And also I refactored properties of kubernetes, because k8s environment should be get the value dynamically by enviroment value.

Please review and give me feedback. 
Thanks.