### PR TITLE
Refactor OcppTagService

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/service/ChargePointService15_Client.java
+++ b/src/main/java/de/rwth/idsg/steve/service/ChargePointService15_Client.java
@@ -28,7 +28,6 @@ import de.rwth.idsg.steve.ocpp.task.GetConfigurationTask;
 import de.rwth.idsg.steve.ocpp.task.GetLocalListVersionTask;
 import de.rwth.idsg.steve.ocpp.task.ReserveNowTask;
 import de.rwth.idsg.steve.ocpp.task.SendLocalListTask;
-import de.rwth.idsg.steve.repository.OcppTagRepository;
 import de.rwth.idsg.steve.repository.ReservationRepository;
 import de.rwth.idsg.steve.repository.dto.ChargePointSelect;
 import de.rwth.idsg.steve.repository.dto.InsertReservationParams;
@@ -55,7 +54,6 @@ import java.util.List;
 @Qualifier("ChargePointService15_Client")
 public class ChargePointService15_Client extends ChargePointService12_Client {
 
-    @Autowired protected OcppTagRepository userRepository;
     @Autowired protected OcppTagService ocppTagService;
     @Autowired protected ReservationRepository reservationRepository;
 
@@ -135,7 +133,7 @@ public class ChargePointService15_Client extends ChargePointService12_Client {
                                                              .build();
 
         int reservationId = reservationRepository.insert(res);
-        String parentIdTag = userRepository.getParentIdtag(params.getIdTag());
+        String parentIdTag = ocppTagService.getParentIdtag(params.getIdTag());
 
         EnhancedReserveNowParams enhancedParams = new EnhancedReserveNowParams(params, reservationId, parentIdTag);
         ReserveNowTask task = new ReserveNowTask(getVersion(), enhancedParams, reservationRepository);

--- a/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
@@ -22,7 +22,10 @@ import com.google.common.base.Strings;
 import de.rwth.idsg.steve.SteveException;
 import de.rwth.idsg.steve.repository.OcppTagRepository;
 import de.rwth.idsg.steve.repository.SettingsRepository;
+import de.rwth.idsg.steve.repository.dto.OcppTag;
 import de.rwth.idsg.steve.service.dto.UnidentifiedIncomingObject;
+import de.rwth.idsg.steve.web.dto.OcppTagForm;
+import de.rwth.idsg.steve.web.dto.OcppTagQueryForm;
 import jooq.steve.db.tables.records.OcppTagActivityRecord;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +36,7 @@ import org.jetbrains.annotations.Nullable;
 import org.joda.time.DateTime;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -49,6 +53,30 @@ public class OcppTagService {
 
     private final SettingsRepository settingsRepository;
     private final OcppTagRepository ocppTagRepository;
+
+    public List<OcppTag.Overview> getOverview(OcppTagQueryForm form) {
+        return ocppTagRepository.getOverview(form);
+    }
+
+    public OcppTagActivityRecord getRecord(int ocppTagPk) {
+        return ocppTagRepository.getRecord(ocppTagPk);
+    }
+
+    public List<String> getIdTags() {
+        return ocppTagRepository.getIdTags();
+    }
+
+    public List<String> getActiveIdTags() {
+        return ocppTagRepository.getActiveIdTags();
+    }
+
+    public List<String> getParentIdTags() {
+        return ocppTagRepository.getParentIdTags();
+    }
+
+    public String getParentIdtag(String idTag) {
+        return ocppTagRepository.getParentIdtag(idTag);
+    }
 
     public List<AuthorizationData> getAuthDataOfAllTags() {
         DateTime nowDt = DateTime.now();
@@ -102,6 +130,28 @@ public class OcppTagService {
             log.error("Exception occurred", e);
             return supplierWhenException.get();
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Create, Update, Delete operations
+    // -------------------------------------------------------------------------
+
+    public int addOcppTag(OcppTagForm form) {
+        var id = ocppTagRepository.addOcppTag(form);
+        removeUnknown(Collections.singletonList(form.getIdTag()));
+        return id;
+    }
+    public void addOcppTagList(List<String> idTagList) {
+        ocppTagRepository.addOcppTagList(idTagList);
+        removeUnknown(idTagList);
+    }
+
+    public void updateOcppTag(OcppTagForm form) {
+        ocppTagRepository.updateOcppTag(form);
+    }
+
+    public void deleteOcppTag(int ocppTagPk) {
+        ocppTagRepository.deleteOcppTag(ocppTagPk);
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
@@ -33,7 +33,6 @@ import ocpp.cs._2015._10.IdTagInfo;
 import org.jetbrains.annotations.Nullable;
 import org.joda.time.DateTime;
 import org.jooq.RecordMapper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -45,12 +44,13 @@ import java.util.function.Supplier;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class OcppTagService {
 
-    @Autowired private SettingsRepository settingsRepository;
-    @Autowired private OcppTagRepository ocppTagRepository;
-
     private final UnidentifiedIncomingObjectService invalidOcppTagService = new UnidentifiedIncomingObjectService(1000);
+
+    private final SettingsRepository settingsRepository;
+    private final OcppTagRepository ocppTagRepository;
 
     public List<AuthorizationData> getAuthDataOfAllTags() {
         return ocppTagRepository.getRecords()

--- a/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
@@ -53,13 +53,13 @@ public class OcppTagService {
     private final OcppTagRepository ocppTagRepository;
 
     public List<AuthorizationData> getAuthDataOfAllTags() {
-        return ocppTagRepository.getRecords()
-                                .map(new AuthorisationDataMapper());
+        DateTime nowDt = DateTime.now();
+        return ocppTagRepository.getRecords().map(record -> mapToAuthorizationData(record, nowDt));
     }
 
     public List<AuthorizationData> getAuthData(List<String> idTagList) {
-        return ocppTagRepository.getRecords(idTagList)
-                                .map(new AuthorisationDataMapper());
+        DateTime nowDt = DateTime.now();
+        return ocppTagRepository.getRecords(idTagList).map(record -> mapToAuthorizationData(record, nowDt));
     }
 
     public List<UnidentifiedIncomingObject> getUnknownOcppTags() {
@@ -195,21 +195,14 @@ public class OcppTagService {
         }
     }
 
-    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-    private static class AuthorisationDataMapper implements RecordMapper<OcppTagActivityRecord, AuthorizationData> {
-
-        private final DateTime nowDt = DateTime.now();
-
-        @Override
-        public AuthorizationData map(OcppTagActivityRecord record) {
-            return new AuthorizationData().withIdTag(record.getIdTag())
-                                          .withIdTagInfo(
-                                                  new ocpp.cp._2015._10.IdTagInfo()
-                                                          .withStatus(decideStatusForAuthData(record, nowDt))
-                                                          .withParentIdTag(record.getParentIdTag())
-                                                          .withExpiryDate(record.getExpiryDate())
-                                          );
-        }
+    private static AuthorizationData mapToAuthorizationData(OcppTagActivityRecord record, DateTime nowDt) {
+        return new AuthorizationData().withIdTag(record.getIdTag())
+                                      .withIdTagInfo(
+                                              new ocpp.cp._2015._10.IdTagInfo()
+                                                      .withStatus(decideStatusForAuthData(record, nowDt))
+                                                      .withParentIdTag(record.getParentIdTag())
+                                                      .withExpiryDate(record.getExpiryDate())
+                                      );
     }
 
     private enum ConcurrencyToggle {

--- a/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
@@ -24,7 +24,6 @@ import de.rwth.idsg.steve.repository.OcppTagRepository;
 import de.rwth.idsg.steve.repository.SettingsRepository;
 import de.rwth.idsg.steve.service.dto.UnidentifiedIncomingObject;
 import jooq.steve.db.tables.records.OcppTagActivityRecord;
-import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import ocpp.cp._2015._10.AuthorizationData;
@@ -32,7 +31,6 @@ import ocpp.cs._2015._10.AuthorizationStatus;
 import ocpp.cs._2015._10.IdTagInfo;
 import org.jetbrains.annotations.Nullable;
 import org.joda.time.DateTime;
-import org.jooq.RecordMapper;
 import org.springframework.stereotype.Service;
 
 import java.util.List;

--- a/src/main/java/de/rwth/idsg/steve/web/api/OcppTagsRestController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/api/OcppTagsRestController.java
@@ -19,7 +19,6 @@
 package de.rwth.idsg.steve.web.api;
 
 import de.rwth.idsg.steve.SteveException;
-import de.rwth.idsg.steve.repository.OcppTagRepository;
 import de.rwth.idsg.steve.repository.dto.OcppTag;
 import de.rwth.idsg.steve.service.OcppTagService;
 import de.rwth.idsg.steve.web.api.ApiControllerAdvice.ApiErrorResponse;
@@ -43,7 +42,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -56,7 +54,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OcppTagsRestController {
 
-    private final OcppTagRepository ocppTagRepository;
     private final OcppTagService ocppTagService;
 
     @ApiResponses(value = {
@@ -70,7 +67,7 @@ public class OcppTagsRestController {
     public List<OcppTag.Overview> get(OcppTagQueryForm.ForApi params) {
         log.debug("Read request for query: {}", params);
 
-        var response = ocppTagRepository.getOverview(params);
+        var response = ocppTagService.getOverview(params);
         log.debug("Read response for query: {}", response);
         return response;
     }
@@ -106,8 +103,7 @@ public class OcppTagsRestController {
     public OcppTag.Overview create(@RequestBody @Valid OcppTagForm params) {
         log.debug("Create request: {}", params);
 
-        int ocppTagPk = ocppTagRepository.addOcppTag(params);
-        ocppTagService.removeUnknown(Collections.singletonList(params.getIdTag()));
+        int ocppTagPk = ocppTagService.addOcppTag(params);
 
         var response = getOneInternal(ocppTagPk);
         log.debug("Create response: {}", response);
@@ -127,7 +123,7 @@ public class OcppTagsRestController {
         params.setOcppTagPk(ocppTagPk); // the one from incoming params does not matter
         log.debug("Update request: {}", params);
 
-        ocppTagRepository.updateOcppTag(params);
+        ocppTagService.updateOcppTag(params);
 
         var response = getOneInternal(ocppTagPk);
         log.debug("Update response: {}", response);
@@ -147,7 +143,7 @@ public class OcppTagsRestController {
         log.debug("Delete request for ocppTagPk: {}", ocppTagPk);
 
         var response = getOneInternal(ocppTagPk);
-        ocppTagRepository.deleteOcppTag(ocppTagPk);
+        ocppTagService.deleteOcppTag(ocppTagPk);
 
         log.debug("Delete response: {}", response);
         return response;
@@ -157,7 +153,7 @@ public class OcppTagsRestController {
         OcppTagQueryForm.ForApi params = new OcppTagQueryForm.ForApi();
         params.setOcppTagPk(ocppTagPk);
 
-        List<OcppTag.Overview> results = ocppTagRepository.getOverview(params);
+        List<OcppTag.Overview> results = ocppTagService.getOverview(params);
         if (results.isEmpty()) {
             throw new SteveException.NotFound("Could not find this ocppTag");
         }

--- a/src/main/java/de/rwth/idsg/steve/web/controller/Ocpp12Controller.java
+++ b/src/main/java/de/rwth/idsg/steve/web/controller/Ocpp12Controller.java
@@ -19,9 +19,9 @@
 package de.rwth.idsg.steve.web.controller;
 
 import de.rwth.idsg.steve.ocpp.OcppVersion;
-import de.rwth.idsg.steve.repository.OcppTagRepository;
 import de.rwth.idsg.steve.service.ChargePointHelperService;
 import de.rwth.idsg.steve.service.ChargePointService12_Client;
+import de.rwth.idsg.steve.service.OcppTagService;
 import de.rwth.idsg.steve.web.dto.ocpp.ChangeAvailabilityParams;
 import de.rwth.idsg.steve.web.dto.ocpp.ChangeConfigurationParams;
 import de.rwth.idsg.steve.web.dto.ocpp.ConfigurationKeyEnum;
@@ -56,7 +56,7 @@ import static de.rwth.idsg.steve.web.dto.ocpp.ConfigurationKeyReadWriteEnum.RW;
 public class Ocpp12Controller {
 
     @Autowired protected ChargePointHelperService chargePointHelperService;
-    @Autowired protected OcppTagRepository ocppTagRepository;
+    @Autowired protected OcppTagService ocppTagService;
 
     @Autowired
     @Qualifier("ChargePointService12_Client")
@@ -111,7 +111,7 @@ public class Ocpp12Controller {
     }
 
     protected void setActiveUserIdTagList(Model model) {
-        model.addAttribute("idTagList", ocppTagRepository.getActiveIdTags());
+        model.addAttribute("idTagList", ocppTagService.getActiveIdTags());
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/de/rwth/idsg/steve/web/controller/Ocpp15Controller.java
+++ b/src/main/java/de/rwth/idsg/steve/web/controller/Ocpp15Controller.java
@@ -102,7 +102,7 @@ public class Ocpp15Controller extends Ocpp12Controller {
     }
 
     private void setAllUserIdTagList(Model model) {
-        model.addAttribute("idTagList", ocppTagRepository.getIdTags());
+        model.addAttribute("idTagList", ocppTagService.getIdTags());
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/de/rwth/idsg/steve/web/controller/OcppTagsController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/controller/OcppTagsController.java
@@ -18,7 +18,6 @@
  */
 package de.rwth.idsg.steve.web.controller;
 
-import de.rwth.idsg.steve.repository.OcppTagRepository;
 import de.rwth.idsg.steve.service.OcppTagService;
 import de.rwth.idsg.steve.utils.ControllerHelper;
 import de.rwth.idsg.steve.utils.mapper.OcppTagFormMapper;
@@ -47,7 +46,6 @@ import java.util.List;
 @RequestMapping(value = "/manager/ocppTags")
 public class OcppTagsController {
 
-    @Autowired protected OcppTagRepository ocppTagRepository;
     @Autowired protected OcppTagService ocppTagService;
 
     protected static final String PARAMS = "params";
@@ -87,7 +85,7 @@ public class OcppTagsController {
 
     @RequestMapping(value = DETAILS_PATH, method = RequestMethod.GET)
     public String getDetails(@PathVariable("ocppTagPk") int ocppTagPk, Model model) {
-        OcppTagActivityRecord record = ocppTagRepository.getRecord(ocppTagPk);
+        OcppTagActivityRecord record = ocppTagService.getRecord(ocppTagPk);
         OcppTagForm form = OcppTagFormMapper.toForm(record);
 
         model.addAttribute("activeTransactionCount", record.getActiveTransactionCount());
@@ -113,7 +111,7 @@ public class OcppTagsController {
             return "data-man/ocppTagAdd";
         }
 
-        add(ocppTagForm);
+        ocppTagService.addOcppTag(ocppTagForm);
         return toOverview();
     }
 
@@ -126,7 +124,7 @@ public class OcppTagsController {
             return "data-man/ocppTagAdd";
         }
 
-        add(form.getIdList());
+        ocppTagService.addOcppTagList(form.getIdList());
         return toOverview();
     }
 
@@ -138,19 +136,19 @@ public class OcppTagsController {
             return "data-man/ocppTagDetails";
         }
 
-        ocppTagRepository.updateOcppTag(ocppTagForm);
+        ocppTagService.updateOcppTag(ocppTagForm);
         return toOverview();
     }
 
     @RequestMapping(value = DELETE_PATH, method = RequestMethod.POST)
     public String delete(@PathVariable("ocppTagPk") int ocppTagPk) {
-        ocppTagRepository.deleteOcppTag(ocppTagPk);
+        ocppTagService.deleteOcppTag(ocppTagPk);
         return toOverview();
     }
 
     @RequestMapping(value = UNKNOWN_ADD_PATH, method = RequestMethod.POST)
     public String addUnknownIdTag(@PathVariable("idTag") String idTag) {
-        add(Collections.singletonList(idTag));
+        ocppTagService.addOcppTagList(Collections.singletonList(idTag));
         return toOverview();
     }
 
@@ -162,14 +160,14 @@ public class OcppTagsController {
 
     private void initList(Model model, OcppTagQueryForm params) {
         model.addAttribute(PARAMS, params);
-        model.addAttribute("idTagList", ocppTagRepository.getIdTags());
-        model.addAttribute("parentIdTagList", ocppTagRepository.getParentIdTags());
-        model.addAttribute("ocppTagList", ocppTagRepository.getOverview(params));
+        model.addAttribute("idTagList", ocppTagService.getIdTags());
+        model.addAttribute("parentIdTagList", ocppTagService.getParentIdTags());
+        model.addAttribute("ocppTagList", ocppTagService.getOverview(params));
         model.addAttribute("unknownList", ocppTagService.getUnknownOcppTags());
     }
 
     protected void setTags(Model model) {
-        model.addAttribute("idTagList", ControllerHelper.idTagEnhancer(ocppTagRepository.getIdTags()));
+        model.addAttribute("idTagList", ControllerHelper.idTagEnhancer(ocppTagService.getIdTags()));
     }
 
     // -------------------------------------------------------------------------
@@ -188,20 +186,6 @@ public class OcppTagsController {
 
     protected String toOverview() {
         return "redirect:/manager/ocppTags";
-    }
-
-    // -------------------------------------------------------------------------
-    // Helpers
-    // -------------------------------------------------------------------------
-
-    private void add(OcppTagForm form) {
-        ocppTagRepository.addOcppTag(form);
-        ocppTagService.removeUnknown(Collections.singletonList(form.getIdTag()));
-    }
-
-    private void add(List<String> idTagList) {
-        ocppTagRepository.addOcppTagList(idTagList);
-        ocppTagService.removeUnknown(idTagList);
     }
 
 }

--- a/src/main/java/de/rwth/idsg/steve/web/controller/TransactionsReservationsController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/controller/TransactionsReservationsController.java
@@ -19,10 +19,10 @@
 package de.rwth.idsg.steve.web.controller;
 
 import de.rwth.idsg.steve.repository.ChargePointRepository;
-import de.rwth.idsg.steve.repository.OcppTagRepository;
 import de.rwth.idsg.steve.repository.ReservationRepository;
 import de.rwth.idsg.steve.repository.ReservationStatus;
 import de.rwth.idsg.steve.repository.TransactionRepository;
+import de.rwth.idsg.steve.service.OcppTagService;
 import de.rwth.idsg.steve.service.TransactionStopService;
 import de.rwth.idsg.steve.web.dto.ReservationQueryForm;
 import de.rwth.idsg.steve.web.dto.TransactionQueryForm;
@@ -52,7 +52,7 @@ public class TransactionsReservationsController {
     @Autowired private TransactionRepository transactionRepository;
     @Autowired private ReservationRepository reservationRepository;
     @Autowired private ChargePointRepository chargePointRepository;
-    @Autowired private OcppTagRepository ocppTagRepository;
+    @Autowired private OcppTagService ocppTagService;
     @Autowired private TransactionStopService transactionStopService;
 
     private static final String PARAMS = "params";
@@ -145,7 +145,7 @@ public class TransactionsReservationsController {
 
     private void initList(Model model) {
         model.addAttribute("cpList", chargePointRepository.getChargeBoxIds());
-        model.addAttribute("idTagList", ocppTagRepository.getIdTags());
+        model.addAttribute("idTagList", ocppTagService.getIdTags());
     }
 
     private void initResList(Model model) {

--- a/src/main/java/de/rwth/idsg/steve/web/controller/UsersController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/controller/UsersController.java
@@ -18,9 +18,9 @@
  */
 package de.rwth.idsg.steve.web.controller;
 
-import de.rwth.idsg.steve.repository.OcppTagRepository;
 import de.rwth.idsg.steve.repository.UserRepository;
 import de.rwth.idsg.steve.repository.dto.User;
+import de.rwth.idsg.steve.service.OcppTagService;
 import de.rwth.idsg.steve.utils.ControllerHelper;
 import de.rwth.idsg.steve.utils.mapper.UserFormMapper;
 import de.rwth.idsg.steve.web.dto.UserForm;
@@ -44,7 +44,7 @@ import javax.validation.Valid;
 @RequestMapping(value = "/manager/users")
 public class UsersController {
 
-    @Autowired private OcppTagRepository ocppTagRepository;
+    @Autowired private OcppTagService ocppTagService;
     @Autowired private UserRepository userRepository;
 
     private static final String PARAMS = "params";
@@ -130,7 +130,7 @@ public class UsersController {
 
     private void setTags(Model model) {
         model.addAttribute("countryCodes", ControllerHelper.COUNTRY_DROPDOWN);
-        model.addAttribute("idTagList", ControllerHelper.idTagEnhancer(ocppTagRepository.getIdTags()));
+        model.addAttribute("idTagList", ControllerHelper.idTagEnhancer(ocppTagService.getIdTags()));
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/de/rwth/idsg/steve/web/api/OcppTagsRestControllerTest.java
+++ b/src/test/java/de/rwth/idsg/steve/web/api/OcppTagsRestControllerTest.java
@@ -19,7 +19,6 @@
 package de.rwth.idsg.steve.web.api;
 
 import de.rwth.idsg.steve.SteveException;
-import de.rwth.idsg.steve.repository.OcppTagRepository;
 import de.rwth.idsg.steve.repository.dto.OcppTag;
 import de.rwth.idsg.steve.service.OcppTagService;
 import de.rwth.idsg.steve.utils.DateTimeUtils;
@@ -71,15 +70,13 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
     private static final String CONTENT_TYPE = "application/json";
 
     @Mock
-    private OcppTagRepository ocppTagRepository;
-    @Mock
     private OcppTagService ocppTagService;
 
     private MockMvc mockMvc;
 
     @BeforeEach
     public void setup() {
-        mockMvc = MockMvcBuilders.standaloneSetup(new OcppTagsRestController(ocppTagRepository, ocppTagService))
+        mockMvc = MockMvcBuilders.standaloneSetup(new OcppTagsRestController(ocppTagService))
             .setControllerAdvice(new ApiControllerAdvice())
             .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
             .alwaysExpect(content().contentType(CONTENT_TYPE))
@@ -93,7 +90,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
         List<OcppTag.Overview> results = Collections.emptyList();
 
         // when
-        when(ocppTagRepository.getOverview(any())).thenReturn(results);
+        when(ocppTagService.getOverview(any())).thenReturn(results);
 
         // then
         mockMvc.perform(get("/api/v1/ocppTags"))
@@ -108,7 +105,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
         List<OcppTag.Overview> results = List.of(OcppTag.Overview.builder().ocppTagPk(96).build());
 
         // when
-        when(ocppTagRepository.getOverview(any())).thenReturn(results);
+        when(ocppTagService.getOverview(any())).thenReturn(results);
 
         // then
         mockMvc.perform(get("/api/v1/ocppTags"))
@@ -121,7 +118,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
     @DisplayName("GET all: Downstream bean throws exception, expected 500")
     public void test3() throws Exception {
         // when
-        when(ocppTagRepository.getOverview(any())).thenThrow(new RuntimeException("failed"));
+        when(ocppTagService.getOverview(any())).thenThrow(new RuntimeException("failed"));
 
         // then
         mockMvc.perform(get("/api/v1/ocppTags"))
@@ -159,7 +156,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             .build();
 
         // when
-        when(ocppTagRepository.getOverview(any())).thenReturn(List.of(result));
+        when(ocppTagService.getOverview(any())).thenReturn(List.of(result));
 
         // then
         mockMvc.perform(get("/api/v1/ocppTags")
@@ -197,7 +194,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
     @DisplayName("GET one: Entity not found, expected 404")
     public void test7() throws Exception {
         // when
-        when(ocppTagRepository.getOverview(any())).thenReturn(Collections.emptyList());
+        when(ocppTagService.getOverview(any())).thenReturn(Collections.emptyList());
 
         // then
         mockMvc.perform(get("/api/v1/ocppTags/12"))
@@ -212,7 +209,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
         OcppTag.Overview result = OcppTag.Overview.builder().ocppTagPk(12).build();
 
         // when
-        when(ocppTagRepository.getOverview(any())).thenReturn(List.of(result));
+        when(ocppTagService.getOverview(any())).thenReturn(List.of(result));
 
         // then
         mockMvc.perform(get("/api/v1/ocppTags/12"))
@@ -236,7 +233,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             .andExpect(status().isBadRequest())
             .andExpectAll(errorJsonMatchers());
 
-        verifyNoInteractions(ocppTagRepository, ocppTagService);
+        verifyNoInteractions(ocppTagService);
     }
 
     @Test
@@ -256,7 +253,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             .andExpect(status().isBadRequest())
             .andExpectAll(errorJsonMatchers());
 
-        verifyNoInteractions(ocppTagRepository, ocppTagService);
+        verifyNoInteractions(ocppTagService);
     }
 
     @Test
@@ -274,8 +271,8 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             .build();
 
         // when
-        when(ocppTagRepository.addOcppTag(eq(form))).thenReturn(ocppTagPk);
-        when(ocppTagRepository.getOverview(any())).thenReturn(List.of(result));
+        when(ocppTagService.addOcppTag(eq(form))).thenReturn(ocppTagPk);
+        when(ocppTagService.getOverview(any())).thenReturn(List.of(result));
 
         // then
         mockMvc.perform(
@@ -286,8 +283,6 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.ocppTagPk").value("123"))
             .andExpect(jsonPath("$.idTag").value("id-123"));
-
-        verify(ocppTagService).removeUnknown(anyList());
     }
 
     @Test
@@ -308,7 +303,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             .build();
 
         // when
-        when(ocppTagRepository.getOverview(any())).thenReturn(List.of(result));
+        when(ocppTagService.getOverview(any())).thenReturn(List.of(result));
 
         // then
         mockMvc.perform(
@@ -318,7 +313,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             )
             .andExpect(status().isOk());
 
-        verify(ocppTagRepository).updateOcppTag(eq(form));
+        verify(ocppTagService).updateOcppTag(eq(form));
     }
 
     @Test
@@ -339,7 +334,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             )
             .andExpect(status().isBadRequest());
 
-        verifyNoInteractions(ocppTagRepository, ocppTagService);
+        verifyNoInteractions(ocppTagService);
     }
 
     @Test
@@ -354,7 +349,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
         form.setNote("note-1");
 
         // when
-        doThrow(new SteveException("failed")).when(ocppTagRepository).updateOcppTag(any());
+        doThrow(new SteveException("failed")).when(ocppTagService).updateOcppTag(any());
 
         // then
         mockMvc.perform(
@@ -379,14 +374,14 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             .build();
 
         // when
-        when(ocppTagRepository.getOverview(any())).thenReturn(List.of(result));
+        when(ocppTagService.getOverview(any())).thenReturn(List.of(result));
 
         // then
         mockMvc.perform(delete("/api/v1/ocppTags/" + ocppTagPk))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.ocppTagPk").value("123"));
 
-        verify(ocppTagRepository).deleteOcppTag(eq(ocppTagPk));
+        verify(ocppTagService).deleteOcppTag(eq(ocppTagPk));
     }
 
     @Test
@@ -402,8 +397,8 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             .build();
 
         // when
-        when(ocppTagRepository.getOverview(any())).thenReturn(List.of(result));
-        doThrow(new SteveException("failed")).when(ocppTagRepository).deleteOcppTag(eq(ocppTagPk));
+        when(ocppTagService.getOverview(any())).thenReturn(List.of(result));
+        doThrow(new SteveException("failed")).when(ocppTagService).deleteOcppTag(eq(ocppTagPk));
 
         // then
         mockMvc.perform(delete("/api/v1/ocppTags/" + ocppTagPk))
@@ -418,14 +413,14 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
         int ocppTagPk = 123;
 
         // when
-        when(ocppTagRepository.getOverview(any())).thenReturn(List.of());
+        when(ocppTagService.getOverview(any())).thenReturn(List.of());
 
         // then
         mockMvc.perform(delete("/api/v1/ocppTags/" + ocppTagPk))
             .andExpect(status().isNotFound())
             .andExpectAll(errorJsonMatchers());
 
-        verify(ocppTagRepository, times(0)).deleteOcppTag(anyInt());
+        verify(ocppTagService, times(0)).deleteOcppTag(anyInt());
     }
 
     @Test
@@ -438,7 +433,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
         form.setIdTag("id-123");
 
         // when
-        when(ocppTagRepository.addOcppTag(eq(form))).thenThrow(new SteveException.AlreadyExists("A user with idTag '%s' already exists.", ocppTagPk));
+        when(ocppTagService.addOcppTag(eq(form))).thenThrow(new SteveException.AlreadyExists("A user with idTag '%s' already exists.", ocppTagPk));
 
         // then
         mockMvc.perform(
@@ -450,7 +445,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             .andExpectAll(errorJsonMatchers());
 
         verify(ocppTagService, times(0)).removeUnknown(anyList());
-        verify(ocppTagRepository, times(0)).getOverview(any(OcppTagQueryForm.ForApi.class));
+        verify(ocppTagService, times(0)).getOverview(any(OcppTagQueryForm.ForApi.class));
     }
 
     @Test
@@ -460,14 +455,14 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
         ArgumentCaptor<OcppTagQueryForm.ForApi> formToCapture = ArgumentCaptor.forClass(OcppTagQueryForm.ForApi.class);
 
         // when
-        when(ocppTagRepository.getOverview(any())).thenReturn(Collections.emptyList());
+        when(ocppTagService.getOverview(any())).thenReturn(Collections.emptyList());
 
         // then
         mockMvc.perform(get("/api/v1/ocppTags")
                 .param("expired", "FALSE"))
             .andExpect(status().isOk());
 
-        verify(ocppTagRepository).getOverview(formToCapture.capture());
+        verify(ocppTagService).getOverview(formToCapture.capture());
         OcppTagQueryForm.ForApi capturedForm = formToCapture.getValue();
 
         assertEquals(capturedForm.getExpired(), OcppTagQueryForm.BooleanType.FALSE);
@@ -482,14 +477,14 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
         ArgumentCaptor<OcppTagQueryForm.ForApi> formToCapture = ArgumentCaptor.forClass(OcppTagQueryForm.ForApi.class);
 
         // when
-        when(ocppTagRepository.getOverview(any())).thenReturn(Collections.emptyList());
+        when(ocppTagService.getOverview(any())).thenReturn(Collections.emptyList());
 
         // then
         mockMvc.perform(get("/api/v1/ocppTags")
                 .param("inTransaction", "TRUE"))
             .andExpect(status().isOk());
 
-        verify(ocppTagRepository).getOverview(formToCapture.capture());
+        verify(ocppTagService).getOverview(formToCapture.capture());
         OcppTagQueryForm.ForApi capturedForm = formToCapture.getValue();
 
         assertEquals(capturedForm.getExpired(), OcppTagQueryForm.BooleanType.ALL);
@@ -504,14 +499,14 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
         ArgumentCaptor<OcppTagQueryForm.ForApi> formToCapture = ArgumentCaptor.forClass(OcppTagQueryForm.ForApi.class);
 
         // when
-        when(ocppTagRepository.getOverview(any())).thenReturn(Collections.emptyList());
+        when(ocppTagService.getOverview(any())).thenReturn(Collections.emptyList());
 
         // then
         mockMvc.perform(get("/api/v1/ocppTags")
                 .param("blocked", "FALSE"))
             .andExpect(status().isOk());
 
-        verify(ocppTagRepository).getOverview(formToCapture.capture());
+        verify(ocppTagService).getOverview(formToCapture.capture());
         OcppTagQueryForm.ForApi capturedForm = formToCapture.getValue();
 
         assertEquals(capturedForm.getExpired(), OcppTagQueryForm.BooleanType.ALL);


### PR DESCRIPTION
simplify some internal code in OcppTagService, and use OcppTagService for all things related to ocpp tags. do not expose OcppTagRepository to controller layer. it is only used internally by OcppTagService.

context: https://github.com/steve-community/steve/pull/953#issuecomment-1321275033