### PR TITLE
Extract tag authorization in a dedicated service

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/service/AuthTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/AuthTagService.java
@@ -18,85 +18,11 @@
  */
 package de.rwth.idsg.steve.service;
 
-import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.isBlocked;
-import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.isExpired;
-import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.reachedLimitOfActiveTransactions;
-
-import de.rwth.idsg.steve.repository.OcppTagRepository;
-import de.rwth.idsg.steve.repository.SettingsRepository;
-import jooq.steve.db.tables.records.OcppTagActivityRecord;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import ocpp.cs._2015._10.AuthorizationStatus;
 import ocpp.cs._2015._10.IdTagInfo;
 import org.jetbrains.annotations.Nullable;
-import org.joda.time.DateTime;
-import org.springframework.stereotype.Service;
 
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class AuthTagService {
+public interface AuthTagService {
 
-    private final OcppTagRepository ocppTagRepository;
-    private final SettingsRepository settingsRepository;
-
-    public IdTagInfo decideStatus(String idTag, boolean isStartTransactionReqContext,
-                                  @Nullable String chargeBoxId, @Nullable Integer connectorId) {
-        OcppTagActivityRecord record = ocppTagRepository.getRecord(idTag);
-        if (record == null) {
-            log.error("The user with idTag '{}' is INVALID (not present in DB).", idTag);
-            return new IdTagInfo().withStatus(AuthorizationStatus.INVALID);
-        }
-
-        if (isBlocked(record)) {
-            log.error("The user with idTag '{}' is BLOCKED.", idTag);
-            return new IdTagInfo()
-                .withStatus(AuthorizationStatus.BLOCKED)
-                .withParentIdTag(record.getParentIdTag())
-                .withExpiryDate(getExpiryDateOrDefault(record));
-        }
-
-        if (isExpired(record, DateTime.now())) {
-            log.error("The user with idTag '{}' is EXPIRED.", idTag);
-            return new IdTagInfo()
-                .withStatus(AuthorizationStatus.EXPIRED)
-                .withParentIdTag(record.getParentIdTag())
-                .withExpiryDate(getExpiryDateOrDefault(record));
-        }
-
-        // https://github.com/steve-community/steve/issues/219
-        if (isStartTransactionReqContext && reachedLimitOfActiveTransactions(record)) {
-            log.warn("The user with idTag '{}' is ALREADY in another transaction(s).", idTag);
-            return new IdTagInfo()
-                .withStatus(AuthorizationStatus.CONCURRENT_TX)
-                .withParentIdTag(record.getParentIdTag())
-                .withExpiryDate(getExpiryDateOrDefault(record));
-        }
-
-        log.debug("The user with idTag '{}' is ACCEPTED.", record.getIdTag());
-        return new IdTagInfo()
-            .withStatus(AuthorizationStatus.ACCEPTED)
-            .withParentIdTag(record.getParentIdTag())
-            .withExpiryDate(getExpiryDateOrDefault(record));
-    }
-
-    /**
-     * If the database contains an actual expiry, use it. Otherwise, calculate an expiry for cached info
-     */
-    @Nullable
-    private DateTime getExpiryDateOrDefault(OcppTagActivityRecord record) {
-        if (record.getExpiryDate() != null) {
-            return record.getExpiryDate();
-        }
-
-        int hoursToExpire = settingsRepository.getHoursToExpire();
-
-        // From web page: The value 0 disables this functionality (i.e. no expiry date will be set).
-        if (hoursToExpire == 0) {
-            return null;
-        } else {
-            return DateTime.now().plusHours(hoursToExpire);
-        }
-    }
+    IdTagInfo decideStatus(String idTag, boolean isStartTransactionReqContext,
+                           @Nullable String chargeBoxId, @Nullable Integer connectorId);
 }

--- a/src/main/java/de/rwth/idsg/steve/service/AuthTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/AuthTagService.java
@@ -1,3 +1,21 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2024 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package de.rwth.idsg.steve.service;
 
 import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.isBlocked;

--- a/src/main/java/de/rwth/idsg/steve/service/AuthTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/AuthTagService.java
@@ -4,42 +4,82 @@ import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.isBlocked;
 import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.isExpired;
 import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.reachedLimitOfActiveTransactions;
 
+import de.rwth.idsg.steve.repository.OcppTagRepository;
+import de.rwth.idsg.steve.repository.SettingsRepository;
 import jooq.steve.db.tables.records.OcppTagActivityRecord;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import ocpp.cs._2015._10.AuthorizationStatus;
+import ocpp.cs._2015._10.IdTagInfo;
 import org.jetbrains.annotations.Nullable;
 import org.joda.time.DateTime;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class AuthTagService {
+  private final OcppTagRepository ocppTagRepository;
+  private final SettingsRepository settingsRepository;
 
-  public AuthorizationStatus decideStatus(@Nullable OcppTagActivityRecord record, String idTag,
-      boolean isStartTransactionReqContext, @Nullable String chargeBoxId,
-      @Nullable Integer connectorId) {
+  public IdTagInfo decideStatus(String idTag,
+                                boolean isStartTransactionReqContext,
+                                @Nullable String chargeBoxId,
+                                @Nullable Integer connectorId) {
+    OcppTagActivityRecord record = ocppTagRepository.getRecord(idTag);
     if (record == null) {
       log.error("The user with idTag '{}' is INVALID (not present in DB).", idTag);
-      return AuthorizationStatus.INVALID;
+      return new IdTagInfo().withStatus(AuthorizationStatus.INVALID);
     }
 
     if (isBlocked(record)) {
       log.error("The user with idTag '{}' is BLOCKED.", idTag);
-      return AuthorizationStatus.BLOCKED;
+      return new IdTagInfo()
+              .withStatus(AuthorizationStatus.BLOCKED)
+              .withParentIdTag(record.getParentIdTag())
+              .withExpiryDate(getExpiryDateOrDefault(record));
     }
 
     if (isExpired(record, DateTime.now())) {
       log.error("The user with idTag '{}' is EXPIRED.", idTag);
-      return AuthorizationStatus.EXPIRED;
+      return new IdTagInfo()
+              .withStatus(AuthorizationStatus.EXPIRED)
+              .withParentIdTag(record.getParentIdTag())
+              .withExpiryDate(getExpiryDateOrDefault(record));
     }
 
     // https://github.com/steve-community/steve/issues/219
     if (isStartTransactionReqContext && reachedLimitOfActiveTransactions(record)) {
       log.warn("The user with idTag '{}' is ALREADY in another transaction(s).", idTag);
-      return AuthorizationStatus.CONCURRENT_TX;
+      return new IdTagInfo()
+              .withStatus(AuthorizationStatus.CONCURRENT_TX)
+              .withParentIdTag(record.getParentIdTag())
+              .withExpiryDate(getExpiryDateOrDefault(record));
     }
 
     log.debug("The user with idTag '{}' is ACCEPTED.", record.getIdTag());
-    return AuthorizationStatus.ACCEPTED;
+    return new IdTagInfo()
+            .withStatus(AuthorizationStatus.ACCEPTED)
+            .withParentIdTag(record.getParentIdTag())
+            .withExpiryDate(getExpiryDateOrDefault(record));
+  }
+
+  /**
+   * If the database contains an actual expiry, use it. Otherwise, calculate an expiry for cached info
+   */
+  @Nullable
+  private DateTime getExpiryDateOrDefault(OcppTagActivityRecord record) {
+    if (record.getExpiryDate() != null) {
+      return record.getExpiryDate();
+    }
+
+    int hoursToExpire = settingsRepository.getHoursToExpire();
+
+    // From web page: The value 0 disables this functionality (i.e. no expiry date will be set).
+    if (hoursToExpire == 0) {
+      return null;
+    } else {
+      return DateTime.now().plusHours(hoursToExpire);
+    }
   }
 }

--- a/src/main/java/de/rwth/idsg/steve/service/AuthTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/AuthTagService.java
@@ -19,67 +19,66 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class AuthTagService {
-  private final OcppTagRepository ocppTagRepository;
-  private final SettingsRepository settingsRepository;
 
-  public IdTagInfo decideStatus(String idTag,
-                                boolean isStartTransactionReqContext,
-                                @Nullable String chargeBoxId,
-                                @Nullable Integer connectorId) {
-    OcppTagActivityRecord record = ocppTagRepository.getRecord(idTag);
-    if (record == null) {
-      log.error("The user with idTag '{}' is INVALID (not present in DB).", idTag);
-      return new IdTagInfo().withStatus(AuthorizationStatus.INVALID);
-    }
+    private final OcppTagRepository ocppTagRepository;
+    private final SettingsRepository settingsRepository;
 
-    if (isBlocked(record)) {
-      log.error("The user with idTag '{}' is BLOCKED.", idTag);
-      return new IdTagInfo()
-              .withStatus(AuthorizationStatus.BLOCKED)
-              .withParentIdTag(record.getParentIdTag())
-              .withExpiryDate(getExpiryDateOrDefault(record));
-    }
+    public IdTagInfo decideStatus(String idTag, boolean isStartTransactionReqContext,
+                                  @Nullable String chargeBoxId, @Nullable Integer connectorId) {
+        OcppTagActivityRecord record = ocppTagRepository.getRecord(idTag);
+        if (record == null) {
+            log.error("The user with idTag '{}' is INVALID (not present in DB).", idTag);
+            return new IdTagInfo().withStatus(AuthorizationStatus.INVALID);
+        }
 
-    if (isExpired(record, DateTime.now())) {
-      log.error("The user with idTag '{}' is EXPIRED.", idTag);
-      return new IdTagInfo()
-              .withStatus(AuthorizationStatus.EXPIRED)
-              .withParentIdTag(record.getParentIdTag())
-              .withExpiryDate(getExpiryDateOrDefault(record));
-    }
+        if (isBlocked(record)) {
+            log.error("The user with idTag '{}' is BLOCKED.", idTag);
+            return new IdTagInfo()
+                .withStatus(AuthorizationStatus.BLOCKED)
+                .withParentIdTag(record.getParentIdTag())
+                .withExpiryDate(getExpiryDateOrDefault(record));
+        }
 
-    // https://github.com/steve-community/steve/issues/219
-    if (isStartTransactionReqContext && reachedLimitOfActiveTransactions(record)) {
-      log.warn("The user with idTag '{}' is ALREADY in another transaction(s).", idTag);
-      return new IdTagInfo()
-              .withStatus(AuthorizationStatus.CONCURRENT_TX)
-              .withParentIdTag(record.getParentIdTag())
-              .withExpiryDate(getExpiryDateOrDefault(record));
-    }
+        if (isExpired(record, DateTime.now())) {
+            log.error("The user with idTag '{}' is EXPIRED.", idTag);
+            return new IdTagInfo()
+                .withStatus(AuthorizationStatus.EXPIRED)
+                .withParentIdTag(record.getParentIdTag())
+                .withExpiryDate(getExpiryDateOrDefault(record));
+        }
 
-    log.debug("The user with idTag '{}' is ACCEPTED.", record.getIdTag());
-    return new IdTagInfo()
+        // https://github.com/steve-community/steve/issues/219
+        if (isStartTransactionReqContext && reachedLimitOfActiveTransactions(record)) {
+            log.warn("The user with idTag '{}' is ALREADY in another transaction(s).", idTag);
+            return new IdTagInfo()
+                .withStatus(AuthorizationStatus.CONCURRENT_TX)
+                .withParentIdTag(record.getParentIdTag())
+                .withExpiryDate(getExpiryDateOrDefault(record));
+        }
+
+        log.debug("The user with idTag '{}' is ACCEPTED.", record.getIdTag());
+        return new IdTagInfo()
             .withStatus(AuthorizationStatus.ACCEPTED)
             .withParentIdTag(record.getParentIdTag())
             .withExpiryDate(getExpiryDateOrDefault(record));
-  }
-
-  /**
-   * If the database contains an actual expiry, use it. Otherwise, calculate an expiry for cached info
-   */
-  @Nullable
-  private DateTime getExpiryDateOrDefault(OcppTagActivityRecord record) {
-    if (record.getExpiryDate() != null) {
-      return record.getExpiryDate();
     }
 
-    int hoursToExpire = settingsRepository.getHoursToExpire();
+    /**
+     * If the database contains an actual expiry, use it. Otherwise, calculate an expiry for cached info
+     */
+    @Nullable
+    private DateTime getExpiryDateOrDefault(OcppTagActivityRecord record) {
+        if (record.getExpiryDate() != null) {
+            return record.getExpiryDate();
+        }
 
-    // From web page: The value 0 disables this functionality (i.e. no expiry date will be set).
-    if (hoursToExpire == 0) {
-      return null;
-    } else {
-      return DateTime.now().plusHours(hoursToExpire);
+        int hoursToExpire = settingsRepository.getHoursToExpire();
+
+        // From web page: The value 0 disables this functionality (i.e. no expiry date will be set).
+        if (hoursToExpire == 0) {
+            return null;
+        } else {
+            return DateTime.now().plusHours(hoursToExpire);
+        }
     }
-  }
 }

--- a/src/main/java/de/rwth/idsg/steve/service/AuthTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/AuthTagService.java
@@ -16,7 +16,8 @@ import org.springframework.stereotype.Service;
 public class AuthTagService {
 
   public AuthorizationStatus decideStatus(@Nullable OcppTagActivityRecord record, String idTag,
-      boolean isStartTransactionReqContext) {
+      boolean isStartTransactionReqContext, @Nullable String chargeBoxId,
+      @Nullable Integer connectorId) {
     if (record == null) {
       log.error("The user with idTag '{}' is INVALID (not present in DB).", idTag);
       return AuthorizationStatus.INVALID;

--- a/src/main/java/de/rwth/idsg/steve/service/AuthTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/AuthTagService.java
@@ -1,0 +1,44 @@
+package de.rwth.idsg.steve.service;
+
+import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.isBlocked;
+import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.isExpired;
+import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.reachedLimitOfActiveTransactions;
+
+import jooq.steve.db.tables.records.OcppTagActivityRecord;
+import lombok.extern.slf4j.Slf4j;
+import ocpp.cs._2015._10.AuthorizationStatus;
+import org.jetbrains.annotations.Nullable;
+import org.joda.time.DateTime;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class AuthTagService {
+
+  public AuthorizationStatus decideStatus(@Nullable OcppTagActivityRecord record, String idTag,
+      boolean isStartTransactionReqContext) {
+    if (record == null) {
+      log.error("The user with idTag '{}' is INVALID (not present in DB).", idTag);
+      return AuthorizationStatus.INVALID;
+    }
+
+    if (isBlocked(record)) {
+      log.error("The user with idTag '{}' is BLOCKED.", idTag);
+      return AuthorizationStatus.BLOCKED;
+    }
+
+    if (isExpired(record, DateTime.now())) {
+      log.error("The user with idTag '{}' is EXPIRED.", idTag);
+      return AuthorizationStatus.EXPIRED;
+    }
+
+    // https://github.com/steve-community/steve/issues/219
+    if (isStartTransactionReqContext && reachedLimitOfActiveTransactions(record)) {
+      log.warn("The user with idTag '{}' is ALREADY in another transaction(s).", idTag);
+      return AuthorizationStatus.CONCURRENT_TX;
+    }
+
+    log.debug("The user with idTag '{}' is ACCEPTED.", record.getIdTag());
+    return AuthorizationStatus.ACCEPTED;
+  }
+}

--- a/src/main/java/de/rwth/idsg/steve/service/AuthTagServiceLocal.java
+++ b/src/main/java/de/rwth/idsg/steve/service/AuthTagServiceLocal.java
@@ -1,0 +1,103 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2024 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.service;
+
+import de.rwth.idsg.steve.repository.OcppTagRepository;
+import de.rwth.idsg.steve.repository.SettingsRepository;
+import jooq.steve.db.tables.records.OcppTagActivityRecord;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import ocpp.cs._2015._10.AuthorizationStatus;
+import ocpp.cs._2015._10.IdTagInfo;
+import org.jetbrains.annotations.Nullable;
+import org.joda.time.DateTime;
+import org.springframework.stereotype.Service;
+
+import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.isBlocked;
+import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.isExpired;
+import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.reachedLimitOfActiveTransactions;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthTagServiceLocal implements AuthTagService {
+
+    private final OcppTagRepository ocppTagRepository;
+    private final SettingsRepository settingsRepository;
+
+    @Override
+    public IdTagInfo decideStatus(String idTag, boolean isStartTransactionReqContext,
+                                  @Nullable String chargeBoxId, @Nullable Integer connectorId) {
+        OcppTagActivityRecord record = ocppTagRepository.getRecord(idTag);
+        if (record == null) {
+            log.error("The user with idTag '{}' is INVALID (not present in DB).", idTag);
+            return new IdTagInfo().withStatus(AuthorizationStatus.INVALID);
+        }
+
+        if (isBlocked(record)) {
+            log.error("The user with idTag '{}' is BLOCKED.", idTag);
+            return new IdTagInfo()
+                .withStatus(AuthorizationStatus.BLOCKED)
+                .withParentIdTag(record.getParentIdTag())
+                .withExpiryDate(getExpiryDateOrDefault(record));
+        }
+
+        if (isExpired(record, DateTime.now())) {
+            log.error("The user with idTag '{}' is EXPIRED.", idTag);
+            return new IdTagInfo()
+                .withStatus(AuthorizationStatus.EXPIRED)
+                .withParentIdTag(record.getParentIdTag())
+                .withExpiryDate(getExpiryDateOrDefault(record));
+        }
+
+        // https://github.com/steve-community/steve/issues/219
+        if (isStartTransactionReqContext && reachedLimitOfActiveTransactions(record)) {
+            log.warn("The user with idTag '{}' is ALREADY in another transaction(s).", idTag);
+            return new IdTagInfo()
+                .withStatus(AuthorizationStatus.CONCURRENT_TX)
+                .withParentIdTag(record.getParentIdTag())
+                .withExpiryDate(getExpiryDateOrDefault(record));
+        }
+
+        log.debug("The user with idTag '{}' is ACCEPTED.", record.getIdTag());
+        return new IdTagInfo()
+            .withStatus(AuthorizationStatus.ACCEPTED)
+            .withParentIdTag(record.getParentIdTag())
+            .withExpiryDate(getExpiryDateOrDefault(record));
+    }
+
+    /**
+     * If the database contains an actual expiry, use it. Otherwise, calculate an expiry for cached info
+     */
+    @Nullable
+    private DateTime getExpiryDateOrDefault(OcppTagActivityRecord record) {
+        if (record.getExpiryDate() != null) {
+            return record.getExpiryDate();
+        }
+
+        int hoursToExpire = settingsRepository.getHoursToExpire();
+
+        // From web page: The value 0 disables this functionality (i.e. no expiry date will be set).
+        if (hoursToExpire == 0) {
+            return null;
+        } else {
+            return DateTime.now().plusHours(hoursToExpire);
+        }
+    }
+}

--- a/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_Service.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_Service.java
@@ -173,6 +173,8 @@ public class CentralSystemService16_Service {
         IdTagInfo info = ocppTagService.getIdTagInfo(
                 parameters.getIdTag(),
                 true,
+                chargeBoxIdentity,
+                parameters.getConnectorId(),
                 () -> new IdTagInfo().withStatus(AuthorizationStatus.INVALID) // IdTagInfo is required
         );
 
@@ -204,6 +206,8 @@ public class CentralSystemService16_Service {
         IdTagInfo idTagInfo = ocppTagService.getIdTagInfo(
                 parameters.getIdTag(),
                 false,
+                chargeBoxIdentity,
+                null,
                 () -> null
         );
 
@@ -239,6 +243,8 @@ public class CentralSystemService16_Service {
         IdTagInfo idTagInfo = ocppTagService.getIdTagInfo(
                 parameters.getIdTag(),
                 false,
+                chargeBoxIdentity,
+                null,
                 () -> new IdTagInfo().withStatus(AuthorizationStatus.INVALID)
         );
 

--- a/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
@@ -102,13 +102,15 @@ public class OcppTagService {
     }
 
     @Nullable
-    public IdTagInfo getIdTagInfo(@Nullable String idTag, boolean isStartTransactionReqContext) {
+    public IdTagInfo getIdTagInfo(@Nullable String idTag, boolean isStartTransactionReqContext,
+        @Nullable String chargeBoxId, @Nullable Integer connectorId) {
         if (Strings.isNullOrEmpty(idTag)) {
             return null;
         }
 
         OcppTagActivityRecord record = ocppTagRepository.getRecord(idTag);
-        AuthorizationStatus status = authTagService.decideStatus(record, idTag, isStartTransactionReqContext);
+        AuthorizationStatus status = authTagService.decideStatus(record, idTag,
+            isStartTransactionReqContext, chargeBoxId, connectorId);
 
         switch (status) {
             case INVALID:
@@ -128,9 +130,11 @@ public class OcppTagService {
     }
 
     @Nullable
-    public IdTagInfo getIdTagInfo(@Nullable String idTag, boolean isStartTransactionReqContext, Supplier<IdTagInfo> supplierWhenException) {
+    public IdTagInfo getIdTagInfo(@Nullable String idTag, boolean isStartTransactionReqContext,
+        @Nullable String chargeBoxId, @Nullable Integer connectorId,
+        Supplier<IdTagInfo> supplierWhenException) {
         try {
-            return getIdTagInfo(idTag, isStartTransactionReqContext);
+            return getIdTagInfo(idTag, isStartTransactionReqContext, chargeBoxId, connectorId);
         } catch (Exception e) {
             log.error("Exception occurred", e);
             return supplierWhenException.get();

--- a/src/main/java/de/rwth/idsg/steve/utils/OcppTagActivityRecordUtils.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/OcppTagActivityRecordUtils.java
@@ -1,3 +1,21 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2024 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package de.rwth.idsg.steve.utils;
 
 import jooq.steve.db.tables.records.OcppTagActivityRecord;

--- a/src/main/java/de/rwth/idsg/steve/utils/OcppTagActivityRecordUtils.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/OcppTagActivityRecordUtils.java
@@ -8,29 +8,29 @@ import org.joda.time.DateTime;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class OcppTagActivityRecordUtils {
 
-  public static boolean isExpired(OcppTagActivityRecord record, DateTime now) {
-    DateTime expiry = record.getExpiryDate();
-    return expiry != null && now.isAfter(expiry);
-  }
-
-  public static boolean isBlocked(OcppTagActivityRecord record) {
-    return record.getMaxActiveTransactionCount() == 0;
-  }
-
-  public static boolean reachedLimitOfActiveTransactions(OcppTagActivityRecord record) {
-    int max = record.getMaxActiveTransactionCount();
-
-    // blocked
-    if (max == 0) {
-      return true;
+    public static boolean isExpired(OcppTagActivityRecord record, DateTime now) {
+        DateTime expiry = record.getExpiryDate();
+        return expiry != null && now.isAfter(expiry);
     }
 
-    // allow all
-    if (max < 0) {
-      return false;
+    public static boolean isBlocked(OcppTagActivityRecord record) {
+        return record.getMaxActiveTransactionCount() == 0;
     }
 
-    // allow as specified
-    return record.getActiveTransactionCount() >= max;
-  }
+    public static boolean reachedLimitOfActiveTransactions(OcppTagActivityRecord record) {
+        int max = record.getMaxActiveTransactionCount();
+
+        // blocked
+        if (max == 0) {
+            return true;
+        }
+
+        // allow all
+        if (max < 0) {
+            return false;
+        }
+
+        // allow as specified
+        return record.getActiveTransactionCount() >= max;
+    }
 }

--- a/src/main/java/de/rwth/idsg/steve/utils/OcppTagActivityRecordUtils.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/OcppTagActivityRecordUtils.java
@@ -1,0 +1,36 @@
+package de.rwth.idsg.steve.utils;
+
+import jooq.steve.db.tables.records.OcppTagActivityRecord;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.joda.time.DateTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class OcppTagActivityRecordUtils {
+
+  public static boolean isExpired(OcppTagActivityRecord record, DateTime now) {
+    DateTime expiry = record.getExpiryDate();
+    return expiry != null && now.isAfter(expiry);
+  }
+
+  public static boolean isBlocked(OcppTagActivityRecord record) {
+    return record.getMaxActiveTransactionCount() == 0;
+  }
+
+  public static boolean reachedLimitOfActiveTransactions(OcppTagActivityRecord record) {
+    int max = record.getMaxActiveTransactionCount();
+
+    // blocked
+    if (max == 0) {
+      return true;
+    }
+
+    // allow all
+    if (max < 0) {
+      return false;
+    }
+
+    // allow as specified
+    return record.getActiveTransactionCount() >= max;
+  }
+}


### PR DESCRIPTION
The objective of the change is to be able to delegate the authorization responsibility to an outside EMSP service if wanted.

WDYT?