### PR TITLE
add specific pmd version

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -13,7 +13,8 @@ jobs:
       - name: Run PMD
         uses: pmd/pmd-github-action@v1
         with:
-          sourcePath: 'src/main/java'
+          version: '6.49.0'
+          sourcePath: './src/main/java'
           rulesets: 'https://raw.githubusercontent.com/apache/maven-pmd-plugin/maven-pmd-plugin-3.19.0/src/main/resources/rulesets/java/maven-pmd-plugin-default.xml'
       - name: Fail build if there are violations
         if: steps.pmd.outputs.violations != 0


### PR DESCRIPTION
reason: github action implicitly uses 6.53.0. the rulesets from maven-pmd-plugin-3.19.0
are for 6.49.0. the action was failing with "Error: Invalid rulesets"