### PR TITLE
remove pmd job in github actions

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,23 +2,6 @@ name: check quality
 on: [ push, pull_request ]
 
 jobs:
-  pmd:
-    runs-on: 'ubuntu-latest'
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Run PMD
-        uses: pmd/pmd-github-action@v1
-        with:
-          version: '6.49.0'
-          sourcePath: './src/main/java'
-          rulesets: 'https://raw.githubusercontent.com/apache/maven-pmd-plugin/maven-pmd-plugin-3.19.0/src/main/resources/rulesets/java/maven-pmd-plugin-default.xml'
-      - name: Fail build if there are violations
-        if: steps.pmd.outputs.violations != 0
-        run: exit 1
   checkstyle:
     runs-on: 'ubuntu-latest'
     steps:


### PR DESCRIPTION
the behaviour of this github action seems to be flaky.

master was broken after adding this job: https://github.com/steve-community/steve/actions/runs/3836455431/jobs/6587998999

based on the github docs, i hoped/assumed that the syntax for the `sourcePath` value had to be a different one. i attempted a solution with: https://github.com/steve-community/steve/commit/f96b9e8e57a6431aea458d886ed2d33f22e38d19

this fixed master. after rebasing a feature branch, the branch was broken. attempted fix: https://github.com/steve-community/steve/pull/1026

the branch still fails: https://github.com/steve-community/steve/actions/runs/3865067797/jobs/6588324097

all of this is too much headache for little value.
