### PR TITLE
Use the default values for input/output buffers #846

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/SteveAppContext.java
+++ b/src/main/java/de/rwth/idsg/steve/SteveAppContext.java
@@ -80,8 +80,6 @@ public class SteveAppContext {
      */
     public void configureWebSocket() {
         JettyWebSocketServerContainer container = JettyWebSocketServerContainer.getContainer(webAppContext.getServletContext());
-        container.setInputBufferSize(MAX_MSG_SIZE);
-        container.setOutputBufferSize(MAX_MSG_SIZE);
         container.setMaxTextMessageSize(MAX_MSG_SIZE);
         container.setIdleTimeout(IDLE_TIMEOUT);
     }


### PR DESCRIPTION
This pull request fixes the excessive memory usage when a new websocket message is received.
For more details, check the issue #846.