### PR TITLE
Allow Heartbeat Interval to be zero

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/web/dto/SettingsForm.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/SettingsForm.java
@@ -48,7 +48,7 @@ public class SettingsForm {
     // OCPP
     // -------------------------------------------------------------------------
 
-    @Min(value = 1, message = "Heartbeat Interval must be at least {value}")
+    @Min(value = 0, message = "Heartbeat Interval must be at least {value}")
     @NotNull(message = "Heartbeat Interval is required")
     private Integer heartbeat;
 

--- a/src/main/resources/webapp/WEB-INF/views/settings.jsp
+++ b/src/main/resources/webapp/WEB-INF/views/settings.jsp
@@ -37,7 +37,8 @@
             <form:input path="heartbeat"/>
         </td></tr>
         <tr><td><i>
-            The time interval in <b>minutes</b> for how often a charge point <br> should request the current time from SteVe.
+            The time interval in <b>minutes</b> for how often a charge point <br> should request the current time from SteVe.<br>
+            The value 0 requests clients to use reasonable default values.
         </i></td><td></td></tr>
         <tr><td>Expiration:</td><td>
             <form:input path="expiration"/>


### PR DESCRIPTION
According to the standard, when a value of zero is returned in the BootNotification, then the client is requested to use a reasonable default interval:

Quote:
  If that interval value is zero, the Charge Point chooses a
  waiting interval on its own, in a way that avoids flooding
  the Central System with requests.

So let's allow the configuration of zero here.