### PR TITLE
STEVE with ARM64 architecture DOCKER fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Ling Li
 # Download and install dockerize.
 # Needed so the web container will wait for MariaDB to start.
 ENV DOCKERIZE_VERSION v0.19.0
-RUN wget -O - https://github.com/powerman/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-`uname -s-uname -m` | install /dev/stdin /usr/local/bin/dockerizeize
+RUN wget -O - https://github.com/powerman/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-`uname -s-uname -m` | install /dev/stdin /usr/local/bin/dockerize
 EXPOSE 8180
 EXPOSE 8443
 WORKDIR /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Ling Li
 # Download and install dockerize.
 # Needed so the web container will wait for MariaDB to start.
 ENV DOCKERIZE_VERSION v0.19.0
-RUN curl -sfL https://github.com/powerman/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-`uname -s`-`uname -m` | install /dev/stdin /usr/local/bin/dockerize
+RUN wget -O - https://github.com/powerman/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-`uname -s-uname -m` | install /dev/stdin /usr/local/bin/dockerizeize
 EXPOSE 8180
 EXPOSE 8443
 WORKDIR /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,8 @@ MAINTAINER Ling Li
 
 # Download and install dockerize.
 # Needed so the web container will wait for MariaDB to start.
-ENV DOCKERIZE_VERSION v0.6.1
-RUN wget --no-verbose https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
-
+ENV DOCKERIZE_VERSION v0.19.0
+RUN curl -sfL https://github.com/powerman/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-`uname -s`-`uname -m` | install /dev/stdin /usr/local/bin/dockerize
 EXPOSE 8180
 EXPOSE 8443
 WORKDIR /code


### PR DESCRIPTION
Original Dockerize project has been left unmanaged. It does not provide a version compatible with ARM64 based processors as of right now and the project could be considered as discontinued for all I know. powerman/dockerize is another project picked up by the community from where the original left off and it seems to be a direct drop in replacement, at least for the basic commands such as dockerize -wait and it should be compatible with all/most architectures. I have a successful build running on an OrangePI4 LTS (aarm64) on which I installed Armbian OS.

You need to have curl installed for this modification to work. on the project github page they also left the wget command, i guess you should decide which is better to use.

wget -O - https://github.com/powerman/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-`uname -s`-`uname -m` | install /dev/stdin /usr/local/bin/dockerize