### PR TITLE
STEVE through DOCKER on ARM64 architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,8 @@ MAINTAINER Ling Li
 
 # Download and install dockerize.
 # Needed so the web container will wait for MariaDB to start.
-ENV DOCKERIZE_VERSION v0.6.1
-RUN wget --no-verbose https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
+ENV DOCKERIZE_VERSION v0.19.0
+RUN curl -sfL https://github.com/powerman/dockerize/releases/download/"$DOCKERIZE_VERSION"/dockerize-`uname -s`-`uname -m` | install /dev/stdin /usr/local/bin/dockerize
 
 EXPOSE 8180
 EXPOSE 8443


### PR DESCRIPTION
On ARM64 processors, as of right now, you cannot launch STEVE services using DOCKER. When ran using the normal java application it launches successfully. This is due to the fact that original Dockerize project has been left unmanaged. It does not provide a version compatible with ARM64 based processors as of right now and the project could be considered as discontinued for all I know. powerman/dockerize is another project picked up by the community from where the original left off and it seems to be a direct drop in replacement, at least for the basic commands such as dockerize -wait and it should be compatible with all/most architectures. I have a successful build running on an OrangePI4 LTS (aarm64) on which I installed Armbian OS. I have left the curl option by default as the wget did not work for me, perhaps it needs some simple modifications but I did not have the time to look over it.

You need to have curl installed for this modification to work. on the project github page ( https://github.com/powerman/dockerize ) they also left the wget command, I guess you should decide which is better to use.

wget -O - https://github.com/powerman/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-`uname -s-uname -m` | install /dev/stdin /usr/local/bin/dockerize