### PR TITLE
Update transactions.jsp

### DIFF
--- a/src/main/resources/webapp/WEB-INF/views/data-man/transactions.jsp
+++ b/src/main/resources/webapp/WEB-INF/views/data-man/transactions.jsp
@@ -123,7 +123,7 @@ Transactions
                 <td>
                     <c:if test="${empty ta.stopValue}">
                         <form:form action="${ctxPath}/manager/transactions/stop/${ta.id}">
-                            <input type="submit" class="redSubmit" title="Manually stop this active transaction" value="Stop">
+                            <input type="submit" class="redSubmit" title="Set manually this transaction form active to stopped. The actual transaction is not affected by this!" value="Stop">
                         </form:form>
                     </c:if>
                 </td>


### PR DESCRIPTION
The STOP button in Transaction.jsp indicates that the loading process can be stopped with the button. The underlying functionality creates a stop event entry in the SQL table, but does not remotely stop the transaction (remoteStopTransaction). Changed the stop button title to better understand this behavior.