### PR TITLE
Pin version of MariaDB for DB migrations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04 ]
         java: [ '11', '17' ]
-        db: [ 'mysql:5.7', 'mysql:8.0', 'mariadb:10.3', 'mariadb:10.4', 'mariadb:10.5', 'mariadb:10.6' ]
+        db: [ 'mysql:5.7', 'mysql:8.0', 'mariadb:10.3', 'mariadb:10.4.30', 'mariadb:10.5.21', 'mariadb:10.6.14' ]
     runs-on: ${{ matrix.os }}
     services:
       mysql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,12 @@ volumes:
 services:
 
   db:
-    image: mariadb:10.4
+    # Pinning MariaDB to point release 10.4.30 works around the issues with the
+    # database migrations seen with 10.4.31 in issue #1212.
+    #
+    # TODO: Get database migrations to work with the latest point releases of
+    # MariaDB 10.4.
+    image: mariadb:10.4.30
     ports:
       - 3306:3306
     environment:


### PR DESCRIPTION
When running database migrations with the latest 10.4.31, they fail as shown in issue #1212. Pinning the point release of MariaDB to the latest known-good version maneuvers around this issue.