### PR TITLE
Fix issue related to invalid characters in tags being submitted.

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/web/validation/IdTag.java
+++ b/src/main/java/de/rwth/idsg/steve/web/validation/IdTag.java
@@ -36,7 +36,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Constraint(validatedBy = {IdTagValidator.class, IdTagListValidator.class})
 public @interface IdTag {
 
-    String message() default "ID Tag can only contain upper or lower case letters, numbers and dot, colon, dash, underscore symbols";
+    String message() default "ID Tag can only contain upper or lower case letters, numbers and dot, colon, dash, underscore or hash symbols";
 
     // Required by validation runtime
     Class<?>[] groups() default {};

--- a/src/main/java/de/rwth/idsg/steve/web/validation/IdTagValidator.java
+++ b/src/main/java/de/rwth/idsg/steve/web/validation/IdTagValidator.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
  */
 public class IdTagValidator implements ConstraintValidator<IdTag, String> {
 
-    private static final String IDTAG_PATTERN = "^[a-zA-Z0-9.:_-]{1,20}$";
+    private static final String IDTAG_PATTERN = "^[a-zA-Z0-9.:_#-]{1,20}$";
     private static final Pattern PATTERN = Pattern.compile(IDTAG_PATTERN);
 
     @Override


### PR DESCRIPTION
The default behaviour of SteVe is to create a new OCPP tag if the charging point submits an unknown tag. If this tag contains invalid characters, the entry ends up in an invalid state:

- you cannot see it in the OCPP tag overview page (and also isn't displayed in the unknown tag section)
- if you go to the active/past sessions pane, and click through to the tag over there, you cannot edit or delete the tag since it doesn't pass validation.

This bug gets triggered because some charge points send arbitrary text as a tag when FreeCharge mode is enabled. The Webasto Next (https://charging.webasto.com/int/products/webasto-next/) chargepoint I use triggers this bug, since it uses the #FreeCharging tag ID when freecharging is enabled.

This PR adds the '#' sign to the whitelist of characters allowed, fixing this issue.