### PR TITLE
add chargeBoxId to table transaction_stop_failed

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImpl.java
@@ -455,6 +455,7 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
         try {
             ctx.insertInto(TRANSACTION_STOP_FAILED)
                .set(TRANSACTION_STOP_FAILED.TRANSACTION_PK, p.getTransactionId())
+               .set(TRANSACTION_STOP_FAILED.CHARGE_BOX_ID, p.getChargeBoxId())
                .set(TRANSACTION_STOP_FAILED.EVENT_TIMESTAMP, p.getEventTimestamp())
                .set(TRANSACTION_STOP_FAILED.EVENT_ACTOR, mapActor(p.getEventActor()))
                .set(TRANSACTION_STOP_FAILED.STOP_TIMESTAMP, p.getStopTimestamp())

--- a/src/main/resources/db/migration/V1_0_4__update.sql
+++ b/src/main/resources/db/migration/V1_0_4__update.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `transaction_stop_failed`
+    ADD COLUMN `charge_box_id` varchar(255) default null AFTER `transaction_pk`;


### PR DESCRIPTION
reason: provide more context and info

this field was available the whole time, actually. i did not think about adding it due to oversight. it might be useful for some people.