### PR TITLE
Propose Docker Compose V2 for bringing up containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ SteVe is designed to run standalone, a java servlet container / web server (e.g.
 
 # Docker
 
-If you prefer to build and start this project via docker (you can skip the steps 1, 4 and 5 from above), this can be done as follows: `docker-compose up -d`
+If you prefer to build and start this project via docker (you can skip the steps 1, 4 and 5 from above), this can be done as follows: `docker compose up -d`
 
-Because the docker-compose file is written to build the project for you, you still have to change the project configuration settings from step 3.
+Because the docker compose file is written to build the project for you, you still have to change the project configuration settings from step 3.
 Instead of changing the [main.properties in the prod directory](src/main/resources/config/prod/main.properties), you have to change the [main.properties in the docker directory](src/main/resources/config/docker/main.properties). There you have to change all configurations which are described in step 3.
-The database password for the user "steve" has to be the same as you have configured it in the docker-compose file.
+The database password for the user "steve" has to be the same as you have configured it in the docker compose file.
 
-With the default docker-compose configuration, the web interface will be accessible at: `http://localhost:8180`
+With the default docker compose configuration, the web interface will be accessible at: `http://localhost:8180`
 
 # Kubernetes
 


### PR DESCRIPTION
Attempting this with Docker Compose V1 (docker-compose in its latest release 1.29.2) results in dockerize (the application container entry point) failing to resolve the DB host. This gives gives the error message
```
Waiting for tcp://mariadb:3306: dial tcp: lookup mariadb on 127.0.0.11:53: server misbehaving.
```
in the log of the application container makes it exit after a while.

Bringing up the containers with
```
$ docker compose up -d
```
works like a treat (with docker 25.0.2).