### PR TITLE
Fix transaction overview page to list all txns instead of just active.

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/web/dto/TransactionQueryForm.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/TransactionQueryForm.java
@@ -44,7 +44,7 @@ public class TransactionQueryForm extends QueryForm {
     private boolean returnCSV = false;
 
     @ApiModelProperty(value = "Return active or all transactions? Defaults to ALL")
-    private QueryType type = QueryType.ACTIVE;
+    private QueryType type = QueryType.ALL;
 
     @ApiModelProperty(value = "Return the time period of the transactions. If FROM_TO, 'from' and 'to' must be set. Additionally, 'to' must be after 'from'. Defaults to ALL")
     private QueryPeriodType periodType = QueryPeriodType.ALL;


### PR DESCRIPTION
The default view on the Data Management > Transactions page is to only list active transactions. This is annoying, since you most likely want to get an overview of all transactions registered if you go into this view since there is a separate button to only show the active transactions. The code also suggests it was supposed to be the case that all transactions (and not just the active ones) would be shown.

This PR fixes this.