### PR TITLE
Setting a database baseline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,6 @@ jobs:
           mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "CREATE DATABASE stevedb_test_2aa6a783d47d;" -v
           mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "CREATE USER 'steve'@'%' IDENTIFIED BY 'changeme';" -v
           mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "GRANT ALL PRIVILEGES ON stevedb_test_2aa6a783d47d.* TO 'steve'@'%';" -v
-          mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "GRANT SELECT ON mysql.proc TO 'steve'@'%';" -v || true
           mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "GRANT SUPER ON *.* TO 'steve'@'%';" -v || true
 
       - name: Build with Maven

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,6 @@ jobs:
           mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "CREATE DATABASE stevedb_test_2aa6a783d47d;" -v
           mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "CREATE USER 'steve'@'%' IDENTIFIED BY 'changeme';" -v
           mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "GRANT ALL PRIVILEGES ON stevedb_test_2aa6a783d47d.* TO 'steve'@'%';" -v
-          mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "GRANT SUPER ON *.* TO 'steve'@'%';" -v || true
 
       - name: Build with Maven
         run: ./mvnw -B -V -Dmaven.javadoc.skip=true -Ptest clean package --file pom.xml

--- a/src/main/resources/db/migration/B1_0_5__stevedb.sql
+++ b/src/main/resources/db/migration/B1_0_5__stevedb.sql
@@ -319,6 +319,12 @@ CREATE TABLE `settings` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
+
+-- Exported data of table stevedb.settings: ~1 rows (approx.)
+INSERT INTO `settings` (`app_id`, `heartbeat_interval_in_seconds`, `hours_to_expire`, `mail_enabled`, `mail_host`, `mail_username`, `mail_password`, `mail_from`, `mail_protocol`, `mail_port`, `mail_recipients`, `notification_features`) VALUES
+	('U3RlY2tkb3NlblZlcndhbHR1bmc=', 14400, 1, 0, NULL, NULL, NULL, NULL, 'smtp', 25, NULL, NULL);
+
+
 --
 -- Temporary table structure for view `transaction`
 --

--- a/src/main/resources/db/migration/B1_0_5__stevedb.sql
+++ b/src/main/resources/db/migration/B1_0_5__stevedb.sql
@@ -5,13 +5,13 @@
 -- ------------------------------------------------------
 -- Server version	11.4.2-MariaDB
 
-/*!40101 SET NAMES utf8mb4 */;
-/*!40103 SET TIME_ZONE='+00:00' */;
-/*!40101 SET character_set_client = utf8 */;
+SET NAMES utf8mb4;
+SET TIME_ZONE='+00:00';
+SET character_set_client = utf8;
 
-/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
-/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
-/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO';
 
 --
 -- Table structure for table `address`
@@ -342,23 +342,23 @@ CREATE TABLE `user` (
 -- Final view structure for view `transaction`
 --
 
-/*!50001 DROP VIEW IF EXISTS `transaction`*/;
-/*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`steve`@`localhost` SQL SECURITY DEFINER */
-/*!50001 VIEW `transaction` AS select `tx1`.`transaction_pk` AS `transaction_pk`,`tx1`.`connector_pk` AS `connector_pk`,`tx1`.`id_tag` AS `id_tag`,`tx1`.`event_timestamp` AS `start_event_timestamp`,`tx1`.`start_timestamp` AS `start_timestamp`,`tx1`.`start_value` AS `start_value`,`tx2`.`event_actor` AS `stop_event_actor`,`tx2`.`event_timestamp` AS `stop_event_timestamp`,`tx2`.`stop_timestamp` AS `stop_timestamp`,`tx2`.`stop_value` AS `stop_value`,`tx2`.`stop_reason` AS `stop_reason` from (`transaction_start` `tx1` left join `transaction_stop` `tx2` on(`tx1`.`transaction_pk` = `tx2`.`transaction_pk` and `tx2`.`event_timestamp` = (select max(`s2`.`event_timestamp`) from `transaction_stop` `s2` where `tx2`.`transaction_pk` = `s2`.`transaction_pk`))) */;
+DROP VIEW IF EXISTS `transaction`;
+CREATE ALGORITHM=UNDEFINED
+DEFINER=`steve`@`localhost` SQL SECURITY DEFINER
+VIEW `transaction` AS select `tx1`.`transaction_pk` AS `transaction_pk`,`tx1`.`connector_pk` AS `connector_pk`,`tx1`.`id_tag` AS `id_tag`,`tx1`.`event_timestamp` AS `start_event_timestamp`,`tx1`.`start_timestamp` AS `start_timestamp`,`tx1`.`start_value` AS `start_value`,`tx2`.`event_actor` AS `stop_event_actor`,`tx2`.`event_timestamp` AS `stop_event_timestamp`,`tx2`.`stop_timestamp` AS `stop_timestamp`,`tx2`.`stop_value` AS `stop_value`,`tx2`.`stop_reason` AS `stop_reason` from (`transaction_start` `tx1` left join `transaction_stop` `tx2` on(`tx1`.`transaction_pk` = `tx2`.`transaction_pk` and `tx2`.`event_timestamp` = (select max(`s2`.`event_timestamp`) from `transaction_stop` `s2` where `tx2`.`transaction_pk` = `s2`.`transaction_pk`)));
 
 
 --
 -- Final view structure for view `ocpp_tag_activity`
 --
 
-/*!50001 DROP VIEW IF EXISTS `ocpp_tag_activity`*/;
-/*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`steve`@`localhost` SQL SECURITY DEFINER */
-/*!50001 VIEW `ocpp_tag_activity` AS select `o`.`ocpp_tag_pk` AS `ocpp_tag_pk`,`o`.`id_tag` AS `id_tag`,`o`.`parent_id_tag` AS `parent_id_tag`,`o`.`expiry_date` AS `expiry_date`,`o`.`max_active_transaction_count` AS `max_active_transaction_count`,`o`.`note` AS `note`,count(`t`.`id_tag`) AS `active_transaction_count`,case when count(`t`.`id_tag`) > 0 then 1 else 0 end AS `in_transaction`,case when `o`.`max_active_transaction_count` = 0 then 1 else 0 end AS `blocked` from (`ocpp_tag` `o` left join `transaction` `t` on(`o`.`id_tag` = `t`.`id_tag` and `t`.`stop_timestamp` is null and `t`.`stop_value` is null)) group by `o`.`ocpp_tag_pk`,`o`.`parent_id_tag`,`o`.`expiry_date`,`o`.`max_active_transaction_count`,`o`.`note` */;
+DROP VIEW IF EXISTS `ocpp_tag_activity`;
+CREATE ALGORITHM=UNDEFINED
+DEFINER=`steve`@`localhost` SQL SECURITY DEFINER
+VIEW `ocpp_tag_activity` AS select `o`.`ocpp_tag_pk` AS `ocpp_tag_pk`,`o`.`id_tag` AS `id_tag`,`o`.`parent_id_tag` AS `parent_id_tag`,`o`.`expiry_date` AS `expiry_date`,`o`.`max_active_transaction_count` AS `max_active_transaction_count`,`o`.`note` AS `note`,count(`t`.`id_tag`) AS `active_transaction_count`,case when count(`t`.`id_tag`) > 0 then 1 else 0 end AS `in_transaction`,case when `o`.`max_active_transaction_count` = 0 then 1 else 0 end AS `blocked` from (`ocpp_tag` `o` left join `transaction` `t` on(`o`.`id_tag` = `t`.`id_tag` and `t`.`stop_timestamp` is null and `t`.`stop_value` is null)) group by `o`.`ocpp_tag_pk`,`o`.`parent_id_tag`,`o`.`expiry_date`,`o`.`max_active_transaction_count`,`o`.`note`;
 
 
-/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
-/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
-/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+SET SQL_MODE=@OLD_SQL_MODE;
+SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
 

--- a/src/main/resources/db/migration/B1_0_5__stevedb.sql
+++ b/src/main/resources/db/migration/B1_0_5__stevedb.sql
@@ -107,7 +107,7 @@ CREATE TABLE IF NOT EXISTS `connector` (
   UNIQUE KEY `connector_pk_UNIQUE` (`connector_pk`),
   UNIQUE KEY `connector_cbid_cid_UNIQUE` (`charge_box_id`,`connector_id`),
   CONSTRAINT `FK_connector_charge_box_cbid` FOREIGN KEY (`charge_box_id`) REFERENCES `charge_box` (`charge_box_id`) ON DELETE CASCADE ON UPDATE NO ACTION
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 
 
 
@@ -211,7 +211,7 @@ CREATE TABLE IF NOT EXISTS `reservation` (
   CONSTRAINT `FK_connector_pk_reserv` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION,
   CONSTRAINT `FK_reservation_ocpp_tag_id_tag` FOREIGN KEY (`id_tag`) REFERENCES `ocpp_tag` (`id_tag`) ON DELETE CASCADE ON UPDATE NO ACTION,
   CONSTRAINT `FK_transaction_pk_r` FOREIGN KEY (`transaction_pk`) REFERENCES `transaction_start` (`transaction_pk`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 
 
 

--- a/src/main/resources/db/migration/B1_0_5__stevedb.sql
+++ b/src/main/resources/db/migration/B1_0_5__stevedb.sql
@@ -1,0 +1,385 @@
+-- --------------------------------------------------------
+-- DB Baseline Script, exported with HeidiSQL
+--
+-- Host:                         127.0.0.1
+-- Server-Version:               10.6.5-MariaDB - mariadb.org binary distribution
+-- Server-OS:                    Win64
+-- HeidiSQL Version:             12.5.0.6677
+-- --------------------------------------------------------
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET NAMES utf8 */;
+/*!50503 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+-- Exported structur of table stevedb.address
+CREATE TABLE IF NOT EXISTS `address` (
+  `address_pk` int(11) NOT NULL AUTO_INCREMENT,
+  `street` varchar(1000) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `house_number` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `zip_code` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `city` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `country` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`address_pk`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of table stevedb.charge_box
+CREATE TABLE IF NOT EXISTS `charge_box` (
+  `charge_box_pk` int(11) NOT NULL AUTO_INCREMENT,
+  `charge_box_id` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `endpoint_address` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `ocpp_protocol` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `registration_status` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT 'Accepted',
+  `charge_point_vendor` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `charge_point_model` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `charge_point_serial_number` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `charge_box_serial_number` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `fw_version` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `fw_update_status` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `fw_update_timestamp` timestamp(6) NULL DEFAULT NULL,
+  `iccid` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `imsi` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `meter_type` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `meter_serial_number` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `diagnostics_status` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `diagnostics_timestamp` timestamp(6) NULL DEFAULT NULL,
+  `last_heartbeat_timestamp` timestamp(6) NULL DEFAULT NULL,
+  `description` mediumtext COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `note` mediumtext COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `location_latitude` decimal(11,8) DEFAULT NULL,
+  `location_longitude` decimal(11,8) DEFAULT NULL,
+  `address_pk` int(11) DEFAULT NULL,
+  `admin_address` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `insert_connector_status_after_transaction_msg` tinyint(1) DEFAULT 1,
+  PRIMARY KEY (`charge_box_pk`),
+  UNIQUE KEY `chargeBoxId_UNIQUE` (`charge_box_id`),
+  KEY `chargebox_op_ep_idx` (`ocpp_protocol`,`endpoint_address`),
+  KEY `FK_charge_box_address_apk` (`address_pk`),
+  CONSTRAINT `FK_charge_box_address_apk` FOREIGN KEY (`address_pk`) REFERENCES `address` (`address_pk`) ON DELETE SET NULL ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of table stevedb.charging_profile
+CREATE TABLE IF NOT EXISTS `charging_profile` (
+  `charging_profile_pk` int(11) NOT NULL AUTO_INCREMENT,
+  `stack_level` int(11) NOT NULL,
+  `charging_profile_purpose` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `charging_profile_kind` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `recurrency_kind` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `valid_from` timestamp(6) NULL DEFAULT NULL,
+  `valid_to` timestamp(6) NULL DEFAULT NULL,
+  `duration_in_seconds` int(11) DEFAULT NULL,
+  `start_schedule` timestamp(6) NULL DEFAULT NULL,
+  `charging_rate_unit` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `min_charging_rate` decimal(15,1) DEFAULT NULL,
+  `description` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `note` text COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`charging_profile_pk`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of table stevedb.charging_schedule_period
+CREATE TABLE IF NOT EXISTS `charging_schedule_period` (
+  `charging_profile_pk` int(11) NOT NULL,
+  `start_period_in_seconds` int(11) NOT NULL,
+  `power_limit` decimal(15,1) NOT NULL,
+  `number_phases` int(11) DEFAULT NULL,
+  UNIQUE KEY `UQ_charging_schedule_period` (`charging_profile_pk`,`start_period_in_seconds`),
+  CONSTRAINT `FK_charging_schedule_period_charging_profile_pk` FOREIGN KEY (`charging_profile_pk`) REFERENCES `charging_profile` (`charging_profile_pk`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of table stevedb.connector
+CREATE TABLE IF NOT EXISTS `connector` (
+  `connector_pk` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `charge_box_id` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `connector_id` int(11) NOT NULL,
+  PRIMARY KEY (`connector_pk`),
+  UNIQUE KEY `connector_pk_UNIQUE` (`connector_pk`),
+  UNIQUE KEY `connector_cbid_cid_UNIQUE` (`charge_box_id`,`connector_id`),
+  CONSTRAINT `FK_connector_charge_box_cbid` FOREIGN KEY (`charge_box_id`) REFERENCES `charge_box` (`charge_box_id`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of table stevedb.connector_charging_profile
+CREATE TABLE IF NOT EXISTS `connector_charging_profile` (
+  `connector_pk` int(11) unsigned NOT NULL,
+  `charging_profile_pk` int(11) NOT NULL,
+  UNIQUE KEY `UQ_connector_charging_profile` (`connector_pk`,`charging_profile_pk`),
+  KEY `FK_connector_charging_profile_charging_profile_pk` (`charging_profile_pk`),
+  CONSTRAINT `FK_connector_charging_profile_charging_profile_pk` FOREIGN KEY (`charging_profile_pk`) REFERENCES `charging_profile` (`charging_profile_pk`) ON DELETE NO ACTION ON UPDATE NO ACTION,
+  CONSTRAINT `FK_connector_charging_profile_connector_pk` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of table stevedb.connector_meter_value
+CREATE TABLE IF NOT EXISTS `connector_meter_value` (
+  `connector_pk` int(11) unsigned NOT NULL,
+  `transaction_pk` int(10) unsigned DEFAULT NULL,
+  `value_timestamp` timestamp(6) NULL DEFAULT NULL,
+  `value` text COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `reading_context` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `format` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `measurand` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `location` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `unit` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `phase` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  KEY `FK_cm_pk_idx` (`connector_pk`),
+  KEY `FK_tid_cm_idx` (`transaction_pk`),
+  KEY `cmv_value_timestamp_idx` (`value_timestamp`),
+  CONSTRAINT `FK_pk_cm` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT `FK_tid_cm` FOREIGN KEY (`transaction_pk`) REFERENCES `transaction_start` (`transaction_pk`) ON DELETE SET NULL ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of table stevedb.connector_status
+CREATE TABLE IF NOT EXISTS `connector_status` (
+  `connector_pk` int(11) unsigned NOT NULL,
+  `status_timestamp` timestamp(6) NULL DEFAULT NULL,
+  `status` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `error_code` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `error_info` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `vendor_id` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `vendor_error_code` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  KEY `FK_cs_pk_idx` (`connector_pk`),
+  KEY `connector_status_cpk_st_idx` (`connector_pk`,`status_timestamp`),
+  CONSTRAINT `FK_cs_pk` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of table stevedb.ocpp_tag
+CREATE TABLE IF NOT EXISTS `ocpp_tag` (
+  `ocpp_tag_pk` int(11) NOT NULL AUTO_INCREMENT,
+  `id_tag` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `parent_id_tag` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `expiry_date` timestamp(6) NULL DEFAULT NULL,
+  `max_active_transaction_count` int(11) NOT NULL DEFAULT 1,
+  `note` mediumtext COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`ocpp_tag_pk`),
+  UNIQUE KEY `idTag_UNIQUE` (`id_tag`),
+  KEY `user_expiryDate_idx` (`expiry_date`),
+  KEY `FK_ocpp_tag_parent_id_tag` (`parent_id_tag`),
+  CONSTRAINT `FK_ocpp_tag_parent_id_tag` FOREIGN KEY (`parent_id_tag`) REFERENCES `ocpp_tag` (`id_tag`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of view stevedb.ocpp_tag_activity
+-- Create a temporary table, to be upfront of view-dependencies
+CREATE TABLE `ocpp_tag_activity` (
+	`ocpp_tag_pk` INT(11) NOT NULL,
+	`id_tag` VARCHAR(255) NOT NULL COLLATE 'utf8mb3_unicode_ci',
+	`parent_id_tag` VARCHAR(255) NULL COLLATE 'utf8mb3_unicode_ci',
+	`expiry_date` TIMESTAMP(6) NULL,
+	`max_active_transaction_count` INT(11) NOT NULL,
+	`note` MEDIUMTEXT NULL COLLATE 'utf8mb3_unicode_ci',
+	`active_transaction_count` BIGINT(21) NOT NULL,
+	`in_transaction` INT(1) NOT NULL,
+	`blocked` INT(1) NOT NULL
+) ENGINE=MyISAM;
+
+-- Exported structur of table stevedb.reservation
+CREATE TABLE IF NOT EXISTS `reservation` (
+  `reservation_pk` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `connector_pk` int(11) unsigned NOT NULL,
+  `transaction_pk` int(10) unsigned DEFAULT NULL,
+  `id_tag` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `start_datetime` datetime DEFAULT NULL,
+  `expiry_datetime` datetime DEFAULT NULL,
+  `status` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  PRIMARY KEY (`reservation_pk`),
+  UNIQUE KEY `reservation_pk_UNIQUE` (`reservation_pk`),
+  UNIQUE KEY `transaction_pk_UNIQUE` (`transaction_pk`),
+  KEY `FK_idTag_r_idx` (`id_tag`),
+  KEY `reservation_start_idx` (`start_datetime`),
+  KEY `reservation_expiry_idx` (`expiry_datetime`),
+  KEY `reservation_status_idx` (`status`),
+  KEY `FK_connector_pk_reserv_idx` (`connector_pk`),
+  CONSTRAINT `FK_connector_pk_reserv` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT `FK_reservation_ocpp_tag_id_tag` FOREIGN KEY (`id_tag`) REFERENCES `ocpp_tag` (`id_tag`) ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT `FK_transaction_pk_r` FOREIGN KEY (`transaction_pk`) REFERENCES `transaction_start` (`transaction_pk`) ON DELETE NO ACTION ON UPDATE NO ACTION
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of table stevedb.schema_version
+CREATE TABLE IF NOT EXISTS `schema_version` (
+  `installed_rank` int(11) NOT NULL,
+  `version` varchar(50) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `description` varchar(200) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `type` varchar(20) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `script` varchar(1000) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `checksum` int(11) DEFAULT NULL,
+  `installed_by` varchar(100) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `installed_on` timestamp NOT NULL DEFAULT current_timestamp(),
+  `execution_time` int(11) NOT NULL,
+  `success` tinyint(1) NOT NULL,
+  PRIMARY KEY (`installed_rank`),
+  KEY `schema_version_s_idx` (`success`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of table stevedb.settings
+CREATE TABLE IF NOT EXISTS `settings` (
+  `app_id` varchar(40) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `heartbeat_interval_in_seconds` int(11) DEFAULT NULL,
+  `hours_to_expire` int(11) DEFAULT NULL,
+  `mail_enabled` tinyint(1) DEFAULT 0,
+  `mail_host` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `mail_username` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `mail_password` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `mail_from` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `mail_protocol` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT 'smtp',
+  `mail_port` int(11) DEFAULT 25,
+  `mail_recipients` text COLLATE utf8mb3_unicode_ci DEFAULT NULL COMMENT 'comma separated list of email addresses',
+  `notification_features` text COLLATE utf8mb3_unicode_ci DEFAULT NULL COMMENT 'comma separated list',
+  PRIMARY KEY (`app_id`),
+  UNIQUE KEY `settings_id_UNIQUE` (`app_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+-- Exported structur of view stevedb.transaction
+-- Create a temporary table, to be upfront of view-dependencies
+CREATE TABLE `transaction` (
+	`transaction_pk` INT(10) UNSIGNED NOT NULL,
+	`connector_pk` INT(11) UNSIGNED NOT NULL,
+	`id_tag` VARCHAR(255) NOT NULL COLLATE 'utf8mb3_unicode_ci',
+	`start_event_timestamp` TIMESTAMP(6) NOT NULL,
+	`start_timestamp` TIMESTAMP(6) NULL,
+	`start_value` VARCHAR(255) NULL COLLATE 'utf8mb3_unicode_ci',
+	`stop_event_actor` ENUM('station','manual') NULL COLLATE 'utf8mb3_unicode_ci',
+	`stop_event_timestamp` TIMESTAMP(6) NULL,
+	`stop_timestamp` TIMESTAMP(6) NULL,
+	`stop_value` VARCHAR(255) NULL COLLATE 'utf8mb3_unicode_ci',
+	`stop_reason` VARCHAR(255) NULL COLLATE 'utf8mb3_unicode_ci'
+) ENGINE=MyISAM;
+
+
+
+-- Exported structur of table stevedb.transaction_start
+CREATE TABLE IF NOT EXISTS `transaction_start` (
+  `transaction_pk` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `event_timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6),
+  `connector_pk` int(11) unsigned NOT NULL,
+  `id_tag` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `start_timestamp` timestamp(6) NULL DEFAULT NULL,
+  `start_value` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`transaction_pk`),
+  UNIQUE KEY `transaction_pk_UNIQUE` (`transaction_pk`),
+  KEY `idTag_idx` (`id_tag`),
+  KEY `connector_pk_idx` (`connector_pk`),
+  KEY `transaction_start_idx` (`start_timestamp`),
+  CONSTRAINT `FK_connector_pk_t` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT `FK_transaction_ocpp_tag_id_tag` FOREIGN KEY (`id_tag`) REFERENCES `ocpp_tag` (`id_tag`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of table stevedb.transaction_stop
+CREATE TABLE IF NOT EXISTS `transaction_stop` (
+  `transaction_pk` int(10) unsigned NOT NULL,
+  `event_timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6),
+  `event_actor` enum('station','manual') COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `stop_timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6),
+  `stop_value` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `stop_reason` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`transaction_pk`,`event_timestamp`),
+  CONSTRAINT `FK_transaction_stop_transaction_pk` FOREIGN KEY (`transaction_pk`) REFERENCES `transaction_start` (`transaction_pk`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of table stevedb.transaction_stop_failed
+CREATE TABLE IF NOT EXISTS `transaction_stop_failed` (
+  `transaction_pk` int(11) DEFAULT NULL,
+  `charge_box_id` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `event_timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6),
+  `event_actor` enum('station','manual') COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `stop_timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6),
+  `stop_value` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `stop_reason` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `fail_reason` text COLLATE utf8mb3_unicode_ci DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of table stevedb.user
+CREATE TABLE IF NOT EXISTS `user` (
+  `user_pk` int(11) NOT NULL AUTO_INCREMENT,
+  `ocpp_tag_pk` int(11) DEFAULT NULL,
+  `address_pk` int(11) DEFAULT NULL,
+  `first_name` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `last_name` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `birth_day` date DEFAULT NULL,
+  `sex` char(1) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `phone` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `e_mail` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `note` text COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`user_pk`),
+  KEY `FK_user_ocpp_tag_otpk` (`ocpp_tag_pk`),
+  KEY `FK_user_address_apk` (`address_pk`),
+  CONSTRAINT `FK_user_address_apk` FOREIGN KEY (`address_pk`) REFERENCES `address` (`address_pk`) ON DELETE SET NULL ON UPDATE NO ACTION,
+  CONSTRAINT `FK_user_ocpp_tag_otpk` FOREIGN KEY (`ocpp_tag_pk`) REFERENCES `ocpp_tag` (`ocpp_tag_pk`) ON DELETE SET NULL ON UPDATE NO ACTION
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+
+
+-- Exported structur of view stevedb.ocpp_tag_activity
+-- Remove the temporary table and create the view
+DROP TABLE IF EXISTS `ocpp_tag_activity`;
+CREATE ALGORITHM=UNDEFINED DEFINER=`steve`@`localhost` SQL SECURITY DEFINER VIEW `ocpp_tag_activity` AS select `o`.*,
+       count(`t`.`id_tag`)                                                AS `active_transaction_count`,
+       case when count(`t`.`id_tag`) > 0 then 1 else 0 end                AS `in_transaction`,
+       case when `o`.`max_active_transaction_count` = 0 then 1 else 0 end AS `blocked`
+from `ocpp_tag` `o` left join `transaction` `t` on (
+    `o`.`id_tag` = `t`.`id_tag` and
+    `t`.`stop_timestamp` is null and
+    `t`.`stop_value` is null)
+group by
+    `o`.`ocpp_tag_pk`,
+    `o`.`parent_id_tag`,
+    `o`.`expiry_date`,
+    `o`.`max_active_transaction_count`,
+    `o`.`note` ;
+
+
+
+-- Exported structur of view stevedb.transaction
+-- Remove the tmeporary table and create the view
+DROP TABLE IF EXISTS `transaction`;
+CREATE ALGORITHM=UNDEFINED DEFINER=`steve`@`localhost` SQL SECURITY DEFINER VIEW `transaction` AS SELECT
+    tx1.transaction_pk,
+    tx1.connector_pk,
+    tx1.id_tag,
+    tx1.event_timestamp as 'start_event_timestamp',
+    tx1.start_timestamp,
+    tx1.start_value,
+    tx2.event_actor as 'stop_event_actor',
+    tx2.event_timestamp as 'stop_event_timestamp',
+    tx2.stop_timestamp,
+    tx2.stop_value,
+    tx2.stop_reason
+FROM transaction_start tx1
+LEFT JOIN transaction_stop tx2
+    ON tx1.transaction_pk = tx2.transaction_pk
+    AND tx2.event_timestamp = (SELECT MAX(event_timestamp) FROM transaction_stop s2 WHERE tx2.transaction_pk = s2.transaction_pk) ;
+
+/*!40103 SET TIME_ZONE=IFNULL(@OLD_TIME_ZONE, 'system') */;
+/*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;
+/*!40014 SET FOREIGN_KEY_CHECKS=IFNULL(@OLD_FOREIGN_KEY_CHECKS, 1) */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40111 SET SQL_NOTES=IFNULL(@OLD_SQL_NOTES, 1) */;

--- a/src/main/resources/db/migration/B1_0_5__stevedb.sql
+++ b/src/main/resources/db/migration/B1_0_5__stevedb.sql
@@ -347,7 +347,6 @@ CREATE TABLE `user` (
 
 DROP VIEW IF EXISTS `transaction`;
 CREATE ALGORITHM=UNDEFINED
-DEFINER=`steve`@`localhost` SQL SECURITY DEFINER
 VIEW `transaction` AS select 
     `tx1`.`transaction_pk` AS `transaction_pk`,
     `tx1`.`connector_pk` AS `connector_pk`,
@@ -373,7 +372,6 @@ VIEW `transaction` AS select
 
 DROP VIEW IF EXISTS `ocpp_tag_activity`;
 CREATE ALGORITHM=UNDEFINED
-DEFINER=`steve`@`localhost` SQL SECURITY DEFINER
 VIEW `ocpp_tag_activity` AS select
     `o`.`ocpp_tag_pk` AS `ocpp_tag_pk`,
     `o`.`id_tag` AS `id_tag`,

--- a/src/main/resources/db/migration/B1_0_5__stevedb.sql
+++ b/src/main/resources/db/migration/B1_0_5__stevedb.sql
@@ -251,6 +251,9 @@ CREATE TABLE IF NOT EXISTS `settings` (
   UNIQUE KEY `settings_id_UNIQUE` (`app_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
 
+-- Exported data of table stevedb.settings: ~1 rows (approx.)
+INSERT INTO `settings` (`app_id`, `heartbeat_interval_in_seconds`, `hours_to_expire`, `mail_enabled`, `mail_host`, `mail_username`, `mail_password`, `mail_from`, `mail_protocol`, `mail_port`, `mail_recipients`, `notification_features`) VALUES
+	('U3RlY2tkb3NlblZlcndhbHR1bmc=', 14400, 1, 0, NULL, NULL, NULL, NULL, 'smtp', 25, NULL, NULL);
 
 -- Exported structur of view stevedb.transaction
 -- Create a temporary table, to be upfront of view-dependencies

--- a/src/main/resources/db/migration/B1_0_5__stevedb.sql
+++ b/src/main/resources/db/migration/B1_0_5__stevedb.sql
@@ -5,10 +5,13 @@
 -- ------------------------------------------------------
 -- Server version	11.4.2-MariaDB
 
+# Set some DB settings
 SET NAMES utf8mb4;
 SET TIME_ZONE='+00:00';
 SET character_set_client = utf8;
 
+# Save Settings of Unique check, Foreign Kex check and the current sql mode.
+# Then deactivate the checks and set sql mode to 'NO_AUTO_VALUE_ON_ZERO'
 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO';
@@ -357,7 +360,7 @@ CREATE ALGORITHM=UNDEFINED
 DEFINER=`steve`@`localhost` SQL SECURITY DEFINER
 VIEW `ocpp_tag_activity` AS select `o`.`ocpp_tag_pk` AS `ocpp_tag_pk`,`o`.`id_tag` AS `id_tag`,`o`.`parent_id_tag` AS `parent_id_tag`,`o`.`expiry_date` AS `expiry_date`,`o`.`max_active_transaction_count` AS `max_active_transaction_count`,`o`.`note` AS `note`,count(`t`.`id_tag`) AS `active_transaction_count`,case when count(`t`.`id_tag`) > 0 then 1 else 0 end AS `in_transaction`,case when `o`.`max_active_transaction_count` = 0 then 1 else 0 end AS `blocked` from (`ocpp_tag` `o` left join `transaction` `t` on(`o`.`id_tag` = `t`.`id_tag` and `t`.`stop_timestamp` is null and `t`.`stop_value` is null)) group by `o`.`ocpp_tag_pk`,`o`.`parent_id_tag`,`o`.`expiry_date`,`o`.`max_active_transaction_count`,`o`.`note`;
 
-
+# Reset the checks and sql mode to the value before executing this script
 SET SQL_MODE=@OLD_SQL_MODE;
 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;

--- a/src/main/resources/db/migration/B1_0_5__stevedb.sql
+++ b/src/main/resources/db/migration/B1_0_5__stevedb.sql
@@ -5,24 +5,19 @@
 -- ------------------------------------------------------
 -- Server version	11.4.2-MariaDB
 
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
-/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
 /*!40101 SET NAMES utf8mb4 */;
-/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
+/*!40101 SET character_set_client = utf8 */;
+
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
-/*M!100616 SET @OLD_NOTE_VERBOSITY=@@NOTE_VERBOSITY, NOTE_VERBOSITY=0 */;
 
 --
 -- Table structure for table `address`
 --
 
 DROP TABLE IF EXISTS `address`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `address` (
   `address_pk` int(11) NOT NULL AUTO_INCREMENT,
   `street` varchar(1000) DEFAULT NULL,
@@ -32,15 +27,12 @@ CREATE TABLE `address` (
   `country` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`address_pk`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `charge_box`
 --
 
 DROP TABLE IF EXISTS `charge_box`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `charge_box` (
   `charge_box_pk` int(11) NOT NULL AUTO_INCREMENT,
   `charge_box_id` varchar(255) NOT NULL,
@@ -74,15 +66,12 @@ CREATE TABLE `charge_box` (
   KEY `FK_charge_box_address_apk` (`address_pk`),
   CONSTRAINT `FK_charge_box_address_apk` FOREIGN KEY (`address_pk`) REFERENCES `address` (`address_pk`) ON DELETE SET NULL ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `charging_profile`
 --
 
 DROP TABLE IF EXISTS `charging_profile`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `charging_profile` (
   `charging_profile_pk` int(11) NOT NULL AUTO_INCREMENT,
   `stack_level` int(11) NOT NULL,
@@ -99,15 +88,12 @@ CREATE TABLE `charging_profile` (
   `note` text DEFAULT NULL,
   PRIMARY KEY (`charging_profile_pk`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `charging_schedule_period`
 --
 
 DROP TABLE IF EXISTS `charging_schedule_period`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `charging_schedule_period` (
   `charging_profile_pk` int(11) NOT NULL,
   `start_period_in_seconds` int(11) NOT NULL,
@@ -116,15 +102,12 @@ CREATE TABLE `charging_schedule_period` (
   UNIQUE KEY `UQ_charging_schedule_period` (`charging_profile_pk`,`start_period_in_seconds`),
   CONSTRAINT `FK_charging_schedule_period_charging_profile_pk` FOREIGN KEY (`charging_profile_pk`) REFERENCES `charging_profile` (`charging_profile_pk`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `connector`
 --
 
 DROP TABLE IF EXISTS `connector`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `connector` (
   `connector_pk` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `charge_box_id` varchar(255) NOT NULL,
@@ -134,15 +117,12 @@ CREATE TABLE `connector` (
   UNIQUE KEY `connector_cbid_cid_UNIQUE` (`charge_box_id`,`connector_id`),
   CONSTRAINT `FK_connector_charge_box_cbid` FOREIGN KEY (`charge_box_id`) REFERENCES `charge_box` (`charge_box_id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `connector_charging_profile`
 --
 
 DROP TABLE IF EXISTS `connector_charging_profile`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `connector_charging_profile` (
   `connector_pk` int(11) unsigned NOT NULL,
   `charging_profile_pk` int(11) NOT NULL,
@@ -151,15 +131,12 @@ CREATE TABLE `connector_charging_profile` (
   CONSTRAINT `FK_connector_charging_profile_charging_profile_pk` FOREIGN KEY (`charging_profile_pk`) REFERENCES `charging_profile` (`charging_profile_pk`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   CONSTRAINT `FK_connector_charging_profile_connector_pk` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `connector_meter_value`
 --
 
 DROP TABLE IF EXISTS `connector_meter_value`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `connector_meter_value` (
   `connector_pk` int(11) unsigned NOT NULL,
   `transaction_pk` int(10) unsigned DEFAULT NULL,
@@ -177,15 +154,12 @@ CREATE TABLE `connector_meter_value` (
   CONSTRAINT `FK_pk_cm` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION,
   CONSTRAINT `FK_tid_cm` FOREIGN KEY (`transaction_pk`) REFERENCES `transaction_start` (`transaction_pk`) ON DELETE SET NULL ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `connector_status`
 --
 
 DROP TABLE IF EXISTS `connector_status`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `connector_status` (
   `connector_pk` int(11) unsigned NOT NULL,
   `status_timestamp` timestamp(6) NULL DEFAULT NULL,
@@ -198,15 +172,12 @@ CREATE TABLE `connector_status` (
   KEY `connector_status_cpk_st_idx` (`connector_pk`,`status_timestamp`),
   CONSTRAINT `FK_cs_pk` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `ocpp_tag`
 --
 
 DROP TABLE IF EXISTS `ocpp_tag`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ocpp_tag` (
   `ocpp_tag_pk` int(11) NOT NULL AUTO_INCREMENT,
   `id_tag` varchar(255) NOT NULL,
@@ -220,35 +191,12 @@ CREATE TABLE `ocpp_tag` (
   KEY `FK_ocpp_tag_parent_id_tag` (`parent_id_tag`),
   CONSTRAINT `FK_ocpp_tag_parent_id_tag` FOREIGN KEY (`parent_id_tag`) REFERENCES `ocpp_tag` (`id_tag`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Temporary table structure for view `ocpp_tag_activity`
---
-
-DROP TABLE IF EXISTS `ocpp_tag_activity`;
-/*!50001 DROP VIEW IF EXISTS `ocpp_tag_activity`*/;
-SET @saved_cs_client     = @@character_set_client;
-SET character_set_client = utf8;
-/*!50001 CREATE VIEW `ocpp_tag_activity` AS SELECT
- 1 AS `ocpp_tag_pk`,
-  1 AS `id_tag`,
-  1 AS `parent_id_tag`,
-  1 AS `expiry_date`,
-  1 AS `max_active_transaction_count`,
-  1 AS `note`,
-  1 AS `active_transaction_count`,
-  1 AS `in_transaction`,
-  1 AS `blocked` */;
-SET character_set_client = @saved_cs_client;
 
 --
 -- Table structure for table `reservation`
 --
 
 DROP TABLE IF EXISTS `reservation`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `reservation` (
   `reservation_pk` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `connector_pk` int(11) unsigned NOT NULL,
@@ -269,15 +217,12 @@ CREATE TABLE `reservation` (
   CONSTRAINT `FK_reservation_ocpp_tag_id_tag` FOREIGN KEY (`id_tag`) REFERENCES `ocpp_tag` (`id_tag`) ON DELETE CASCADE ON UPDATE NO ACTION,
   CONSTRAINT `FK_transaction_pk_r` FOREIGN KEY (`transaction_pk`) REFERENCES `transaction_start` (`transaction_pk`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `schema_version`
 --
 
 DROP TABLE IF EXISTS `schema_version`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `schema_version` (
   `installed_rank` int(11) NOT NULL,
   `version` varchar(50) DEFAULT NULL,
@@ -292,15 +237,12 @@ CREATE TABLE `schema_version` (
   PRIMARY KEY (`installed_rank`),
   KEY `schema_version_s_idx` (`success`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `settings`
 --
 
 DROP TABLE IF EXISTS `settings`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `settings` (
   `app_id` varchar(40) NOT NULL,
   `heartbeat_interval_in_seconds` int(11) DEFAULT NULL,
@@ -317,7 +259,6 @@ CREATE TABLE `settings` (
   PRIMARY KEY (`app_id`),
   UNIQUE KEY `settings_id_UNIQUE` (`app_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 
 -- Exported data of table stevedb.settings: ~1 rows (approx.)
@@ -325,35 +266,7 @@ INSERT INTO `settings` (`app_id`, `heartbeat_interval_in_seconds`, `hours_to_exp
 	('U3RlY2tkb3NlblZlcndhbHR1bmc=', 14400, 1, 0, NULL, NULL, NULL, NULL, 'smtp', 25, NULL, NULL);
 
 
---
--- Temporary table structure for view `transaction`
---
-
-DROP TABLE IF EXISTS `transaction`;
-/*!50001 DROP VIEW IF EXISTS `transaction`*/;
-SET @saved_cs_client     = @@character_set_client;
-SET character_set_client = utf8;
-/*!50001 CREATE VIEW `transaction` AS SELECT
- 1 AS `transaction_pk`,
-  1 AS `connector_pk`,
-  1 AS `id_tag`,
-  1 AS `start_event_timestamp`,
-  1 AS `start_timestamp`,
-  1 AS `start_value`,
-  1 AS `stop_event_actor`,
-  1 AS `stop_event_timestamp`,
-  1 AS `stop_timestamp`,
-  1 AS `stop_value`,
-  1 AS `stop_reason` */;
-SET character_set_client = @saved_cs_client;
-
---
--- Table structure for table `transaction_start`
---
-
 DROP TABLE IF EXISTS `transaction_start`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `transaction_start` (
   `transaction_pk` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `event_timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6),
@@ -369,15 +282,12 @@ CREATE TABLE `transaction_start` (
   CONSTRAINT `FK_connector_pk_t` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION,
   CONSTRAINT `FK_transaction_ocpp_tag_id_tag` FOREIGN KEY (`id_tag`) REFERENCES `ocpp_tag` (`id_tag`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `transaction_stop`
 --
 
 DROP TABLE IF EXISTS `transaction_stop`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `transaction_stop` (
   `transaction_pk` int(10) unsigned NOT NULL,
   `event_timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6),
@@ -388,15 +298,12 @@ CREATE TABLE `transaction_stop` (
   PRIMARY KEY (`transaction_pk`,`event_timestamp`),
   CONSTRAINT `FK_transaction_stop_transaction_pk` FOREIGN KEY (`transaction_pk`) REFERENCES `transaction_start` (`transaction_pk`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `transaction_stop_failed`
 --
 
 DROP TABLE IF EXISTS `transaction_stop_failed`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `transaction_stop_failed` (
   `transaction_pk` int(11) DEFAULT NULL,
   `charge_box_id` varchar(255) DEFAULT NULL,
@@ -407,15 +314,12 @@ CREATE TABLE `transaction_stop_failed` (
   `stop_reason` varchar(255) DEFAULT NULL,
   `fail_reason` text DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
 
 --
 -- Table structure for table `user`
 --
 
 DROP TABLE IF EXISTS `user`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `user` (
   `user_pk` int(11) NOT NULL AUTO_INCREMENT,
   `ocpp_tag_pk` int(11) DEFAULT NULL,
@@ -433,51 +337,28 @@ CREATE TABLE `user` (
   CONSTRAINT `FK_user_address_apk` FOREIGN KEY (`address_pk`) REFERENCES `address` (`address_pk`) ON DELETE SET NULL ON UPDATE NO ACTION,
   CONSTRAINT `FK_user_ocpp_tag_otpk` FOREIGN KEY (`ocpp_tag_pk`) REFERENCES `ocpp_tag` (`ocpp_tag_pk`) ON DELETE SET NULL ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Final view structure for view `ocpp_tag_activity`
---
-
-/*!50001 DROP VIEW IF EXISTS `ocpp_tag_activity`*/;
-/*!50001 SET @saved_cs_client          = @@character_set_client */;
-/*!50001 SET @saved_cs_results         = @@character_set_results */;
-/*!50001 SET @saved_col_connection     = @@collation_connection */;
-/*!50001 SET character_set_client      = utf8mb4 */;
-/*!50001 SET character_set_results     = utf8mb4 */;
-/*!50001 SET collation_connection      = utf8mb4_general_ci */;
-/*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`steve`@`localhost` SQL SECURITY DEFINER */
-/*!50001 VIEW `ocpp_tag_activity` AS select `o`.`ocpp_tag_pk` AS `ocpp_tag_pk`,`o`.`id_tag` AS `id_tag`,`o`.`parent_id_tag` AS `parent_id_tag`,`o`.`expiry_date` AS `expiry_date`,`o`.`max_active_transaction_count` AS `max_active_transaction_count`,`o`.`note` AS `note`,count(`t`.`id_tag`) AS `active_transaction_count`,case when count(`t`.`id_tag`) > 0 then 1 else 0 end AS `in_transaction`,case when `o`.`max_active_transaction_count` = 0 then 1 else 0 end AS `blocked` from (`ocpp_tag` `o` left join `transaction` `t` on(`o`.`id_tag` = `t`.`id_tag` and `t`.`stop_timestamp` is null and `t`.`stop_value` is null)) group by `o`.`ocpp_tag_pk`,`o`.`parent_id_tag`,`o`.`expiry_date`,`o`.`max_active_transaction_count`,`o`.`note` */;
-/*!50001 SET character_set_client      = @saved_cs_client */;
-/*!50001 SET character_set_results     = @saved_cs_results */;
-/*!50001 SET collation_connection      = @saved_col_connection */;
 
 --
 -- Final view structure for view `transaction`
 --
 
 /*!50001 DROP VIEW IF EXISTS `transaction`*/;
-/*!50001 SET @saved_cs_client          = @@character_set_client */;
-/*!50001 SET @saved_cs_results         = @@character_set_results */;
-/*!50001 SET @saved_col_connection     = @@collation_connection */;
-/*!50001 SET character_set_client      = utf8mb4 */;
-/*!50001 SET character_set_results     = utf8mb4 */;
-/*!50001 SET collation_connection      = utf8mb4_general_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
 /*!50013 DEFINER=`steve`@`localhost` SQL SECURITY DEFINER */
 /*!50001 VIEW `transaction` AS select `tx1`.`transaction_pk` AS `transaction_pk`,`tx1`.`connector_pk` AS `connector_pk`,`tx1`.`id_tag` AS `id_tag`,`tx1`.`event_timestamp` AS `start_event_timestamp`,`tx1`.`start_timestamp` AS `start_timestamp`,`tx1`.`start_value` AS `start_value`,`tx2`.`event_actor` AS `stop_event_actor`,`tx2`.`event_timestamp` AS `stop_event_timestamp`,`tx2`.`stop_timestamp` AS `stop_timestamp`,`tx2`.`stop_value` AS `stop_value`,`tx2`.`stop_reason` AS `stop_reason` from (`transaction_start` `tx1` left join `transaction_stop` `tx2` on(`tx1`.`transaction_pk` = `tx2`.`transaction_pk` and `tx2`.`event_timestamp` = (select max(`s2`.`event_timestamp`) from `transaction_stop` `s2` where `tx2`.`transaction_pk` = `s2`.`transaction_pk`))) */;
-/*!50001 SET character_set_client      = @saved_cs_client */;
-/*!50001 SET character_set_results     = @saved_cs_results */;
-/*!50001 SET collation_connection      = @saved_col_connection */;
-/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+
+--
+-- Final view structure for view `ocpp_tag_activity`
+--
+
+/*!50001 DROP VIEW IF EXISTS `ocpp_tag_activity`*/;
+/*!50001 CREATE ALGORITHM=UNDEFINED */
+/*!50013 DEFINER=`steve`@`localhost` SQL SECURITY DEFINER */
+/*!50001 VIEW `ocpp_tag_activity` AS select `o`.`ocpp_tag_pk` AS `ocpp_tag_pk`,`o`.`id_tag` AS `id_tag`,`o`.`parent_id_tag` AS `parent_id_tag`,`o`.`expiry_date` AS `expiry_date`,`o`.`max_active_transaction_count` AS `max_active_transaction_count`,`o`.`note` AS `note`,count(`t`.`id_tag`) AS `active_transaction_count`,case when count(`t`.`id_tag`) > 0 then 1 else 0 end AS `in_transaction`,case when `o`.`max_active_transaction_count` = 0 then 1 else 0 end AS `blocked` from (`ocpp_tag` `o` left join `transaction` `t` on(`o`.`id_tag` = `t`.`id_tag` and `t`.`stop_timestamp` is null and `t`.`stop_value` is null)) group by `o`.`ocpp_tag_pk`,`o`.`parent_id_tag`,`o`.`expiry_date`,`o`.`max_active_transaction_count`,`o`.`note` */;
+
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
-/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
-/*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
 
--- Dump completed on 2024-06-04 14:20:56

--- a/src/main/resources/db/migration/B1_0_5__stevedb.sql
+++ b/src/main/resources/db/migration/B1_0_5__stevedb.sql
@@ -1,61 +1,72 @@
--- --------------------------------------------------------
--- DB Baseline Script, exported with HeidiSQL
+/*!999999\- enable the sandbox mode */ 
+-- MariaDB dump 10.19-11.4.2-MariaDB, for Win64 (AMD64)
 --
--- Host:                         127.0.0.1
--- Server-Version:               10.6.5-MariaDB - mariadb.org binary distribution
--- Server-OS:                    Win64
--- HeidiSQL Version:             12.5.0.6677
--- --------------------------------------------------------
+-- Host: localhost    Database: SteveDB
+-- ------------------------------------------------------
+-- Server version	11.4.2-MariaDB
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET NAMES utf8 */;
-/*!50503 SET NAMES utf8mb4 */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
-/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+/*M!100616 SET @OLD_NOTE_VERBOSITY=@@NOTE_VERBOSITY, NOTE_VERBOSITY=0 */;
 
--- Exported structur of table stevedb.address
-CREATE TABLE IF NOT EXISTS `address` (
+--
+-- Table structure for table `address`
+--
+
+DROP TABLE IF EXISTS `address`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `address` (
   `address_pk` int(11) NOT NULL AUTO_INCREMENT,
-  `street` varchar(1000) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `house_number` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `zip_code` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `city` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `country` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `street` varchar(1000) DEFAULT NULL,
+  `house_number` varchar(255) DEFAULT NULL,
+  `zip_code` varchar(255) DEFAULT NULL,
+  `city` varchar(255) DEFAULT NULL,
+  `country` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`address_pk`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `charge_box`
+--
 
-
--- Exported structur of table stevedb.charge_box
-CREATE TABLE IF NOT EXISTS `charge_box` (
+DROP TABLE IF EXISTS `charge_box`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `charge_box` (
   `charge_box_pk` int(11) NOT NULL AUTO_INCREMENT,
-  `charge_box_id` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
-  `endpoint_address` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `ocpp_protocol` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `registration_status` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL DEFAULT 'Accepted',
-  `charge_point_vendor` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `charge_point_model` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `charge_point_serial_number` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `charge_box_serial_number` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `fw_version` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `fw_update_status` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `charge_box_id` varchar(255) NOT NULL,
+  `endpoint_address` varchar(255) DEFAULT NULL,
+  `ocpp_protocol` varchar(255) DEFAULT NULL,
+  `registration_status` varchar(255) NOT NULL DEFAULT 'Accepted',
+  `charge_point_vendor` varchar(255) DEFAULT NULL,
+  `charge_point_model` varchar(255) DEFAULT NULL,
+  `charge_point_serial_number` varchar(255) DEFAULT NULL,
+  `charge_box_serial_number` varchar(255) DEFAULT NULL,
+  `fw_version` varchar(255) DEFAULT NULL,
+  `fw_update_status` varchar(255) DEFAULT NULL,
   `fw_update_timestamp` timestamp(6) NULL DEFAULT NULL,
-  `iccid` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `imsi` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `meter_type` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `meter_serial_number` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `diagnostics_status` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `iccid` varchar(255) DEFAULT NULL,
+  `imsi` varchar(255) DEFAULT NULL,
+  `meter_type` varchar(255) DEFAULT NULL,
+  `meter_serial_number` varchar(255) DEFAULT NULL,
+  `diagnostics_status` varchar(255) DEFAULT NULL,
   `diagnostics_timestamp` timestamp(6) NULL DEFAULT NULL,
   `last_heartbeat_timestamp` timestamp(6) NULL DEFAULT NULL,
-  `description` mediumtext COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `note` mediumtext COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `description` mediumtext DEFAULT NULL,
+  `note` mediumtext DEFAULT NULL,
   `location_latitude` decimal(11,8) DEFAULT NULL,
   `location_longitude` decimal(11,8) DEFAULT NULL,
   `address_pk` int(11) DEFAULT NULL,
-  `admin_address` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `admin_address` varchar(255) DEFAULT NULL,
   `insert_connector_status_after_transaction_msg` tinyint(1) DEFAULT 1,
   PRIMARY KEY (`charge_box_pk`),
   UNIQUE KEY `chargeBoxId_UNIQUE` (`charge_box_id`),
@@ -63,31 +74,41 @@ CREATE TABLE IF NOT EXISTS `charge_box` (
   KEY `FK_charge_box_address_apk` (`address_pk`),
   CONSTRAINT `FK_charge_box_address_apk` FOREIGN KEY (`address_pk`) REFERENCES `address` (`address_pk`) ON DELETE SET NULL ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `charging_profile`
+--
 
-
--- Exported structur of table stevedb.charging_profile
-CREATE TABLE IF NOT EXISTS `charging_profile` (
+DROP TABLE IF EXISTS `charging_profile`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `charging_profile` (
   `charging_profile_pk` int(11) NOT NULL AUTO_INCREMENT,
   `stack_level` int(11) NOT NULL,
-  `charging_profile_purpose` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
-  `charging_profile_kind` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
-  `recurrency_kind` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `charging_profile_purpose` varchar(255) NOT NULL,
+  `charging_profile_kind` varchar(255) NOT NULL,
+  `recurrency_kind` varchar(255) DEFAULT NULL,
   `valid_from` timestamp(6) NULL DEFAULT NULL,
   `valid_to` timestamp(6) NULL DEFAULT NULL,
   `duration_in_seconds` int(11) DEFAULT NULL,
   `start_schedule` timestamp(6) NULL DEFAULT NULL,
-  `charging_rate_unit` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `charging_rate_unit` varchar(255) NOT NULL,
   `min_charging_rate` decimal(15,1) DEFAULT NULL,
-  `description` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `note` text COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `description` varchar(255) DEFAULT NULL,
+  `note` text DEFAULT NULL,
   PRIMARY KEY (`charging_profile_pk`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `charging_schedule_period`
+--
 
-
--- Exported structur of table stevedb.charging_schedule_period
-CREATE TABLE IF NOT EXISTS `charging_schedule_period` (
+DROP TABLE IF EXISTS `charging_schedule_period`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `charging_schedule_period` (
   `charging_profile_pk` int(11) NOT NULL,
   `start_period_in_seconds` int(11) NOT NULL,
   `power_limit` decimal(15,1) NOT NULL,
@@ -95,24 +116,34 @@ CREATE TABLE IF NOT EXISTS `charging_schedule_period` (
   UNIQUE KEY `UQ_charging_schedule_period` (`charging_profile_pk`,`start_period_in_seconds`),
   CONSTRAINT `FK_charging_schedule_period_charging_profile_pk` FOREIGN KEY (`charging_profile_pk`) REFERENCES `charging_profile` (`charging_profile_pk`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `connector`
+--
 
-
--- Exported structur of table stevedb.connector
-CREATE TABLE IF NOT EXISTS `connector` (
+DROP TABLE IF EXISTS `connector`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `connector` (
   `connector_pk` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `charge_box_id` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `charge_box_id` varchar(255) NOT NULL,
   `connector_id` int(11) NOT NULL,
   PRIMARY KEY (`connector_pk`),
   UNIQUE KEY `connector_pk_UNIQUE` (`connector_pk`),
   UNIQUE KEY `connector_cbid_cid_UNIQUE` (`charge_box_id`,`connector_id`),
   CONSTRAINT `FK_connector_charge_box_cbid` FOREIGN KEY (`charge_box_id`) REFERENCES `charge_box` (`charge_box_id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `connector_charging_profile`
+--
 
-
--- Exported structur of table stevedb.connector_charging_profile
-CREATE TABLE IF NOT EXISTS `connector_charging_profile` (
+DROP TABLE IF EXISTS `connector_charging_profile`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `connector_charging_profile` (
   `connector_pk` int(11) unsigned NOT NULL,
   `charging_profile_pk` int(11) NOT NULL,
   UNIQUE KEY `UQ_connector_charging_profile` (`connector_pk`,`charging_profile_pk`),
@@ -120,86 +151,112 @@ CREATE TABLE IF NOT EXISTS `connector_charging_profile` (
   CONSTRAINT `FK_connector_charging_profile_charging_profile_pk` FOREIGN KEY (`charging_profile_pk`) REFERENCES `charging_profile` (`charging_profile_pk`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   CONSTRAINT `FK_connector_charging_profile_connector_pk` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `connector_meter_value`
+--
 
-
--- Exported structur of table stevedb.connector_meter_value
-CREATE TABLE IF NOT EXISTS `connector_meter_value` (
+DROP TABLE IF EXISTS `connector_meter_value`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `connector_meter_value` (
   `connector_pk` int(11) unsigned NOT NULL,
   `transaction_pk` int(10) unsigned DEFAULT NULL,
   `value_timestamp` timestamp(6) NULL DEFAULT NULL,
-  `value` text COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `reading_context` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `format` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `measurand` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `location` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `unit` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `phase` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `value` text DEFAULT NULL,
+  `reading_context` varchar(255) DEFAULT NULL,
+  `format` varchar(255) DEFAULT NULL,
+  `measurand` varchar(255) DEFAULT NULL,
+  `location` varchar(255) DEFAULT NULL,
+  `unit` varchar(255) DEFAULT NULL,
+  `phase` varchar(255) DEFAULT NULL,
   KEY `FK_cm_pk_idx` (`connector_pk`),
   KEY `FK_tid_cm_idx` (`transaction_pk`),
   KEY `cmv_value_timestamp_idx` (`value_timestamp`),
   CONSTRAINT `FK_pk_cm` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION,
   CONSTRAINT `FK_tid_cm` FOREIGN KEY (`transaction_pk`) REFERENCES `transaction_start` (`transaction_pk`) ON DELETE SET NULL ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `connector_status`
+--
 
-
--- Exported structur of table stevedb.connector_status
-CREATE TABLE IF NOT EXISTS `connector_status` (
+DROP TABLE IF EXISTS `connector_status`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `connector_status` (
   `connector_pk` int(11) unsigned NOT NULL,
   `status_timestamp` timestamp(6) NULL DEFAULT NULL,
-  `status` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `error_code` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `error_info` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `vendor_id` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `vendor_error_code` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `status` varchar(255) DEFAULT NULL,
+  `error_code` varchar(255) DEFAULT NULL,
+  `error_info` varchar(255) DEFAULT NULL,
+  `vendor_id` varchar(255) DEFAULT NULL,
+  `vendor_error_code` varchar(255) DEFAULT NULL,
   KEY `FK_cs_pk_idx` (`connector_pk`),
   KEY `connector_status_cpk_st_idx` (`connector_pk`,`status_timestamp`),
   CONSTRAINT `FK_cs_pk` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `ocpp_tag`
+--
 
-
--- Exported structur of table stevedb.ocpp_tag
-CREATE TABLE IF NOT EXISTS `ocpp_tag` (
+DROP TABLE IF EXISTS `ocpp_tag`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `ocpp_tag` (
   `ocpp_tag_pk` int(11) NOT NULL AUTO_INCREMENT,
-  `id_tag` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
-  `parent_id_tag` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `id_tag` varchar(255) NOT NULL,
+  `parent_id_tag` varchar(255) DEFAULT NULL,
   `expiry_date` timestamp(6) NULL DEFAULT NULL,
   `max_active_transaction_count` int(11) NOT NULL DEFAULT 1,
-  `note` mediumtext COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `note` mediumtext DEFAULT NULL,
   PRIMARY KEY (`ocpp_tag_pk`),
   UNIQUE KEY `idTag_UNIQUE` (`id_tag`),
   KEY `user_expiryDate_idx` (`expiry_date`),
   KEY `FK_ocpp_tag_parent_id_tag` (`parent_id_tag`),
   CONSTRAINT `FK_ocpp_tag_parent_id_tag` FOREIGN KEY (`parent_id_tag`) REFERENCES `ocpp_tag` (`id_tag`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Temporary table structure for view `ocpp_tag_activity`
+--
 
+DROP TABLE IF EXISTS `ocpp_tag_activity`;
+/*!50001 DROP VIEW IF EXISTS `ocpp_tag_activity`*/;
+SET @saved_cs_client     = @@character_set_client;
+SET character_set_client = utf8;
+/*!50001 CREATE VIEW `ocpp_tag_activity` AS SELECT
+ 1 AS `ocpp_tag_pk`,
+  1 AS `id_tag`,
+  1 AS `parent_id_tag`,
+  1 AS `expiry_date`,
+  1 AS `max_active_transaction_count`,
+  1 AS `note`,
+  1 AS `active_transaction_count`,
+  1 AS `in_transaction`,
+  1 AS `blocked` */;
+SET character_set_client = @saved_cs_client;
 
--- Exported structur of view stevedb.ocpp_tag_activity
--- Create a temporary table, to be upfront of view-dependencies
-CREATE TABLE `ocpp_tag_activity` (
-	`ocpp_tag_pk` INT(11) NOT NULL,
-	`id_tag` VARCHAR(255) NOT NULL COLLATE 'utf8mb3_unicode_ci',
-	`parent_id_tag` VARCHAR(255) NULL COLLATE 'utf8mb3_unicode_ci',
-	`expiry_date` TIMESTAMP(6) NULL,
-	`max_active_transaction_count` INT(11) NOT NULL,
-	`note` MEDIUMTEXT NULL COLLATE 'utf8mb3_unicode_ci',
-	`active_transaction_count` BIGINT(21) NOT NULL,
-	`in_transaction` INT(1) NOT NULL,
-	`blocked` INT(1) NOT NULL
-) ENGINE=MyISAM;
+--
+-- Table structure for table `reservation`
+--
 
--- Exported structur of table stevedb.reservation
-CREATE TABLE IF NOT EXISTS `reservation` (
+DROP TABLE IF EXISTS `reservation`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `reservation` (
   `reservation_pk` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `connector_pk` int(11) unsigned NOT NULL,
   `transaction_pk` int(10) unsigned DEFAULT NULL,
-  `id_tag` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `id_tag` varchar(255) NOT NULL,
   `start_datetime` datetime DEFAULT NULL,
   `expiry_datetime` datetime DEFAULT NULL,
-  `status` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `status` varchar(255) NOT NULL,
   PRIMARY KEY (`reservation_pk`),
   UNIQUE KEY `reservation_pk_UNIQUE` (`reservation_pk`),
   UNIQUE KEY `transaction_pk_UNIQUE` (`transaction_pk`),
@@ -212,75 +269,92 @@ CREATE TABLE IF NOT EXISTS `reservation` (
   CONSTRAINT `FK_reservation_ocpp_tag_id_tag` FOREIGN KEY (`id_tag`) REFERENCES `ocpp_tag` (`id_tag`) ON DELETE CASCADE ON UPDATE NO ACTION,
   CONSTRAINT `FK_transaction_pk_r` FOREIGN KEY (`transaction_pk`) REFERENCES `transaction_start` (`transaction_pk`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `schema_version`
+--
 
-
--- Exported structur of table stevedb.schema_version
-CREATE TABLE IF NOT EXISTS `schema_version` (
+DROP TABLE IF EXISTS `schema_version`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `schema_version` (
   `installed_rank` int(11) NOT NULL,
-  `version` varchar(50) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `description` varchar(200) COLLATE utf8mb3_unicode_ci NOT NULL,
-  `type` varchar(20) COLLATE utf8mb3_unicode_ci NOT NULL,
-  `script` varchar(1000) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `version` varchar(50) DEFAULT NULL,
+  `description` varchar(200) NOT NULL,
+  `type` varchar(20) NOT NULL,
+  `script` varchar(1000) NOT NULL,
   `checksum` int(11) DEFAULT NULL,
-  `installed_by` varchar(100) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `installed_by` varchar(100) NOT NULL,
   `installed_on` timestamp NOT NULL DEFAULT current_timestamp(),
   `execution_time` int(11) NOT NULL,
   `success` tinyint(1) NOT NULL,
   PRIMARY KEY (`installed_rank`),
   KEY `schema_version_s_idx` (`success`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `settings`
+--
 
-
--- Exported structur of table stevedb.settings
-CREATE TABLE IF NOT EXISTS `settings` (
-  `app_id` varchar(40) COLLATE utf8mb3_unicode_ci NOT NULL,
+DROP TABLE IF EXISTS `settings`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `settings` (
+  `app_id` varchar(40) NOT NULL,
   `heartbeat_interval_in_seconds` int(11) DEFAULT NULL,
   `hours_to_expire` int(11) DEFAULT NULL,
   `mail_enabled` tinyint(1) DEFAULT 0,
-  `mail_host` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `mail_username` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `mail_password` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `mail_from` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `mail_protocol` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT 'smtp',
+  `mail_host` varchar(255) DEFAULT NULL,
+  `mail_username` varchar(255) DEFAULT NULL,
+  `mail_password` varchar(255) DEFAULT NULL,
+  `mail_from` varchar(255) DEFAULT NULL,
+  `mail_protocol` varchar(255) DEFAULT 'smtp',
   `mail_port` int(11) DEFAULT 25,
-  `mail_recipients` text COLLATE utf8mb3_unicode_ci DEFAULT NULL COMMENT 'comma separated list of email addresses',
-  `notification_features` text COLLATE utf8mb3_unicode_ci DEFAULT NULL COMMENT 'comma separated list',
+  `mail_recipients` text DEFAULT NULL COMMENT 'comma separated list of email addresses',
+  `notification_features` text DEFAULT NULL COMMENT 'comma separated list',
   PRIMARY KEY (`app_id`),
   UNIQUE KEY `settings_id_UNIQUE` (`app_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
--- Exported data of table stevedb.settings: ~1 rows (approx.)
-INSERT INTO `settings` (`app_id`, `heartbeat_interval_in_seconds`, `hours_to_expire`, `mail_enabled`, `mail_host`, `mail_username`, `mail_password`, `mail_from`, `mail_protocol`, `mail_port`, `mail_recipients`, `notification_features`) VALUES
-	('U3RlY2tkb3NlblZlcndhbHR1bmc=', 14400, 1, 0, NULL, NULL, NULL, NULL, 'smtp', 25, NULL, NULL);
+--
+-- Temporary table structure for view `transaction`
+--
 
--- Exported structur of view stevedb.transaction
--- Create a temporary table, to be upfront of view-dependencies
-CREATE TABLE `transaction` (
-	`transaction_pk` INT(10) UNSIGNED NOT NULL,
-	`connector_pk` INT(11) UNSIGNED NOT NULL,
-	`id_tag` VARCHAR(255) NOT NULL COLLATE 'utf8mb3_unicode_ci',
-	`start_event_timestamp` TIMESTAMP(6) NOT NULL,
-	`start_timestamp` TIMESTAMP(6) NULL,
-	`start_value` VARCHAR(255) NULL COLLATE 'utf8mb3_unicode_ci',
-	`stop_event_actor` ENUM('station','manual') NULL COLLATE 'utf8mb3_unicode_ci',
-	`stop_event_timestamp` TIMESTAMP(6) NULL,
-	`stop_timestamp` TIMESTAMP(6) NULL,
-	`stop_value` VARCHAR(255) NULL COLLATE 'utf8mb3_unicode_ci',
-	`stop_reason` VARCHAR(255) NULL COLLATE 'utf8mb3_unicode_ci'
-) ENGINE=MyISAM;
+DROP TABLE IF EXISTS `transaction`;
+/*!50001 DROP VIEW IF EXISTS `transaction`*/;
+SET @saved_cs_client     = @@character_set_client;
+SET character_set_client = utf8;
+/*!50001 CREATE VIEW `transaction` AS SELECT
+ 1 AS `transaction_pk`,
+  1 AS `connector_pk`,
+  1 AS `id_tag`,
+  1 AS `start_event_timestamp`,
+  1 AS `start_timestamp`,
+  1 AS `start_value`,
+  1 AS `stop_event_actor`,
+  1 AS `stop_event_timestamp`,
+  1 AS `stop_timestamp`,
+  1 AS `stop_value`,
+  1 AS `stop_reason` */;
+SET character_set_client = @saved_cs_client;
 
+--
+-- Table structure for table `transaction_start`
+--
 
-
--- Exported structur of table stevedb.transaction_start
-CREATE TABLE IF NOT EXISTS `transaction_start` (
+DROP TABLE IF EXISTS `transaction_start`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `transaction_start` (
   `transaction_pk` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `event_timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6),
   `connector_pk` int(11) unsigned NOT NULL,
-  `id_tag` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
+  `id_tag` varchar(255) NOT NULL,
   `start_timestamp` timestamp(6) NULL DEFAULT NULL,
-  `start_value` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `start_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`transaction_pk`),
   UNIQUE KEY `transaction_pk_UNIQUE` (`transaction_pk`),
   KEY `idTag_idx` (`id_tag`),
@@ -289,100 +363,115 @@ CREATE TABLE IF NOT EXISTS `transaction_start` (
   CONSTRAINT `FK_connector_pk_t` FOREIGN KEY (`connector_pk`) REFERENCES `connector` (`connector_pk`) ON DELETE CASCADE ON UPDATE NO ACTION,
   CONSTRAINT `FK_transaction_ocpp_tag_id_tag` FOREIGN KEY (`id_tag`) REFERENCES `ocpp_tag` (`id_tag`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `transaction_stop`
+--
 
-
--- Exported structur of table stevedb.transaction_stop
-CREATE TABLE IF NOT EXISTS `transaction_stop` (
+DROP TABLE IF EXISTS `transaction_stop`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `transaction_stop` (
   `transaction_pk` int(10) unsigned NOT NULL,
   `event_timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6),
-  `event_actor` enum('station','manual') COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `event_actor` enum('station','manual') DEFAULT NULL,
   `stop_timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6),
-  `stop_value` varchar(255) COLLATE utf8mb3_unicode_ci NOT NULL,
-  `stop_reason` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `stop_value` varchar(255) NOT NULL,
+  `stop_reason` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`transaction_pk`,`event_timestamp`),
   CONSTRAINT `FK_transaction_stop_transaction_pk` FOREIGN KEY (`transaction_pk`) REFERENCES `transaction_start` (`transaction_pk`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `transaction_stop_failed`
+--
 
-
--- Exported structur of table stevedb.transaction_stop_failed
-CREATE TABLE IF NOT EXISTS `transaction_stop_failed` (
+DROP TABLE IF EXISTS `transaction_stop_failed`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `transaction_stop_failed` (
   `transaction_pk` int(11) DEFAULT NULL,
-  `charge_box_id` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `charge_box_id` varchar(255) DEFAULT NULL,
   `event_timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6),
-  `event_actor` enum('station','manual') COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `event_actor` enum('station','manual') DEFAULT NULL,
   `stop_timestamp` timestamp(6) NOT NULL DEFAULT current_timestamp(6),
-  `stop_value` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `stop_reason` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `fail_reason` text COLLATE utf8mb3_unicode_ci DEFAULT NULL
+  `stop_value` varchar(255) DEFAULT NULL,
+  `stop_reason` varchar(255) DEFAULT NULL,
+  `fail_reason` text DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Table structure for table `user`
+--
 
-
--- Exported structur of table stevedb.user
-CREATE TABLE IF NOT EXISTS `user` (
+DROP TABLE IF EXISTS `user`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `user` (
   `user_pk` int(11) NOT NULL AUTO_INCREMENT,
   `ocpp_tag_pk` int(11) DEFAULT NULL,
   `address_pk` int(11) DEFAULT NULL,
-  `first_name` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `last_name` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `first_name` varchar(255) DEFAULT NULL,
+  `last_name` varchar(255) DEFAULT NULL,
   `birth_day` date DEFAULT NULL,
-  `sex` char(1) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `phone` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `e_mail` varchar(255) COLLATE utf8mb3_unicode_ci DEFAULT NULL,
-  `note` text COLLATE utf8mb3_unicode_ci DEFAULT NULL,
+  `sex` char(1) DEFAULT NULL,
+  `phone` varchar(255) DEFAULT NULL,
+  `e_mail` varchar(255) DEFAULT NULL,
+  `note` text DEFAULT NULL,
   PRIMARY KEY (`user_pk`),
   KEY `FK_user_ocpp_tag_otpk` (`ocpp_tag_pk`),
   KEY `FK_user_address_apk` (`address_pk`),
   CONSTRAINT `FK_user_address_apk` FOREIGN KEY (`address_pk`) REFERENCES `address` (`address_pk`) ON DELETE SET NULL ON UPDATE NO ACTION,
   CONSTRAINT `FK_user_ocpp_tag_otpk` FOREIGN KEY (`ocpp_tag_pk`) REFERENCES `ocpp_tag` (`ocpp_tag_pk`) ON DELETE SET NULL ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 
+--
+-- Final view structure for view `ocpp_tag_activity`
+--
 
+/*!50001 DROP VIEW IF EXISTS `ocpp_tag_activity`*/;
+/*!50001 SET @saved_cs_client          = @@character_set_client */;
+/*!50001 SET @saved_cs_results         = @@character_set_results */;
+/*!50001 SET @saved_col_connection     = @@collation_connection */;
+/*!50001 SET character_set_client      = utf8mb4 */;
+/*!50001 SET character_set_results     = utf8mb4 */;
+/*!50001 SET collation_connection      = utf8mb4_general_ci */;
+/*!50001 CREATE ALGORITHM=UNDEFINED */
+/*!50013 DEFINER=`steve`@`localhost` SQL SECURITY DEFINER */
+/*!50001 VIEW `ocpp_tag_activity` AS select `o`.`ocpp_tag_pk` AS `ocpp_tag_pk`,`o`.`id_tag` AS `id_tag`,`o`.`parent_id_tag` AS `parent_id_tag`,`o`.`expiry_date` AS `expiry_date`,`o`.`max_active_transaction_count` AS `max_active_transaction_count`,`o`.`note` AS `note`,count(`t`.`id_tag`) AS `active_transaction_count`,case when count(`t`.`id_tag`) > 0 then 1 else 0 end AS `in_transaction`,case when `o`.`max_active_transaction_count` = 0 then 1 else 0 end AS `blocked` from (`ocpp_tag` `o` left join `transaction` `t` on(`o`.`id_tag` = `t`.`id_tag` and `t`.`stop_timestamp` is null and `t`.`stop_value` is null)) group by `o`.`ocpp_tag_pk`,`o`.`parent_id_tag`,`o`.`expiry_date`,`o`.`max_active_transaction_count`,`o`.`note` */;
+/*!50001 SET character_set_client      = @saved_cs_client */;
+/*!50001 SET character_set_results     = @saved_cs_results */;
+/*!50001 SET collation_connection      = @saved_col_connection */;
 
--- Exported structur of view stevedb.ocpp_tag_activity
--- Remove the temporary table and create the view
-DROP TABLE IF EXISTS `ocpp_tag_activity`;
-CREATE ALGORITHM=UNDEFINED DEFINER=`steve`@`localhost` SQL SECURITY DEFINER VIEW `ocpp_tag_activity` AS select `o`.*,
-       count(`t`.`id_tag`)                                                AS `active_transaction_count`,
-       case when count(`t`.`id_tag`) > 0 then 1 else 0 end                AS `in_transaction`,
-       case when `o`.`max_active_transaction_count` = 0 then 1 else 0 end AS `blocked`
-from `ocpp_tag` `o` left join `transaction` `t` on (
-    `o`.`id_tag` = `t`.`id_tag` and
-    `t`.`stop_timestamp` is null and
-    `t`.`stop_value` is null)
-group by
-    `o`.`ocpp_tag_pk`,
-    `o`.`parent_id_tag`,
-    `o`.`expiry_date`,
-    `o`.`max_active_transaction_count`,
-    `o`.`note` ;
+--
+-- Final view structure for view `transaction`
+--
 
+/*!50001 DROP VIEW IF EXISTS `transaction`*/;
+/*!50001 SET @saved_cs_client          = @@character_set_client */;
+/*!50001 SET @saved_cs_results         = @@character_set_results */;
+/*!50001 SET @saved_col_connection     = @@collation_connection */;
+/*!50001 SET character_set_client      = utf8mb4 */;
+/*!50001 SET character_set_results     = utf8mb4 */;
+/*!50001 SET collation_connection      = utf8mb4_general_ci */;
+/*!50001 CREATE ALGORITHM=UNDEFINED */
+/*!50013 DEFINER=`steve`@`localhost` SQL SECURITY DEFINER */
+/*!50001 VIEW `transaction` AS select `tx1`.`transaction_pk` AS `transaction_pk`,`tx1`.`connector_pk` AS `connector_pk`,`tx1`.`id_tag` AS `id_tag`,`tx1`.`event_timestamp` AS `start_event_timestamp`,`tx1`.`start_timestamp` AS `start_timestamp`,`tx1`.`start_value` AS `start_value`,`tx2`.`event_actor` AS `stop_event_actor`,`tx2`.`event_timestamp` AS `stop_event_timestamp`,`tx2`.`stop_timestamp` AS `stop_timestamp`,`tx2`.`stop_value` AS `stop_value`,`tx2`.`stop_reason` AS `stop_reason` from (`transaction_start` `tx1` left join `transaction_stop` `tx2` on(`tx1`.`transaction_pk` = `tx2`.`transaction_pk` and `tx2`.`event_timestamp` = (select max(`s2`.`event_timestamp`) from `transaction_stop` `s2` where `tx2`.`transaction_pk` = `s2`.`transaction_pk`))) */;
+/*!50001 SET character_set_client      = @saved_cs_client */;
+/*!50001 SET character_set_results     = @saved_cs_results */;
+/*!50001 SET collation_connection      = @saved_col_connection */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
-
--- Exported structur of view stevedb.transaction
--- Remove the tmeporary table and create the view
-DROP TABLE IF EXISTS `transaction`;
-CREATE ALGORITHM=UNDEFINED DEFINER=`steve`@`localhost` SQL SECURITY DEFINER VIEW `transaction` AS SELECT
-    tx1.transaction_pk,
-    tx1.connector_pk,
-    tx1.id_tag,
-    tx1.event_timestamp as 'start_event_timestamp',
-    tx1.start_timestamp,
-    tx1.start_value,
-    tx2.event_actor as 'stop_event_actor',
-    tx2.event_timestamp as 'stop_event_timestamp',
-    tx2.stop_timestamp,
-    tx2.stop_value,
-    tx2.stop_reason
-FROM transaction_start tx1
-LEFT JOIN transaction_stop tx2
-    ON tx1.transaction_pk = tx2.transaction_pk
-    AND tx2.event_timestamp = (SELECT MAX(event_timestamp) FROM transaction_stop s2 WHERE tx2.transaction_pk = s2.transaction_pk) ;
-
-/*!40103 SET TIME_ZONE=IFNULL(@OLD_TIME_ZONE, 'system') */;
-/*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;
-/*!40014 SET FOREIGN_KEY_CHECKS=IFNULL(@OLD_FOREIGN_KEY_CHECKS, 1) */;
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40111 SET SQL_NOTES=IFNULL(@OLD_SQL_NOTES, 1) */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
+
+-- Dump completed on 2024-06-04 14:20:56


### PR DESCRIPTION
Some combination of DB versions and OS versions seems to have problems with the DB migration scripts. 
@juherr suggested (https://github.com/steve-community/steve/pull/1394#issuecomment-2031314233) a baseline script to solve the issues (e.g. #1417). 
The PR #1394 and #1428   addresses the same issues, but changes the existing migration scripts, which could causes trouble at updating existing Steve servers. 

The baseline also improved slightly the build process, because less DB build/migration operation are executed.

The script is exported (by mariadb-dump) from a fresh build Steve instance. The baseline creates all tables and views and inserts the data of the setting table.