### PR TITLE
insert connector conditionally for SetChargingProfile tasks (#1473)

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ChargingProfileRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ChargingProfileRepositoryImpl.java
@@ -68,6 +68,8 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
 
     @Override
     public void setProfile(int chargingProfilePk, String chargeBoxId, int connectorId) {
+        OcppServerRepositoryImpl.insertIgnoreConnector(ctx, chargeBoxId, connectorId);
+
         SelectConditionStep<Record1<Integer>> connectorPkSelect = ctx.select(CONNECTOR.CONNECTOR_PK)
                                                                      .from(CONNECTOR)
                                                                      .where(CONNECTOR.CHARGE_BOX_ID.eq(chargeBoxId))

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImpl.java
@@ -379,7 +379,7 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
     /**
      * If the connector information was not received before, insert it. Otherwise, ignore.
      */
-    private void insertIgnoreConnector(DSLContext ctx, String chargeBoxIdentity, int connectorId) {
+    public static void insertIgnoreConnector(DSLContext ctx, String chargeBoxIdentity, int connectorId) {
         int count = ctx.insertInto(CONNECTOR,
                             CONNECTOR.CHARGE_BOX_ID, CONNECTOR.CONNECTOR_ID)
                        .values(chargeBoxIdentity, connectorId)


### PR DESCRIPTION
if the connector (for which a SetChargingProfile was sent) was not observed this far (i.e. the station did not report it), insert it before saving profile info.