### PR TITLE
Update docker-compose.yml to add restart policies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     # TODO: Get database migrations to work with the latest point releases of
     # MariaDB 10.4.
     image: mariadb:10.4.30
+    restart: unless-stopped
     ports:
       - 3306:3306
     environment:
@@ -20,8 +21,8 @@ services:
       MYSQL_DATABASE: stevedb
       MYSQL_USER: steve
       MYSQL_PASSWORD: changeme
-
   app:
+    restart: unless-stopped
     build: .
     links:
       - "db:mariadb"
@@ -32,3 +33,4 @@ services:
       - "8443:8443"
     depends_on:
       - db
+    


### PR DESCRIPTION
Added 'unless-stopped' restart policies to both the 'db' and 'app' services in docker-compose.yml to ensure they automatically restart unless explicitly stopped by the user.