### PR TITLE
fix ObjectMapper used for API endpoint errors

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/config/BeanConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/BeanConfiguration.java
@@ -21,7 +21,6 @@ package de.rwth.idsg.steve.config;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.mysql.cj.conf.PropertyKey;
 import com.zaxxer.hikari.HikariConfig;
@@ -39,7 +38,6 @@ import org.jooq.conf.Settings;
 import org.jooq.impl.DSL;
 import org.jooq.impl.DataSourceConnectionProvider;
 import org.jooq.impl.DefaultConfiguration;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -267,8 +265,7 @@ public class BeanConfiguration implements WebMvcConfigurer {
      * {@link WebMvcConfigurationSupport#requestMappingHandlerAdapter(ContentNegotiationManager, FormattingConversionService, org.springframework.validation.Validator)}.
      */
     @Bean
-    @Qualifier("steveObjectMapper")
-    public ObjectMapper objectMapper(RequestMappingHandlerAdapter requestMappingHandlerAdapter) {
+    public ObjectMapper jacksonObjectMapper(RequestMappingHandlerAdapter requestMappingHandlerAdapter) {
         return requestMappingHandlerAdapter.getMessageConverters().stream()
             .filter(converter -> converter instanceof MappingJackson2HttpMessageConverter)
             .findAny()

--- a/src/main/java/de/rwth/idsg/steve/config/BeanConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/BeanConfiguration.java
@@ -39,6 +39,7 @@ import org.jooq.conf.Settings;
 import org.jooq.impl.DSL;
 import org.jooq.impl.DataSourceConnectionProvider;
 import org.jooq.impl.DefaultConfiguration;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -266,6 +267,7 @@ public class BeanConfiguration implements WebMvcConfigurer {
      * {@link WebMvcConfigurationSupport#requestMappingHandlerAdapter(ContentNegotiationManager, FormattingConversionService, org.springframework.validation.Validator)}.
      */
     @Bean
+    @Qualifier("steveObjectMapper")
     public ObjectMapper objectMapper(RequestMappingHandlerAdapter requestMappingHandlerAdapter) {
         return requestMappingHandlerAdapter.getMessageConverters().stream()
             .filter(converter -> converter instanceof MappingJackson2HttpMessageConverter)

--- a/src/main/java/de/rwth/idsg/steve/config/SecurityConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/SecurityConfiguration.java
@@ -23,6 +23,7 @@ import com.google.common.base.Strings;
 import de.rwth.idsg.steve.SteveProdCondition;
 import de.rwth.idsg.steve.web.api.ApiControllerAdvice;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -116,7 +117,7 @@ public class SecurityConfiguration {
 
     @Bean
     @Order(1)
-    public SecurityFilterChain apiKeyFilterChain(HttpSecurity http, ObjectMapper objectMapper) throws Exception {
+    public SecurityFilterChain apiKeyFilterChain(HttpSecurity http, @Qualifier("steveObjectMapper") ObjectMapper objectMapper) throws Exception {
         return http.securityMatcher(CONFIG.getApiMapping() + "/**")
             .csrf(k -> k.disable())
             .sessionManagement(k -> k.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/de/rwth/idsg/steve/config/SecurityConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/SecurityConfiguration.java
@@ -117,13 +117,13 @@ public class SecurityConfiguration {
 
     @Bean
     @Order(1)
-    public SecurityFilterChain apiKeyFilterChain(HttpSecurity http, @Qualifier("steveObjectMapper") ObjectMapper objectMapper) throws Exception {
+    public SecurityFilterChain apiKeyFilterChain(HttpSecurity http, ObjectMapper jacksonObjectMapper) throws Exception {
         return http.securityMatcher(CONFIG.getApiMapping() + "/**")
             .csrf(k -> k.disable())
             .sessionManagement(k -> k.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .addFilter(new ApiKeyFilter())
             .authorizeHttpRequests(k -> k.anyRequest().authenticated())
-            .exceptionHandling(k -> k.authenticationEntryPoint(new ApiKeyAuthenticationEntryPoint(objectMapper)))
+            .exceptionHandling(k -> k.authenticationEntryPoint(new ApiKeyAuthenticationEntryPoint(jacksonObjectMapper)))
             .build();
     }
 


### PR DESCRIPTION
reason: warnings like the following

> [WARN ] 2024-08-08 23:34:20,844 org.eclipse.jetty.ee10.servlet.ServletChannel (qtp739264372-28) - handleException /steve/api/v1/transactions com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Joda date/time type `org.joda.time.DateTime` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-joda" to enable handling (through reference chain: de.rwth.idsg.steve.web.api.ApiControllerAdvice$ApiErrorResponse["timestamp"])

ApiDocsConfiguration activates JacksonAutoConfiguration which creates a default/primary ObjectMapper
that is different from our ObjectMapper. this came with the spring 6.x migration since OpenApi integration
was massively refactored with that as well.