### PR TITLE
set ram percentage in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ COPY . /code
 # Build and run steve, requires a db to be available on port 3306
 CMD dockerize -wait tcp://mariadb:3306 -timeout 60s && \
 	./mvnw clean package -Pdocker -Djdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2" && \
-	java -jar target/steve.jar
+	java -XX:MaxRAMPercentage=85 -jar target/steve.jar
 


### PR DESCRIPTION
default is 25% which is too conservative.

details: https://developers.redhat.com/articles/2022/04/19/java-17-whats-new-openjdks-container-awareness#tuning_defaults_for_containers