### PR TITLE
migrate "header value" as "api password" to database (#1540)

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/service/WebUserService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/WebUserService.java
@@ -26,12 +26,14 @@ import de.rwth.idsg.steve.SteveConfiguration;
 import de.rwth.idsg.steve.repository.WebUserRepository;
 import jooq.steve.db.tables.records.WebUserRecord;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.jooq.JSON;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.userdetails.User;
@@ -80,14 +82,20 @@ public class WebUserService implements UserDetailsManager {
             return;
         }
 
-        var user = User
-            .withUsername(SteveConfiguration.CONFIG.getAuth().getUserName())
-            .password(SteveConfiguration.CONFIG.getAuth().getEncodedPassword())
-            .disabled(false)
-            .authorities("ADMIN")
-            .build();
+        var headerVal = SteveConfiguration.CONFIG.getWebApi().getHeaderValue();
 
-        this.createUser(user);
+        var encodedApiPassword = StringUtils.isEmpty(headerVal)
+            ? null
+            : SteveConfiguration.CONFIG.getAuth().getPasswordEncoder().encode(headerVal);
+
+        var user = new WebUserRecord()
+            .setUsername(SteveConfiguration.CONFIG.getAuth().getUserName())
+            .setPassword(SteveConfiguration.CONFIG.getAuth().getEncodedPassword())
+            .setApiPassword(encodedApiPassword)
+            .setEnabled(true)
+            .setAuthorities(toJson(AuthorityUtils.createAuthorityList("ADMIN")));
+
+        webUserRepository.createUser(user);
     }
 
     @Override


### PR DESCRIPTION
FYI @MaticBobnar @fluppie @juherr 

i addressed the initial starting point only (i.e. there is no user in db at all), upon which this creates the admin user with password and api_password. i did not target your "partial" state (admin user was created, but api_password was not set). 

you can tell me if you are okay with this solution.

context: https://github.com/steve-community/steve/discussions/1582