### PR TITLE
Fix Dockerfile mvnw Not Found Error and Optimize Image Size with Multi-Stage Build

### DIFF
--- a/k8s/docker/Dockerfile
+++ b/k8s/docker/Dockerfile
@@ -1,27 +1,48 @@
-FROM eclipse-temurin:17-jdk
+# Build Stage
+FROM eclipse-temurin:17-jdk AS build
 MAINTAINER daynnnnn
 
+# Setting environment variables
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
+# Arguments for database configuration
 ARG DB_HOST
 ARG DB_USERNAME
 ARG DB_PASSWORD
 ARG DB_DATABASE
 ARG DB_PORT
 
+# Set the working directory for the build stage
 WORKDIR /code
 
+# Copy project files to the build stage
 ADD /src /code/src
 ADD /website /code/website
 ADD /pom.xml /code/pom.xml
+ADD mvnw /code/mvnw
+ADD .mvn /code/.mvn
 
+# Replace placeholders in pom.xml with actual environment values
 RUN sed -i 's|${db.ip}|${env.DB_HOST}|g' pom.xml
 RUN sed -i 's|${db.port}|${env.DB_PORT}|g' pom.xml
 RUN sed -i 's|${db.user}|${env.DB_USERNAME}|g' pom.xml
 RUN sed -i 's|${db.password}|${env.DB_PASSWORD}|g' pom.xml
 RUN sed -i 's|${db.schema}|${env.DB_DATABASE}|g' pom.xml
 
+# Make the Maven wrapper executable
+RUN chmod +x mvnw
+
+# Build the project
 RUN ./mvnw clean package -Pkubernetes -Djdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2"
 
-CMD java -jar target/steve.jar
+# Release Stage
+FROM eclipse-temurin:17-jdk AS release
 
+# Copy only the generated jar file from the build stage
+COPY --from=build /code/target/steve.jar /app/steve.jar
+
+# Expose any necessary ports (example: 8080)
+EXPOSE 8080
+
+# Define the entrypoint for the release stage
+CMD ["java", "-jar", "/app/steve.jar"]


### PR DESCRIPTION
This PR introduces two main improvements to the Dockerfile:

1. Fix for mvnw Not Found Error:
  Added the following lines to the Dockerfile to include the Maven wrapper (mvnw) and .mvn directory, ensuring that the build process runs smoothly:
```
  ADD mvnw /code/mvnw
  ADD .mvn /code/.mvn
```
This resolves potential build errors caused by missing Maven wrapper files.

2. Optimized Dockerfile with Multi-Stage Build:
Converted the Dockerfile to a two-stage build process (build and release stages), which reduces the final image size by separating the build dependencies from the runtime environment. Only the required application jar file is copied into the release stage, making the final image more efficient and secure.