### PR TITLE
Fix Dockerfile for k8s mvnw Not Found Error , Optimize Image Size with Multi-Stage Build and SERVER_HOST

### DIFF
--- a/k8s/docker/Dockerfile
+++ b/k8s/docker/Dockerfile
@@ -1,27 +1,49 @@
-FROM eclipse-temurin:17-jdk
+# Build Stage
+FROM eclipse-temurin:17-jdk AS build
 MAINTAINER daynnnnn
 
+# Setting environment variables
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
+# Arguments for database configuration
 ARG DB_HOST
 ARG DB_USERNAME
 ARG DB_PASSWORD
 ARG DB_DATABASE
 ARG DB_PORT
 
+# Set the working directory for the build stage
 WORKDIR /code
 
+# Copy project files to the build stage
 ADD /src /code/src
 ADD /website /code/website
 ADD /pom.xml /code/pom.xml
+ADD mvnw /code/mvnw
+ADD .mvn /code/.mvn
 
+# Replace placeholders in pom.xml with actual environment values
 RUN sed -i 's|${db.ip}|${env.DB_HOST}|g' pom.xml
 RUN sed -i 's|${db.port}|${env.DB_PORT}|g' pom.xml
 RUN sed -i 's|${db.user}|${env.DB_USERNAME}|g' pom.xml
 RUN sed -i 's|${db.password}|${env.DB_PASSWORD}|g' pom.xml
 RUN sed -i 's|${db.schema}|${env.DB_DATABASE}|g' pom.xml
+RUN sed -i 's|${server.host}|${env.SERVER_HOST}|g' pom.xml
 
+# Make the Maven wrapper executable
+RUN chmod +x mvnw
+
+# Build the project
 RUN ./mvnw clean package -Pkubernetes -Djdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2"
 
-CMD java -jar target/steve.jar
+# Release Stage
+FROM eclipse-temurin:17-jdk AS release
 
+# Copy only the generated jar file from the build stage
+COPY --from=build /code/target /app
+
+# Expose any necessary ports (example: 8080)
+EXPOSE 8080
+
+# Define the entrypoint for the release stage
+CMD ["java", "-jar", "/app/steve.jar"]

--- a/k8s/docker/Dockerfile
+++ b/k8s/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM eclipse-temurin:17-jdk AS build
+FROM eclipse-temurin:21-jdk AS build
 MAINTAINER daynnnnn
 
 # Setting environment variables
@@ -37,7 +37,7 @@ RUN chmod +x mvnw
 RUN ./mvnw clean package -Pkubernetes -Djdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2"
 
 # Release Stage
-FROM eclipse-temurin:17-jdk AS release
+FROM eclipse-temurin:21-jdk AS release
 
 # Copy only the generated jar file from the build stage
 COPY --from=build /code/target /app

--- a/k8s/docker/Dockerfile
+++ b/k8s/docker/Dockerfile
@@ -39,8 +39,9 @@ RUN ./mvnw clean package -Pkubernetes -Djdk.tls.client.protocols="TLSv1,TLSv1.1,
 # Release Stage
 FROM eclipse-temurin:21-jdk AS release
 
-# Copy only the generated jar file from the build stage
-COPY --from=build /code/target /app
+# Copy relevant files from the build stage
+COPY --from=build /code/target/steve.jar /app/steve.jar
+COPY --from=build /code/target/libs /app/libs
 
 # Expose any necessary ports (example: 8080)
 EXPOSE 8080

--- a/k8s/docker/Dockerfile
+++ b/k8s/docker/Dockerfile
@@ -1,5 +1,4 @@
-# Build Stage
-FROM eclipse-temurin:21-jdk AS build
+FROM eclipse-temurin:21-jdk AS base
 MAINTAINER daynnnnn
 
 # Setting environment variables
@@ -11,6 +10,9 @@ ARG DB_USERNAME
 ARG DB_PASSWORD
 ARG DB_DATABASE
 ARG DB_PORT
+
+# Build Stage
+FROM base as build
 
 # Set the working directory for the build stage
 WORKDIR /code
@@ -37,7 +39,7 @@ RUN chmod +x mvnw
 RUN ./mvnw clean package -Pkubernetes -Djdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2"
 
 # Release Stage
-FROM eclipse-temurin:21-jdk AS release
+FROM base AS release
 
 # Copy relevant files from the build stage
 COPY --from=build /code/target/steve.jar /app/steve.jar

--- a/k8s/yaml/Deployment.yaml
+++ b/k8s/yaml/Deployment.yaml
@@ -28,6 +28,8 @@ spec:
           value: ""
         - name: DB_DATABASE
           value: ""
+        - name: SERVER_HOST
+          value: "0.0.0.0"
         - name: ADMIN_USERNAME
           value: ""
         - name: ADMIN_PASSWORD


### PR DESCRIPTION
This PR introduces three main improvements to the Dockerfile:

1. Fix Dockerfile Errors:
- Added the following lines to ensure that the Maven Wrapper (mvnw) and the Maven directory (.mvn) are included in the image during the build process.

2. Optimized Dockerfile with Multi-Stage Build:
- Refactored the Dockerfile to utilize a multi-stage build process. This separates the build and release stages, which helps to reduce the final image size by including only the necessary files in the runtime image.

3. Introduce SERVER_HOST Environment Variable:
- Added a new environment variable SERVER_HOST to allow configuration of the server's bind address. This will enhance flexibility in deployment scenarios.
