### PR TITLE
add annotationProcessorPaths (closes #1644)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,13 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
builds were working without this until jdk 23 (for whatever reason). it is part of lombok documentation to use this anyways: https://projectlombok.org/setup/maven so we are adding it.