### PR TITLE
Improve query functionality

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/repository/OcppTagRepository.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/OcppTagRepository.java
@@ -31,7 +31,7 @@ import java.util.List;
  * @since 19.08.2014
  */
 public interface OcppTagRepository {
-    List<OcppTag.Overview> getOverview(OcppTagQueryForm form);
+    List<OcppTag.OcppTagOverview> getOverview(OcppTagQueryForm form);
 
     Result<OcppTagActivityRecord> getRecords();
     Result<OcppTagActivityRecord> getRecords(List<String> idTagList);

--- a/src/main/java/de/rwth/idsg/steve/repository/dto/OcppTag.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/dto/OcppTag.java
@@ -35,7 +35,7 @@ public final class OcppTag {
     @Getter
     @Builder
     @ToString
-    public static final class Overview {
+    public static final class OcppTagOverview {
         @Schema(description = "PK of the OCPP tag")
         private final Integer ocppTagPk;
 

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
@@ -158,6 +158,10 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
             selectQuery.addConditions(includes(CHARGE_BOX.CHARGE_BOX_ID, form.getChargeBoxId()));
         }
 
+        if (form.isSetNote()) {
+            selectQuery.addConditions(includes(CHARGE_BOX.NOTE, form.getNote()));
+        }
+
         switch (form.getHeartbeatPeriod()) {
             case ALL:
                 break;

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImpl.java
@@ -20,7 +20,7 @@ package de.rwth.idsg.steve.repository.impl;
 
 import de.rwth.idsg.steve.SteveException;
 import de.rwth.idsg.steve.repository.OcppTagRepository;
-import de.rwth.idsg.steve.repository.dto.OcppTag.Overview;
+import de.rwth.idsg.steve.repository.dto.OcppTag.OcppTagOverview;
 import de.rwth.idsg.steve.web.dto.OcppTagForm;
 import de.rwth.idsg.steve.web.dto.OcppTagQueryForm;
 import jooq.steve.db.tables.OcppTagActivity;
@@ -66,7 +66,7 @@ public class OcppTagRepositoryImpl implements OcppTagRepository {
 
     @Override
     @SuppressWarnings("unchecked")
-    public List<Overview> getOverview(OcppTagQueryForm form) {
+    public List<OcppTagOverview> getOverview(OcppTagQueryForm form) {
         SelectQuery selectQuery = ctx.selectQuery();
         selectQuery.addFrom(OCPP_TAG_ACTIVITY);
 
@@ -258,10 +258,10 @@ public class OcppTagRepositoryImpl implements OcppTagRepository {
     }
 
     private static class UserMapper
-            implements RecordMapper<Record10<Integer, Integer, String, String, DateTime, Boolean, Boolean, Integer, Long, String>, Overview> {
+            implements RecordMapper<Record10<Integer, Integer, String, String, DateTime, Boolean, Boolean, Integer, Long, String>, OcppTagOverview> {
         @Override
-        public Overview map(Record10<Integer, Integer, String, String, DateTime, Boolean, Boolean, Integer, Long, String> r) {
-            return Overview.builder()
+        public OcppTagOverview map(Record10<Integer, Integer, String, String, DateTime, Boolean, Boolean, Integer, Long, String> r) {
+            return OcppTagOverview.builder()
                           .ocppTagPk(r.value1())
                           .parentOcppTagPk(r.value2())
                           .idTag(r.value3())

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImpl.java
@@ -43,6 +43,7 @@ import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static de.rwth.idsg.steve.utils.CustomDSL.includes;
 import static de.rwth.idsg.steve.utils.DateTimeUtils.humanize;
 import static de.rwth.idsg.steve.utils.DateTimeUtils.toDateTime;
 import static jooq.steve.db.tables.OcppTag.OCPP_TAG;
@@ -96,6 +97,10 @@ public class OcppTagRepositoryImpl implements OcppTagRepository {
 
         if (form.isParentIdTagSet()) {
             selectQuery.addConditions(OCPP_TAG_ACTIVITY.PARENT_ID_TAG.eq(form.getParentIdTag()));
+        }
+
+        if (form.isNoteSet()) {
+            selectQuery.addConditions(includes(OCPP_TAG_ACTIVITY.NOTE, form.getNote()));
         }
 
         switch (form.getExpired()) {

--- a/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
@@ -22,7 +22,6 @@ import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.isBlocked;
 import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.isExpired;
 
 import com.google.common.base.Strings;
-import de.rwth.idsg.steve.SteveException;
 import de.rwth.idsg.steve.repository.OcppTagRepository;
 import de.rwth.idsg.steve.repository.dto.OcppTag;
 import de.rwth.idsg.steve.service.dto.UnidentifiedIncomingObject;
@@ -56,7 +55,7 @@ public class OcppTagService {
     private final OcppTagRepository ocppTagRepository;
     private final AuthTagService authTagService;
 
-    public List<OcppTag.Overview> getOverview(OcppTagQueryForm form) {
+    public List<OcppTag.OcppTagOverview> getOverview(OcppTagQueryForm form) {
         return ocppTagRepository.getOverview(form);
     }
 

--- a/src/main/java/de/rwth/idsg/steve/web/api/OcppTagsRestController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/api/OcppTagsRestController.java
@@ -19,11 +19,11 @@
 package de.rwth.idsg.steve.web.api;
 
 import de.rwth.idsg.steve.SteveException;
-import de.rwth.idsg.steve.repository.dto.OcppTag;
+import de.rwth.idsg.steve.repository.dto.OcppTag.OcppTagOverview;
 import de.rwth.idsg.steve.service.OcppTagService;
 import de.rwth.idsg.steve.web.api.ApiControllerAdvice.ApiErrorResponse;
 import de.rwth.idsg.steve.web.dto.OcppTagForm;
-import de.rwth.idsg.steve.web.dto.OcppTagQueryForm;
+import de.rwth.idsg.steve.web.dto.OcppTagQueryForm.OcppTagQueryFormForApi;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -80,7 +80,7 @@ public class OcppTagsRestController {
     )
     @GetMapping(value = "")
     @ResponseBody
-    public List<OcppTag.Overview> get(OcppTagQueryForm.ForApi params) {
+    public List<OcppTagOverview> get(OcppTagQueryFormForApi params) {
         log.debug("Read request for query: {}", params);
 
         var response = ocppTagService.getOverview(params);
@@ -100,7 +100,7 @@ public class OcppTagsRestController {
     )
     @GetMapping("/{ocppTagPk}")
     @ResponseBody
-    public OcppTag.Overview getOne(@PathVariable("ocppTagPk") Integer ocppTagPk) {
+    public OcppTagOverview getOne(@PathVariable("ocppTagPk") Integer ocppTagPk) {
         log.debug("Read request for ocppTagPk: {}", ocppTagPk);
 
         var response = getOneInternal(ocppTagPk);
@@ -123,7 +123,7 @@ public class OcppTagsRestController {
     @PostMapping
     @ResponseBody
     @ResponseStatus(HttpStatus.CREATED)
-    public OcppTag.Overview create(@RequestBody @Valid OcppTagForm params) {
+    public OcppTagOverview create(@RequestBody @Valid OcppTagForm params) {
         log.debug("Create request: {}", params);
 
         int ocppTagPk = ocppTagService.addOcppTag(params);
@@ -145,7 +145,7 @@ public class OcppTagsRestController {
     )
     @PutMapping("/{ocppTagPk}")
     @ResponseBody
-    public OcppTag.Overview update(@PathVariable("ocppTagPk") Integer ocppTagPk, @RequestBody @Valid OcppTagForm params) {
+    public OcppTagOverview update(@PathVariable("ocppTagPk") Integer ocppTagPk, @RequestBody @Valid OcppTagForm params) {
         params.setOcppTagPk(ocppTagPk); // the one from incoming params does not matter
         log.debug("Update request: {}", params);
 
@@ -169,7 +169,7 @@ public class OcppTagsRestController {
     )
     @DeleteMapping("/{ocppTagPk}")
     @ResponseBody
-    public OcppTag.Overview delete(@PathVariable("ocppTagPk") Integer ocppTagPk) {
+    public OcppTagOverview delete(@PathVariable("ocppTagPk") Integer ocppTagPk) {
         log.debug("Delete request for ocppTagPk: {}", ocppTagPk);
 
         var response = getOneInternal(ocppTagPk);
@@ -179,11 +179,11 @@ public class OcppTagsRestController {
         return response;
     }
 
-    private OcppTag.Overview getOneInternal(int ocppTagPk) {
-        OcppTagQueryForm.ForApi params = new OcppTagQueryForm.ForApi();
+    private OcppTagOverview getOneInternal(int ocppTagPk) {
+        OcppTagQueryFormForApi params = new OcppTagQueryFormForApi();
         params.setOcppTagPk(ocppTagPk);
 
-        List<OcppTag.Overview> results = ocppTagService.getOverview(params);
+        List<OcppTagOverview> results = ocppTagService.getOverview(params);
         if (results.isEmpty()) {
             throw new SteveException.NotFound("Could not find this ocppTag");
         }

--- a/src/main/java/de/rwth/idsg/steve/web/api/TransactionsRestController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/api/TransactionsRestController.java
@@ -70,7 +70,7 @@ public class TransactionsRestController {
     )
     @GetMapping(value = "")
     @ResponseBody
-    public List<Transaction> get(@Valid TransactionQueryForm.ForApi params) {
+    public List<Transaction> get(@Valid TransactionQueryForm.TransactionQueryFormForApi params) {
         log.debug("Read request for query: {}", params);
 
         if (params.isReturnCSV()) {

--- a/src/main/java/de/rwth/idsg/steve/web/dto/ChargePointQueryForm.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ChargePointQueryForm.java
@@ -18,6 +18,7 @@
  */
 package de.rwth.idsg.steve.web.dto;
 
+import com.google.common.base.Strings;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,7 @@ public class ChargePointQueryForm {
 
     private String chargeBoxId;
     private String description;
+    private String note;
     private OcppVersion ocppVersion;
     private QueryPeriodType heartbeatPeriod;
 
@@ -55,6 +57,10 @@ public class ChargePointQueryForm {
 
     public boolean isSetChargeBoxId() {
         return chargeBoxId != null;
+    }
+
+    public boolean isSetNote() {
+        return !Strings.isNullOrEmpty(note);
     }
 
     @RequiredArgsConstructor

--- a/src/main/java/de/rwth/idsg/steve/web/dto/OcppTagQueryForm.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/OcppTagQueryForm.java
@@ -18,6 +18,7 @@
  */
 package de.rwth.idsg.steve.web.dto;
 
+import com.google.common.base.Strings;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +54,9 @@ public class OcppTagQueryForm {
     @Schema(description = "Return blocked, not blocked, or all Ocpp tags? Defaults to ALL")
     private BooleanType blocked = BooleanType.FALSE;
 
+    @Schema(description = "Query by the note associated with the OCPP tag. The value of this field does not have to exactly match the note. A substring is also accepted.")
+    private String note;
+
     @Schema(hidden = true)
     public boolean isOcppTagPkSet() {
         return ocppTagPk != null;
@@ -66,6 +70,11 @@ public class OcppTagQueryForm {
     @Schema(hidden = true)
     public boolean isParentIdTagSet() {
         return parentIdTag != null;
+    }
+
+    @Schema(hidden = true)
+    public boolean isNoteSet() {
+        return !Strings.isNullOrEmpty(note);
     }
 
     public BooleanType getExpired() {

--- a/src/main/java/de/rwth/idsg/steve/web/dto/OcppTagQueryForm.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/OcppTagQueryForm.java
@@ -116,9 +116,9 @@ public class OcppTagQueryForm {
     }
 
     @ToString(callSuper = true)
-    public static class ForApi extends OcppTagQueryForm {
+    public static class OcppTagQueryFormForApi extends OcppTagQueryForm {
 
-        public ForApi () {
+        public OcppTagQueryFormForApi() {
             super();
             setExpired(BooleanType.ALL);
             setInTransaction(BooleanType.ALL);

--- a/src/main/java/de/rwth/idsg/steve/web/dto/TransactionQueryForm.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/TransactionQueryForm.java
@@ -119,9 +119,9 @@ public class TransactionQueryForm extends QueryForm {
     }
 
     @ToString(callSuper = true)
-    public static class ForApi extends TransactionQueryForm {
+    public static class TransactionQueryFormForApi extends TransactionQueryForm {
 
-        public ForApi() {
+        public TransactionQueryFormForApi() {
             super();
             setType(QueryType.ALL);
             setPeriodType(QueryPeriodType.ALL);

--- a/src/main/resources/webapp/WEB-INF/views/data-man/chargepoints.jsp
+++ b/src/main/resources/webapp/WEB-INF/views/data-man/chargepoints.jsp
@@ -99,6 +99,10 @@
                     </td>
                 </tr>
                 <tr>
+                    <td>Note:</td>
+                    <td><form:input path="note"/></td>
+                </tr>
+                <tr>
                     <td></td>
                     <td id="add_space">
                         <input type="submit" value="Get">

--- a/src/main/resources/webapp/WEB-INF/views/data-man/ocppTags.jsp
+++ b/src/main/resources/webapp/WEB-INF/views/data-man/ocppTags.jsp
@@ -113,6 +113,10 @@
                     </td>
                 </tr>
                 <tr>
+                    <td>Note:</td>
+                    <td><form:input path="note"/></td>
+                </tr>
+                <tr>
                     <td></td>
                     <td id="add_space">
                         <input type="submit" value="Get">

--- a/src/test/java/de/rwth/idsg/steve/issues/Issue1219.java
+++ b/src/test/java/de/rwth/idsg/steve/issues/Issue1219.java
@@ -94,7 +94,7 @@ public class Issue1219 {
         var repository = new OcppTagRepositoryImpl(ctx);
 
         long start = System.currentTimeMillis();
-        List<OcppTag.Overview> values = repository.getOverview(new OcppTagQueryForm());
+        List<OcppTag.OcppTagOverview> values = repository.getOverview(new OcppTagQueryForm());
         long stop = System.currentTimeMillis();
 
         System.out.println("took " + Duration.millis(stop - start));

--- a/src/test/java/de/rwth/idsg/steve/web/api/OcppTagsRestControllerTest.java
+++ b/src/test/java/de/rwth/idsg/steve/web/api/OcppTagsRestControllerTest.java
@@ -87,7 +87,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
     @DisplayName("GET all: Test with empty results, expected 200")
     public void test1() throws Exception {
         // given
-        List<OcppTag.Overview> results = Collections.emptyList();
+        List<OcppTag.OcppTagOverview> results = Collections.emptyList();
 
         // when
         when(ocppTagService.getOverview(any())).thenReturn(results);
@@ -102,7 +102,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
     @DisplayName("GET all: Test with one result, expected 200")
     public void test2() throws Exception {
         // given
-        List<OcppTag.Overview> results = List.of(OcppTag.Overview.builder().ocppTagPk(96).build());
+        List<OcppTag.OcppTagOverview> results = List.of(OcppTag.OcppTagOverview.builder().ocppTagPk(96).build());
 
         // when
         when(ocppTagService.getOverview(any())).thenReturn(results);
@@ -141,7 +141,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
     public void test5() throws Exception {
         // given
         DateTime someDate = DateTime.parse("2020-10-01T00:00:00.000Z");
-        OcppTag.Overview result = OcppTag.Overview.builder()
+        OcppTag.OcppTagOverview result = OcppTag.OcppTagOverview.builder()
             .ocppTagPk(121)
             .idTag("id-1")
             .parentOcppTagPk(454)
@@ -206,7 +206,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
     @DisplayName("GET one: One entity found, expected 200")
     public void test8() throws Exception {
         // given
-        OcppTag.Overview result = OcppTag.Overview.builder().ocppTagPk(12).build();
+        OcppTag.OcppTagOverview result = OcppTag.OcppTagOverview.builder().ocppTagPk(12).build();
 
         // when
         when(ocppTagService.getOverview(any())).thenReturn(List.of(result));
@@ -265,7 +265,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
         OcppTagForm form = new OcppTagForm();
         form.setIdTag("id-123");
 
-        OcppTag.Overview result = OcppTag.Overview.builder()
+        OcppTag.OcppTagOverview result = OcppTag.OcppTagOverview.builder()
             .ocppTagPk(ocppTagPk)
             .idTag(form.getIdTag())
             .build();
@@ -296,7 +296,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
         form.setIdTag("id-123");
         form.setNote("note-1");
 
-        OcppTag.Overview result = OcppTag.Overview.builder()
+        OcppTag.OcppTagOverview result = OcppTag.OcppTagOverview.builder()
             .ocppTagPk(ocppTagPk)
             .idTag(form.getIdTag())
             .note(form.getNote())
@@ -367,7 +367,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
         // given
         int ocppTagPk = 123;
 
-        OcppTag.Overview result = OcppTag.Overview.builder()
+        OcppTag.OcppTagOverview result = OcppTag.OcppTagOverview.builder()
             .ocppTagPk(ocppTagPk)
             .idTag("id-123")
             .note("note-2")
@@ -390,7 +390,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
         // given
         int ocppTagPk = 123;
 
-        OcppTag.Overview result = OcppTag.Overview.builder()
+        OcppTag.OcppTagOverview result = OcppTag.OcppTagOverview.builder()
             .ocppTagPk(ocppTagPk)
             .idTag("id-123")
             .note("note-2")
@@ -445,14 +445,14 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             .andExpectAll(errorJsonMatchers());
 
         verify(ocppTagService, times(0)).removeUnknown(anyList());
-        verify(ocppTagService, times(0)).getOverview(any(OcppTagQueryForm.ForApi.class));
+        verify(ocppTagService, times(0)).getOverview(any(OcppTagQueryForm.OcppTagQueryFormForApi.class));
     }
 
     @Test
     @DisplayName("GET all: Query param 'expired' is translated correctly, while others are defaulted")
     public void test19() throws Exception {
         // given
-        ArgumentCaptor<OcppTagQueryForm.ForApi> formToCapture = ArgumentCaptor.forClass(OcppTagQueryForm.ForApi.class);
+        ArgumentCaptor<OcppTagQueryForm.OcppTagQueryFormForApi> formToCapture = ArgumentCaptor.forClass(OcppTagQueryForm.OcppTagQueryFormForApi.class);
 
         // when
         when(ocppTagService.getOverview(any())).thenReturn(Collections.emptyList());
@@ -463,7 +463,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             .andExpect(status().isOk());
 
         verify(ocppTagService).getOverview(formToCapture.capture());
-        OcppTagQueryForm.ForApi capturedForm = formToCapture.getValue();
+        OcppTagQueryForm.OcppTagQueryFormForApi capturedForm = formToCapture.getValue();
 
         assertEquals(capturedForm.getExpired(), OcppTagQueryForm.BooleanType.FALSE);
         assertEquals(capturedForm.getInTransaction(), OcppTagQueryForm.BooleanType.ALL);
@@ -474,7 +474,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
     @DisplayName("GET all: Query param 'inTransaction' is translated correctly, while others are defaulted")
     public void test20() throws Exception {
         // given
-        ArgumentCaptor<OcppTagQueryForm.ForApi> formToCapture = ArgumentCaptor.forClass(OcppTagQueryForm.ForApi.class);
+        ArgumentCaptor<OcppTagQueryForm.OcppTagQueryFormForApi> formToCapture = ArgumentCaptor.forClass(OcppTagQueryForm.OcppTagQueryFormForApi.class);
 
         // when
         when(ocppTagService.getOverview(any())).thenReturn(Collections.emptyList());
@@ -485,7 +485,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             .andExpect(status().isOk());
 
         verify(ocppTagService).getOverview(formToCapture.capture());
-        OcppTagQueryForm.ForApi capturedForm = formToCapture.getValue();
+        OcppTagQueryForm.OcppTagQueryFormForApi capturedForm = formToCapture.getValue();
 
         assertEquals(capturedForm.getExpired(), OcppTagQueryForm.BooleanType.ALL);
         assertEquals(capturedForm.getInTransaction(), OcppTagQueryForm.BooleanType.TRUE);
@@ -496,7 +496,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
     @DisplayName("GET all: Query param 'inTransaction' is translated correctly, while others are defaulted")
     public void test21() throws Exception {
         // given
-        ArgumentCaptor<OcppTagQueryForm.ForApi> formToCapture = ArgumentCaptor.forClass(OcppTagQueryForm.ForApi.class);
+        ArgumentCaptor<OcppTagQueryForm.OcppTagQueryFormForApi> formToCapture = ArgumentCaptor.forClass(OcppTagQueryForm.OcppTagQueryFormForApi.class);
 
         // when
         when(ocppTagService.getOverview(any())).thenReturn(Collections.emptyList());
@@ -507,7 +507,7 @@ public class OcppTagsRestControllerTest extends AbstractControllerTest {
             .andExpect(status().isOk());
 
         verify(ocppTagService).getOverview(formToCapture.capture());
-        OcppTagQueryForm.ForApi capturedForm = formToCapture.getValue();
+        OcppTagQueryForm.OcppTagQueryFormForApi capturedForm = formToCapture.getValue();
 
         assertEquals(capturedForm.getExpired(), OcppTagQueryForm.BooleanType.ALL);
         assertEquals(capturedForm.getInTransaction(), OcppTagQueryForm.BooleanType.ALL);

--- a/src/test/java/de/rwth/idsg/steve/web/api/TransactionRestControllerTest.java
+++ b/src/test/java/de/rwth/idsg/steve/web/api/TransactionRestControllerTest.java
@@ -213,7 +213,7 @@ public class TransactionRestControllerTest extends AbstractControllerTest {
     @DisplayName("GET all: Query param 'type' is translated correctly, while others are defaulted")
     public void test10() throws Exception {
         // given
-        ArgumentCaptor<TransactionQueryForm.ForApi> formToCapture = ArgumentCaptor.forClass(TransactionQueryForm.ForApi.class);
+        ArgumentCaptor<TransactionQueryForm.TransactionQueryFormForApi> formToCapture = ArgumentCaptor.forClass(TransactionQueryForm.TransactionQueryFormForApi.class);
 
         // when
         when(transactionRepository.getTransactions(any())).thenReturn(Collections.emptyList());
@@ -224,7 +224,7 @@ public class TransactionRestControllerTest extends AbstractControllerTest {
             .andExpect(status().isOk());
 
         verify(transactionRepository).getTransactions(formToCapture.capture());
-        TransactionQueryForm.ForApi capturedForm = formToCapture.getValue();
+        TransactionQueryForm.TransactionQueryFormForApi capturedForm = formToCapture.getValue();
 
         assertEquals(capturedForm.getType(), TransactionQueryForm.QueryType.ACTIVE);
         assertEquals(capturedForm.getPeriodType(), TransactionQueryForm.QueryPeriodType.ALL);
@@ -234,7 +234,7 @@ public class TransactionRestControllerTest extends AbstractControllerTest {
     @DisplayName("GET all: Query param 'periodType' is translated correctly, while others are defaulted")
     public void test11() throws Exception {
         // given
-        ArgumentCaptor<TransactionQueryForm.ForApi> formToCapture = ArgumentCaptor.forClass(TransactionQueryForm.ForApi.class);
+        ArgumentCaptor<TransactionQueryForm.TransactionQueryFormForApi> formToCapture = ArgumentCaptor.forClass(TransactionQueryForm.TransactionQueryFormForApi.class);
 
         // when
         when(transactionRepository.getTransactions(any())).thenReturn(Collections.emptyList());
@@ -245,7 +245,7 @@ public class TransactionRestControllerTest extends AbstractControllerTest {
             .andExpect(status().isOk());
 
         verify(transactionRepository).getTransactions(formToCapture.capture());
-        TransactionQueryForm.ForApi capturedForm = formToCapture.getValue();
+        TransactionQueryForm.TransactionQueryFormForApi capturedForm = formToCapture.getValue();
 
         assertEquals(capturedForm.getType(), TransactionQueryForm.QueryType.ALL);
         assertEquals(capturedForm.getPeriodType(), TransactionQueryForm.QueryPeriodType.LAST_30);


### PR DESCRIPTION
1st commit adds a new functionality in terms of a new field to query by.

2nd commit addresses an annoyance and confusion when using swagger. apparently, another solution is setting the property `springdoc.use-fqn=true`. but then the class name uses the complete package name, which can be considered an unnecessary leak of impl detail.