### PR TITLE
refactor task/job executors

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/config/BeanConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/BeanConfiguration.java
@@ -21,7 +21,6 @@ package de.rwth.idsg.steve.config;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.mysql.cj.conf.PropertyKey;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -45,6 +44,7 @@ import org.springframework.format.support.FormattingConversionService;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.accept.ContentNegotiationManager;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -55,16 +55,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 
-import jakarta.annotation.PreDestroy;
 import jakarta.validation.Validator;
 
 import javax.sql.DataSource;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Executor;
 
 import static de.rwth.idsg.steve.SteveConfiguration.CONFIG;
 
@@ -80,8 +75,6 @@ import static de.rwth.idsg.steve.SteveConfiguration.CONFIG;
 @EnableScheduling
 @ComponentScan("de.rwth.idsg.steve")
 public class BeanConfiguration implements WebMvcConfigurer {
-
-    private ScheduledThreadPoolExecutor executor;
 
     /**
      * https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration
@@ -144,13 +137,15 @@ public class BeanConfiguration implements WebMvcConfigurer {
         return DSL.using(conf);
     }
 
-    @Bean
-    public ScheduledExecutorService scheduledExecutorService() {
-        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("SteVe-Executor-%d")
-                                                                .build();
-
-        executor = new ScheduledThreadPoolExecutor(5, threadFactory);
-        return executor;
+    @Bean(name = {"asyncTaskScheduler", "asyncTaskExecutor"})
+    public ThreadPoolTaskScheduler asyncTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5);
+        scheduler.setThreadNamePrefix("SteVe-Executor-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+        scheduler.initialize();
+        return scheduler;
     }
 
     @Bean
@@ -170,29 +165,6 @@ public class BeanConfiguration implements WebMvcConfigurer {
             return new GithubReleaseCheckService();
         } else {
             return new DummyReleaseCheckService();
-        }
-    }
-
-    @PreDestroy
-    public void shutDown() {
-        if (executor != null) {
-            gracefulShutDown(executor);
-        }
-    }
-
-    private void gracefulShutDown(ExecutorService executor) {
-        try {
-            executor.shutdown();
-            executor.awaitTermination(30, TimeUnit.SECONDS);
-
-        } catch (InterruptedException e) {
-            log.error("Termination interrupted", e);
-
-        } finally {
-            if (!executor.isTerminated()) {
-                log.warn("Killing non-finished tasks");
-            }
-            executor.shutdownNow();
         }
     }
 

--- a/src/main/java/de/rwth/idsg/steve/config/DelegatingTaskExecutor.java
+++ b/src/main/java/de/rwth/idsg/steve/config/DelegatingTaskExecutor.java
@@ -1,0 +1,48 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2025 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 02.02.2025
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class DelegatingTaskExecutor implements Closeable {
+
+    private final ThreadPoolTaskExecutor delegate;
+
+    @Override
+    public void close() throws IOException {
+        log.info("Shutting down");
+        delegate.shutdown();
+    }
+
+    public void execute(Runnable task) {
+        delegate.execute(task);
+    }
+
+}

--- a/src/main/java/de/rwth/idsg/steve/config/DelegatingTaskScheduler.java
+++ b/src/main/java/de/rwth/idsg/steve/config/DelegatingTaskScheduler.java
@@ -1,0 +1,51 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2025 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ScheduledFuture;
+
+/**
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 02.02.2025
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class DelegatingTaskScheduler implements Closeable {
+
+    private final ThreadPoolTaskScheduler delegate;
+
+    @Override
+    public void close() throws IOException {
+        log.info("Shutting down");
+        delegate.shutdown();
+    }
+
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, Instant startTime, Duration period) {
+        return delegate.scheduleAtFixedRate(task, startTime, period);
+    }
+
+}

--- a/src/main/java/de/rwth/idsg/steve/config/WebSocketConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/WebSocketConfiguration.java
@@ -51,7 +51,7 @@ public class WebSocketConfiguration implements WebSocketConfigurer {
     @Autowired private Ocpp16WebSocketEndpoint ocpp16WebSocketEndpoint;
 
     public static final String PATH_INFIX = "/websocket/CentralSystemService/";
-    public static final long PING_INTERVAL = TimeUnit.MINUTES.toMinutes(15);
+    public static final Duration PING_INTERVAL = Duration.ofMinutes(15);
     public static final Duration IDLE_TIMEOUT = Duration.ofHours(2);
     public static final int MAX_MSG_SIZE = 8_388_608; // 8 MB for max message size
 

--- a/src/main/java/de/rwth/idsg/steve/ocpp/soap/MessageHeaderInterceptor.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/soap/MessageHeaderInterceptor.java
@@ -18,6 +18,7 @@
  */
 package de.rwth.idsg.steve.ocpp.soap;
 
+import de.rwth.idsg.steve.config.DelegatingTaskExecutor;
 import de.rwth.idsg.steve.ocpp.OcppProtocol;
 import de.rwth.idsg.steve.repository.OcppServerRepository;
 import de.rwth.idsg.steve.repository.impl.ChargePointRepositoryImpl;
@@ -41,7 +42,6 @@ import org.springframework.stereotype.Component;
 
 import javax.xml.namespace.QName;
 import java.util.Optional;
-import java.util.concurrent.Executor;
 
 import static org.apache.cxf.ws.addressing.JAXWSAConstants.ADDRESSING_PROPERTIES_INBOUND;
 
@@ -62,7 +62,7 @@ public class MessageHeaderInterceptor extends AbstractPhaseInterceptor<Message> 
 
     @Autowired private OcppServerRepository ocppServerRepository;
     @Autowired private ChargePointHelperService chargePointHelperService;
-    @Autowired private Executor asyncTaskExecutor;
+    @Autowired private DelegatingTaskExecutor asyncTaskExecutor;
 
     private static final String BOOT_OPERATION_NAME = "BootNotification";
     private static final String CHARGEBOX_ID_HEADER = "ChargeBoxIdentity";

--- a/src/main/java/de/rwth/idsg/steve/ocpp/soap/MessageHeaderInterceptor.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/soap/MessageHeaderInterceptor.java
@@ -41,7 +41,7 @@ import org.springframework.stereotype.Component;
 
 import javax.xml.namespace.QName;
 import java.util.Optional;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executor;
 
 import static org.apache.cxf.ws.addressing.JAXWSAConstants.ADDRESSING_PROPERTIES_INBOUND;
 
@@ -62,7 +62,7 @@ public class MessageHeaderInterceptor extends AbstractPhaseInterceptor<Message> 
 
     @Autowired private OcppServerRepository ocppServerRepository;
     @Autowired private ChargePointHelperService chargePointHelperService;
-    @Autowired private ScheduledExecutorService executorService;
+    @Autowired private Executor asyncTaskExecutor;
 
     private static final String BOOT_OPERATION_NAME = "BootNotification";
     private static final String CHARGEBOX_ID_HEADER = "ChargeBoxIdentity";
@@ -93,7 +93,7 @@ public class MessageHeaderInterceptor extends AbstractPhaseInterceptor<Message> 
         // 2. update endpoint
         // -------------------------------------------------------------------------
 
-        executorService.execute(() -> {
+        asyncTaskExecutor.execute(() -> {
             try {
                 String endpointAddress = getEndpointAddress(message);
                 if (endpointAddress != null) {

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/AbstractWebSocketEndpoint.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/AbstractWebSocketEndpoint.java
@@ -20,6 +20,7 @@ package de.rwth.idsg.steve.ocpp.ws;
 
 import com.google.common.base.Strings;
 import de.rwth.idsg.steve.config.WebSocketConfiguration;
+import de.rwth.idsg.steve.config.DelegatingTaskScheduler;
 import de.rwth.idsg.steve.ocpp.OcppTransport;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
@@ -31,7 +32,6 @@ import de.rwth.idsg.steve.service.notification.OcppStationWebSocketDisconnected;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.PongMessage;
@@ -55,7 +55,7 @@ import java.util.function.Consumer;
  */
 public abstract class AbstractWebSocketEndpoint extends ConcurrentWebSocketHandler implements SubProtocolCapable {
 
-    @Autowired private ThreadPoolTaskScheduler asyncTaskScheduler;
+    @Autowired private DelegatingTaskScheduler asyncTaskScheduler;
     @Autowired private OcppServerRepository ocppServerRepository;
     @Autowired private FutureResponseContextStore futureResponseContextStore;
     @Autowired private ApplicationEventPublisher applicationEventPublisher;

--- a/src/main/java/de/rwth/idsg/steve/service/BackgroundService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/BackgroundService.java
@@ -23,7 +23,7 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
 /**
@@ -32,10 +32,10 @@ import java.util.function.Consumer;
  */
 @RequiredArgsConstructor
 public class BackgroundService {
-    private final ExecutorService executorService;
+    private final Executor asyncTaskExecutor;
 
-    public static BackgroundService with(ExecutorService executorService) {
-        return new BackgroundService(executorService);
+    public static BackgroundService with(Executor asyncTaskExecutor) {
+        return new BackgroundService(asyncTaskExecutor);
     }
 
     public Runner forFirst(List<ChargePointSelect> list) {
@@ -56,7 +56,7 @@ public class BackgroundService {
 
         @Override
         public void execute(Consumer<ChargePointSelect> consumer) {
-            executorService.execute(() -> consumer.accept(cps));
+            asyncTaskExecutor.execute(() -> consumer.accept(cps));
         }
     }
 
@@ -66,7 +66,7 @@ public class BackgroundService {
 
         @Override
         public void execute(Consumer<ChargePointSelect> consumer) {
-            executorService.execute(() -> list.forEach(consumer));
+            asyncTaskExecutor.execute(() -> list.forEach(consumer));
         }
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/service/BackgroundService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/BackgroundService.java
@@ -18,12 +18,12 @@
  */
 package de.rwth.idsg.steve.service;
 
+import de.rwth.idsg.steve.config.DelegatingTaskExecutor;
 import de.rwth.idsg.steve.repository.dto.ChargePointSelect;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
-import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
 /**
@@ -32,9 +32,10 @@ import java.util.function.Consumer;
  */
 @RequiredArgsConstructor
 public class BackgroundService {
-    private final Executor asyncTaskExecutor;
 
-    public static BackgroundService with(Executor asyncTaskExecutor) {
+    private final DelegatingTaskExecutor asyncTaskExecutor;
+
+    public static BackgroundService with(DelegatingTaskExecutor asyncTaskExecutor) {
         return new BackgroundService(asyncTaskExecutor);
     }
 

--- a/src/main/java/de/rwth/idsg/steve/service/ChargePointServiceClient.java
+++ b/src/main/java/de/rwth/idsg/steve/service/ChargePointServiceClient.java
@@ -21,7 +21,6 @@ package de.rwth.idsg.steve.service;
 import de.rwth.idsg.steve.SteveException;
 import de.rwth.idsg.steve.ocpp.ChargePointServiceInvokerImpl;
 import de.rwth.idsg.steve.ocpp.OcppCallback;
-import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.task.CancelReservationTask;
 import de.rwth.idsg.steve.ocpp.task.ChangeAvailabilityTask;
 import de.rwth.idsg.steve.ocpp.task.ChangeConfigurationTask;
@@ -75,7 +74,7 @@ import org.joda.time.DateTime;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executor;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -90,7 +89,7 @@ public class ChargePointServiceClient {
     private final ReservationRepository reservationRepository;
     private final OcppTagService ocppTagService;
 
-    private final ScheduledExecutorService executorService;
+    private final Executor asyncTaskExecutor;
     private final TaskStore taskStore;
     private final ChargePointServiceInvokerImpl invoker;
 
@@ -107,7 +106,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.changeAvailability(c, task));
 
@@ -123,7 +122,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.changeConfiguration(c, task));
 
@@ -139,7 +138,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.clearCache(c, task));
 
@@ -155,7 +154,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.getDiagnostics(c, task));
 
@@ -171,7 +170,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.reset(c, task));
 
@@ -187,7 +186,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.updateFirmware(c, task));
 
@@ -207,7 +206,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forFirst(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.remoteStartTransaction(c, task));
 
@@ -223,7 +222,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forFirst(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.remoteStopTransaction(c, task));
 
@@ -239,7 +238,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forFirst(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.unlockConnector(c, task));
 
@@ -259,7 +258,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.dataTransfer(c, task));
 
@@ -275,7 +274,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.getConfiguration(c, task));
 
@@ -291,7 +290,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.getLocalListVersion(c, task));
 
@@ -307,7 +306,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.sendLocalList(c, task));
 
@@ -341,7 +340,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forFirst(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.reserveNow(c, task));
 
@@ -357,7 +356,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forFirst(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.cancelReservation(c, task));
 
@@ -377,7 +376,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.triggerMessage(c, task));
 
@@ -398,7 +397,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.setChargingProfile(c, task));
 
@@ -414,7 +413,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.clearChargingProfile(c, task));
 
@@ -430,7 +429,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        BackgroundService.with(executorService)
+        BackgroundService.with(asyncTaskExecutor)
             .forEach(task.getParams().getChargePointSelectList())
             .execute(c -> invoker.getCompositeSchedule(c, task));
 

--- a/src/main/java/de/rwth/idsg/steve/service/ChargePointServiceClient.java
+++ b/src/main/java/de/rwth/idsg/steve/service/ChargePointServiceClient.java
@@ -19,6 +19,7 @@
 package de.rwth.idsg.steve.service;
 
 import de.rwth.idsg.steve.SteveException;
+import de.rwth.idsg.steve.config.DelegatingTaskExecutor;
 import de.rwth.idsg.steve.ocpp.ChargePointServiceInvokerImpl;
 import de.rwth.idsg.steve.ocpp.OcppCallback;
 import de.rwth.idsg.steve.ocpp.task.CancelReservationTask;
@@ -74,7 +75,6 @@ import org.joda.time.DateTime;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.concurrent.Executor;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -89,7 +89,7 @@ public class ChargePointServiceClient {
     private final ReservationRepository reservationRepository;
     private final OcppTagService ocppTagService;
 
-    private final Executor asyncTaskExecutor;
+    private final DelegatingTaskExecutor asyncTaskExecutor;
     private final TaskStore taskStore;
     private final ChargePointServiceInvokerImpl invoker;
 

--- a/src/main/java/de/rwth/idsg/steve/service/MailService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/MailService.java
@@ -20,6 +20,7 @@ package de.rwth.idsg.steve.service;
 
 import com.google.common.base.Strings;
 import de.rwth.idsg.steve.SteveException;
+import de.rwth.idsg.steve.config.DelegatingTaskExecutor;
 import de.rwth.idsg.steve.repository.SettingsRepository;
 import de.rwth.idsg.steve.repository.dto.MailSettings;
 import lombok.extern.slf4j.Slf4j;
@@ -36,7 +37,6 @@ import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 
 import java.util.Properties;
-import java.util.concurrent.Executor;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -47,7 +47,7 @@ import java.util.concurrent.Executor;
 public class MailService {
 
     @Autowired private SettingsRepository settingsRepository;
-    @Autowired private Executor asyncTaskExecutor;
+    @Autowired private DelegatingTaskExecutor asyncTaskExecutor;
 
     public MailSettings getSettings() {
         return settingsRepository.getMailSettings();

--- a/src/main/java/de/rwth/idsg/steve/service/MailService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/MailService.java
@@ -36,7 +36,7 @@ import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 
 import java.util.Properties;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executor;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -47,7 +47,7 @@ import java.util.concurrent.ScheduledExecutorService;
 public class MailService {
 
     @Autowired private SettingsRepository settingsRepository;
-    @Autowired private ScheduledExecutorService executorService;
+    @Autowired private Executor asyncTaskExecutor;
 
     public MailSettings getSettings() {
         return settingsRepository.getMailSettings();
@@ -62,7 +62,7 @@ public class MailService {
     }
 
     public void sendAsync(String subject, String body) {
-        executorService.execute(() -> {
+        asyncTaskExecutor.execute(() -> {
             try {
                 send(subject, body);
             } catch (MessagingException e) {


### PR DESCRIPTION
* migrate from java's executor impl to spring's abstraction: let spring handle the bean lifecycle, graceful shutdown etc.

* separate on interface-level between scheduled and async tasks: we only have 1 use case for scheduled tasks (websocket ping-pongs), whereas all other usages of ScheduledExecutorService were just async job submissions. separation might be useful in future, if we want to have distinct thread pools as well.

* with regards to the previous point: separate TaskExecutor and TaskScheduler usage already