### PR TITLE
fix the way request params are rendered on Swagger UI

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/web/api/OcppTagsRestController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/api/OcppTagsRestController.java
@@ -32,6 +32,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -80,7 +81,7 @@ public class OcppTagsRestController {
     )
     @GetMapping(value = "")
     @ResponseBody
-    public List<OcppTagOverview> get(OcppTagQueryFormForApi params) {
+    public List<OcppTagOverview> get(@ParameterObject OcppTagQueryFormForApi params) {
         log.debug("Read request for query: {}", params);
 
         var response = ocppTagService.getOverview(params);

--- a/src/main/java/de/rwth/idsg/steve/web/api/TransactionsRestController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/api/TransactionsRestController.java
@@ -31,6 +31,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -70,7 +71,7 @@ public class TransactionsRestController {
     )
     @GetMapping(value = "")
     @ResponseBody
-    public List<Transaction> get(@Valid TransactionQueryForm.TransactionQueryFormForApi params) {
+    public List<Transaction> get(@Valid @ParameterObject TransactionQueryForm.TransactionQueryFormForApi params) {
         log.debug("Read request for query: {}", params);
 
         if (params.isReturnCSV()) {


### PR DESCRIPTION
before:
<img width="486" alt="Screenshot 2025-02-23 at 15 52 22" src="https://github.com/user-attachments/assets/c1805197-b482-4050-acd7-7aac04ed2c0b" />


after:
<img width="1135" alt="Screenshot 2025-02-23 at 15 53 33" src="https://github.com/user-attachments/assets/33f0bc4c-2fb9-4e3e-a7d7-2215d038d9e0" />