### PR TITLE
retire ubuntu 20, use ubuntu 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04 ]
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
         java: [ '17', '21' ]
         db: [ 'mysql:8.0', 'mariadb:10.3', 'mariadb:10.4.30', 'mariadb:10.5.21', 'mariadb:10.6.14' ]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
builds are failing because we use ubuntu-20 but [it is not supported anymore](https://github.com/actions/runner-images?tab=readme-ov-file#available-images).

[example error:](https://github.com/steve-community/steve/actions/runs/15229757123/job/42836212986?pr=1754)
<img width="1315" height="117" alt="Screenshot 2025-08-14 at 00 12 46" src="https://github.com/user-attachments/assets/e332c089-9db3-4684-acf3-277982107a43" />
