### PR TITLE
make DefaultHandshakeHandler a bean (#1844)

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/config/WebSocketConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/WebSocketConfiguration.java
@@ -28,6 +28,7 @@ import de.rwth.idsg.steve.web.validation.ChargeBoxIdValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.websocket.core.WebSocketConstants;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
@@ -62,7 +63,7 @@ public class WebSocketConfiguration implements WebSocketConfigurer {
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         OcppWebSocketHandshakeHandler handshakeHandler = new OcppWebSocketHandshakeHandler(
             chargeBoxIdValidator,
-            defaultHandshakeHandler(),
+            handshakeHandler(),
             Lists.newArrayList(ocpp16WebSocketEndpoint, ocpp15WebSocketEndpoint, ocpp12WebSocketEndpoint),
             chargePointRegistrationService
         );
@@ -77,7 +78,8 @@ public class WebSocketConfiguration implements WebSocketConfigurer {
      *
      * Otherwise, defaults come from {@link WebSocketConstants}
      */
-    private static DefaultHandshakeHandler defaultHandshakeHandler() {
+    @Bean
+    public DefaultHandshakeHandler handshakeHandler() {
         JettyRequestUpgradeStrategy strategy = new JettyRequestUpgradeStrategy();
 
         strategy.addWebSocketConfigurer(configurable -> {


### PR DESCRIPTION
if it is not a bean, DefaultHandshakeHandler.setServletContext is not called. DefaultHandshakeHandler delegates the call to RequestUpgradeStrategy.setServletContext. JettyRequestUpgradeStrategy's setServletContext calls the webSocketConfigurer.

this call was missing in the chain. we need it to be called since webSocketConfigurer contains config for extended idle timeout.