### PR TITLE
bugfix: FROM/TO timestamp filter is not applied when getting all transactions

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/utils/CustomDSL.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/CustomDSL.java
@@ -19,6 +19,8 @@
 package de.rwth.idsg.steve.utils;
 
 import de.rwth.idsg.steve.SteveException;
+import de.rwth.idsg.steve.web.dto.QueryPeriodFromToFilter;
+import de.rwth.idsg.steve.web.dto.QueryPeriodType;
 import de.rwth.idsg.steve.web.dto.QueryPeriodTypeFilter;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -86,7 +88,13 @@ public final class CustomDSL {
 
     @Nullable
     public static Condition getTimeCondition(Field<DateTime> timestampField, QueryPeriodTypeFilter form) {
-        switch (form.getPeriodType()) {
+        return getTimeCondition(timestampField, form, form.getPeriodType());
+    }
+
+    @Nullable
+    public static Condition getTimeCondition(Field<DateTime> timestampField, QueryPeriodFromToFilter form,
+                                             QueryPeriodType periodType) {
+        switch (periodType) {
             case TODAY:
                 return date(timestampField).eq(date(DateTime.now()));
 
@@ -95,7 +103,7 @@ public final class CustomDSL {
             case LAST_90:
                 DateTime now = DateTime.now();
                 return date(timestampField).between(
-                    date(now.minusDays(form.getPeriodType().getInterval())),
+                    date(now.minusDays(periodType.getInterval())),
                     date(now)
                 );
 


### PR DESCRIPTION
### **User description**
... (regardless of active or stopped)

reason: notice the "return null" in else-branch of the previous code. this was the reason.
with these changes we start applying the timestamp filter only to START_TIMESTAMP column
for all activity types (active / stopped / all). even for stopped transactions. before this, we were
applying FROM/TO to STOP_TIMESTAMP, if we were getting only stopped transactions. i argue
that this is unnecessary nuance. getting rid of this enabled to use an existing generalistic method.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix FROM/TO timestamp filter not applied when querying all transactions

- Consolidate timestamp filtering logic to always use START_TIMESTAMP column

- Remove transaction type-specific filtering logic that caused null returns

- Generalize time condition method for reuse across different query contexts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TransactionRepositoryImpl<br/>getConditions method"] -->|calls| B["CustomDSL<br/>getTimeCondition"]
  B -->|filters by| C["START_TIMESTAMP<br/>for all types"]
  D["Old logic<br/>type-specific filtering"] -->|removed| E["Null return<br/>bug eliminated"]
  C -->|applies to| F["Active/Stopped/All<br/>transactions"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TransactionRepositoryImpl.java</strong><dd><code>Remove type-specific timestamp filtering logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/de/rwth/idsg/steve/repository/impl/TransactionRepositoryImpl.java

<ul><li>Removed private <code>getTimeCondition</code> method that had type-specific logic<br> <li> Updated call to use generalized <code>getTimeCondition</code> from CustomDSL with <br>START_TIMESTAMP<br> <li> Added import for <code>getTimeCondition</code> utility method<br> <li> Simplified filtering to always apply timestamp conditions to <br>START_TIMESTAMP column</ul>


</details>


  </td>
  <td><a href="https://github.com/steve-community/steve/pull/1902/files#diff-ff642f46fe4341466a32c873645133648539cfd11669145a0ad2606e3289075a">+2/-35</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CustomDSL.java</strong><dd><code>Generalize time condition filtering method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/de/rwth/idsg/steve/utils/CustomDSL.java

<ul><li>Added new overloaded <code>getTimeCondition</code> method accepting <br>QueryPeriodFromToFilter and QueryPeriodType parameters<br> <li> Refactored existing method to delegate to new overload for code reuse<br> <li> Updated period type reference to use parameter instead of form method <br>call<br> <li> Added imports for QueryPeriodFromToFilter and QueryPeriodType classes</ul>


</details>


  </td>
  <td><a href="https://github.com/steve-community/steve/pull/1902/files#diff-3b8d46df722a1c25c23ad7677092c0d8a9f3e7061f7a801c9df0ddafe8af7cee">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

