### PR TITLE
Websocket improvements

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketLogger.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketLogger.java
@@ -46,6 +46,10 @@ public final class WebSocketLogger {
         log.info("[chargeBoxId={}, sessionId={}] Sending: {}", chargeBoxId, session.getId(), msg);
     }
 
+    public static void willNotSend(String chargeBoxId, WebSocketSession session, String msg) {
+        log.warn("[chargeBoxId={}, sessionId={}] Attempted to send to closed session: {}", chargeBoxId, session.getId(), msg);
+    }
+
     public static void sendingPing(String chargeBoxId, WebSocketSession session) {
         log.debug("[chargeBoxId={}, sessionId={}] Sending ping message", chargeBoxId, session.getId());
     }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Sender.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Sender.java
@@ -45,13 +45,17 @@ public enum Sender implements Consumer<CommunicationContext> {
         String chargeBoxId = context.getChargeBoxId();
         WebSocketSession session = context.getSession();
 
-        WebSocketLogger.sending(chargeBoxId, session, outgoingString);
+        // https://github.com/steve-community/steve/issues/1914
+        if (!session.isOpen()) {
+            WebSocketLogger.willNotSend(chargeBoxId, session, outgoingString);
+            return;
+        }
 
+        WebSocketLogger.sending(chargeBoxId, session, outgoingString);
         TextMessage out = new TextMessage(outgoingString);
         try {
             session.sendMessage(out);
         } catch (IOException e) {
-
             // Do NOT swallow exceptions for outgoing CALLs. For others just log.
             if (context.getOutgoingMessage() instanceof OcppJsonCall) {
                 throw new SteveException(e.getMessage());


### PR DESCRIPTION
### **User description**
- https://github.com/steve-community/steve/issues/1913
- https://github.com/steve-community/steve/issues/1914


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improve logging for ClosedChannelException in transport errors
  - Distinguish between expected connection closures and actual errors
  - Avoid printing useless stacktraces for abrupt client disconnections

- Check WebSocket session status before sending messages
  - Prevent sending to closed sessions with early return
  - Log attempted sends to closed sessions as warnings

- Add new logging method for closed session send attempts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WebSocket Message Send"] --> B{"Session Open?"}
  B -->|No| C["Log willNotSend Warning"]
  C --> D["Return Early"]
  B -->|Yes| E["Send Message"]
  E --> F{"IOException?"}
  F -->|ClosedChannelException| G["Log as Expected Closure"]
  F -->|Other Error| H["Log as Transport Error"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>WebSocketLogger.java</strong><dd><code>Improve logging for closed channel exceptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketLogger.java

<ul><li>Added import for <code>ClosedChannelException</code> class<br> <li> Added new <code>willNotSend()</code> method to log attempts to send to closed <br>sessions<br> <li> Enhanced <code>transportError()</code> method to distinguish between <br><code>ClosedChannelException</code> and other errors<br> <li> <code>ClosedChannelException</code> now logged as warning without stacktrace <br>instead of error</ul>


</details>


  </td>
  <td><a href="https://github.com/steve-community/steve/pull/1915/files#diff-f06b5b2b3c8fed4b6a88641955ee71c543fc0b882a0dbaa10a4471d7e8b8f322">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Sender.java</strong><dd><code>Validate WebSocket session before sending</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Sender.java

<ul><li>Added session open status check before attempting to send messages<br> <li> Early return with warning log if session is closed<br> <li> Reordered logging to occur after session validation<br> <li> Removed unnecessary blank line in exception handling block</ul>


</details>


  </td>
  <td><a href="https://github.com/steve-community/steve/pull/1915/files#diff-e137e8a4a5c3cbd42f67f9342a28b32b7ebd38d5249c411e03c9d611850b3577">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

