### PR TITLE
Small improvements

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/service/ChargePointService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/ChargePointService.java
@@ -130,9 +130,12 @@ public class ChargePointService {
         log.info("Deleted charge point with chargeBoxPk={} and chargeBoxId={}", chargeBoxPk, chargeBoxId);
 
         // https://github.com/steve-community/steve/issues/1871
-        var version = OcppProtocol.fromCompositeValue(details.getChargeBox().getOcppProtocol()).getVersion();
-        log.info("Closing all WebSocket sessions of chargeBoxPk={} and chargeBoxId={}", chargeBoxPk, chargeBoxId);
-        sessionContextStoreHolder.getOrCreate(version).closeSessions(chargeBoxId);
+        String ocppProtocol = details.getChargeBox().getOcppProtocol();
+        if (!StringUtils.isEmpty(ocppProtocol)) {
+            var version = OcppProtocol.fromCompositeValue(ocppProtocol).getVersion();
+            log.info("Closing all WebSocket sessions of chargeBoxPk={} and chargeBoxId={}", chargeBoxPk, chargeBoxId);
+            sessionContextStoreHolder.getOrCreate(version).closeSessions(chargeBoxId);
+        }
     }
 
     private void encodePasswordIfNeeded(ChargePointForm form) {


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix NullPointerException when deleting chargers without OCPP protocol

- Make basic auth username validation case-insensitive

- Add null check before closing WebSocket connections

- Improve error message clarity for authentication failures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Delete ChargePoint"] --> B{"OCPP Protocol exists?"}
  B -->|Yes| C["Close WebSocket Sessions"]
  B -->|No| D["Skip WS Closure"]
  E["Basic Auth Validation"] --> F["Case-insensitive Username Match"]
  F --> G["Authentication Result"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChargePointService.java</strong><dd><code>Fix null pointer and improve auth validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/de/rwth/idsg/steve/service/ChargePointService.java

<ul><li>Added null check for OCPP protocol before attempting to close <br>WebSocket sessions<br> <li> Prevents NullPointerException when protocol is not set during charger <br>deletion<br> <li> Changed basic auth username validation from case-sensitive to <br>case-insensitive using <code>equalsIgnoreCase()</code><br> <li> Updated error message to clarify case-insensitive validation failure</ul>


</details>


  </td>
  <td><a href="https://github.com/steve-community/steve/pull/1938/files#diff-400b24fa46176b032ed368600ae15532a1984baf9aced7e8841c8d80bdde6db0">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

