### PR TITLE
Fix OCPP response when Charger does not accept command

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/ocpp/CommunicationTask.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/CommunicationTask.java
@@ -145,6 +145,20 @@ public abstract class CommunicationTask<S extends ChargePointSelection, RESPONSE
         }
     }
 
+    /**
+     * Relevant to WebSocket/JSON transport: Handle OCPP error responses (e.g., NotImplemented, NotSupported)
+     * from charging stations. This iterates through all registered callbacks, not just the default one.
+     */
+    public void success(String chargeBoxId, OcppJsonError error) {
+        for (OcppCallback<RESPONSE> c : callbackList) {
+            try {
+                c.success(chargeBoxId, error);
+            } catch (Exception e) {
+                log.error("Exception occurred in OcppCallback", e);
+            }
+        }
+    }
+
     public <T extends ResponseType> AsyncHandler<T> getHandler(String chargeBoxId) {
         return switch (versionMap.get(chargeBoxId)) {
             case V_12 -> getOcpp12Handler(chargeBoxId);

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/CommunicationContext.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/CommunicationContext.java
@@ -68,9 +68,7 @@ public class CommunicationContext {
     }
 
     public void createErrorHandler(CommunicationTask task) {
-        // TODO: not so sure about this
-        errorHandler = result -> task.defaultCallback()
-                                     .success(chargeBoxId, result);
+        errorHandler = result -> task.success(chargeBoxId, result);
     }
 
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)


### PR DESCRIPTION
### **User description**
…tc.)

Previously, when a charging station responded with an OCPP error (e.g., NotImplemented, NotSupported), only the default callback was invoked via task.defaultCallback().success(). This bypassed all custom callbacks registered via task.addCallback().

The fix adds an overloaded success(String, OcppJsonError) method to CommunicationTask that iterates through all registered callbacks, consistent with how success responses are handled.


___

### **PR Type**
Bug fix


___

### **Description**
- Invoke all registered callbacks for OCPP error responses

- Previously only default callback was called for errors

- Add overloaded success method to iterate through callback list

- Update error handler to use new method instead of defaultCallback


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OCPP Error Response"] --> B["CommunicationContext.errorHandler"]
  B --> C["task.success with OcppJsonError"]
  C --> D["Iterate all callbacks"]
  D --> E["Invoke each callback.success"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommunicationTask.java</strong><dd><code>Add success method for OCPP error responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/de/rwth/idsg/steve/ocpp/CommunicationTask.java

<ul><li>Add overloaded <code>success(String chargeBoxId, OcppJsonError error)</code> method<br> <li> Iterates through all registered callbacks in <code>callbackList</code><br> <li> Handles exceptions per callback with error logging<br> <li> Mirrors existing pattern used in <code>failed()</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/steve-community/steve/pull/1939/files#diff-a3f6c72ffbf94f2bd80e49a5e822745f02fa96f4da939ce234599c1b6e77e9f4">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CommunicationContext.java</strong><dd><code>Update error handler to use new callback method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/de/rwth/idsg/steve/ocpp/ws/data/CommunicationContext.java

<ul><li>Replace <code>task.defaultCallback().success()</code> with <code>task.success()</code><br> <li> Use new overloaded method to invoke all callbacks<br> <li> Remove outdated TODO comment</ul>


</details>


  </td>
  <td><a href="https://github.com/steve-community/steve/pull/1939/files#diff-3bdfb2937ea9fc3e89af58e7b18065b447493107c54aac20a8be9c4b66317b7a">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

