### PR TITLE
Revert "Improve docker"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,26 @@
-# Build stage
-FROM eclipse-temurin:21-jdk AS builder
+FROM eclipse-temurin:21-jdk
+
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
-WORKDIR /code
+MAINTAINER Ling Li
 
-# Copy relevant project files to the build stage
-ADD /src /code/src
-ADD /pom.xml /code/pom.xml
-ADD mvnw /code/mvnw
-ADD .mvn /code/.mvn
-
-# Build the app
-RUN ./mvnw clean package -Pdocker -Djdk.tls.client.protocols="TLSv1.2,TLSv1.3"
-
-# Runtime stage
-FROM eclipse-temurin:21-jre
-ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
-
-# Create a non-root user and group
-RUN groupadd --system appgroup && useradd --system --gid appgroup appuser
-
-WORKDIR /code
-
-# Copy only the built WAR from builder stage and set ownership
-COPY --chown=appuser:appgroup --from=builder /code/target/steve.war ./steve.war
+# Download and install dockerize.
+# Needed so the web container will wait for MariaDB to start.
+ENV DOCKERIZE_VERSION v0.19.0
+RUN curl -sfL https://github.com/powerman/dockerize/releases/download/"$DOCKERIZE_VERSION"/dockerize-`uname -s`-`uname -m` | install /dev/stdin /usr/local/bin/dockerize
 
 EXPOSE 8180
 EXPOSE 8443
+WORKDIR /code
 
-# Switch to the non-root user
-USER appuser
+VOLUME ["/code"]
 
-# Run the app
-CMD ["java", "-Djdk.tls.client.protocols=TLSv1.2,TLSv1.3", "-XX:MaxRAMPercentage=85", "-jar", "steve.war"]
+# Copy the application's code
+COPY . /code
+
+# Wait for the db to startup(via dockerize), then 
+# Build and run steve, requires a db to be available on port 3306
+CMD dockerize -wait tcp://mariadb:3306 -timeout 60s && \
+	./mvnw clean package -Pdocker -Djdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2" && \
+	java -XX:MaxRAMPercentage=85 -jar target/steve.war
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,11 @@
+version: "3.0"
+
 volumes:
   db-data:
     external: false
 
 services:
+
   db:
     # Pinning MariaDB to point release 10.4.30 works around the issues with the
     # database migrations seen with 10.4.31 in issue #1212.
@@ -18,21 +21,16 @@ services:
       MYSQL_DATABASE: stevedb
       MYSQL_USER: steve
       MYSQL_PASSWORD: changeme
-    # https://mariadb.com/docs/server/server-management/automated-mariadb-deployment-and-administration/docker-and-mariadb/using-healthcheck-sh
-    healthcheck:
-      test: [ "CMD", "healthcheck.sh", "--connect", "--innodb_initialized" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
   app:
     restart: unless-stopped
     build: .
     links:
       - "db:mariadb"
+    volumes:
+      - .:/code
     ports:
       - "8180:8180"
       - "8443:8443"
     depends_on:
-      db:
-        condition: service_healthy
+      - db
+    

--- a/k8s/docker/Dockerfile
+++ b/k8s/docker/Dockerfile
@@ -1,5 +1,7 @@
-# Build stage
-FROM eclipse-temurin:21-jdk AS builder
+FROM eclipse-temurin:21-jdk AS base
+MAINTAINER daynnnnn
+
+# Setting environment variables
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # Arguments for database configuration
@@ -9,10 +11,15 @@ ARG DB_PASSWORD
 ARG DB_DATABASE
 ARG DB_PORT
 
+# Build Stage
+FROM base as build
+
+# Set the working directory for the build stage
 WORKDIR /code
 
-# Copy relevant project files to the build stage
+# Copy project files to the build stage
 ADD /src /code/src
+ADD /website /code/website
 ADD /pom.xml /code/pom.xml
 ADD mvnw /code/mvnw
 ADD .mvn /code/.mvn
@@ -28,26 +35,18 @@ RUN sed -i 's|${server.host}|${env.SERVER_HOST}|g' pom.xml
 # Make the Maven wrapper executable
 RUN chmod +x mvnw
 
-# Build the app
-RUN ./mvnw clean package -Pkubernetes -Djdk.tls.client.protocols="TLSv1.2,TLSv1.3"
+# Build the project
+RUN ./mvnw clean package -Pkubernetes -Djdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2"
 
-# Runtime stage
-FROM eclipse-temurin:21-jre
-ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+# Release Stage
+FROM base AS release
 
-# Create a non-root user and group
-RUN groupadd --system appgroup && useradd --system --gid appgroup appuser
-
-WORKDIR /code
-
-# Copy only the built WAR from builder stage and set ownership
-COPY --chown=appuser:appgroup --from=builder /code/target/steve.war ./steve.war
+# Copy relevant files from the build stage
+COPY --from=build /code/target/steve.jar /app/steve.war
+COPY --from=build /code/target/libs /app/libs
 
 # Expose any necessary ports (example: 8080)
 EXPOSE 8080
 
-# Switch to the non-root user
-USER appuser
-
-# Run the app
-CMD ["java", "-Djdk.tls.client.protocols=TLSv1.2,TLSv1.3", "-jar", "steve.war"]
+# Define the entrypoint for the release stage
+CMD ["java", "-jar", "/app/steve.war"]


### PR DESCRIPTION
### **User description**
Reverts steve-community/steve#1921

because of issues expressed in https://github.com/steve-community/steve/issues/1923


___

### **PR Type**
Bug fix


___

### **Description**
- Reverts multi-stage Docker build improvements due to reported issues

- Restores simpler single-stage Dockerfile with dockerize dependency

- Removes health checks and non-root user security hardening

- Reverts Kubernetes Dockerfile to previous multi-stage configuration

- Simplifies docker-compose dependencies from health checks to basic service ordering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Multi-stage optimized Dockerfile"] -->|Revert| B["Single-stage with dockerize"]
  C["Health checks enabled"] -->|Remove| D["Basic depends_on"]
  E["Non-root user appuser"] -->|Remove| F["Root user execution"]
  G["JDK-only to JRE runtime"] -->|Revert| H["JDK runtime"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Revert to single-stage Docker build with dockerize</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<ul><li>Reverts from multi-stage build (builder + runtime) to single-stage <br>using JDK<br> <li> Removes non-root user creation and permission management<br> <li> Adds dockerize utility for MariaDB startup synchronization<br> <li> Changes build and run to single CMD with dockerize wait logic<br> <li> Downgrades TLS protocols from TLSv1.2,TLSv1.3 to TLSv1,TLSv1.1,TLSv1.2</ul>


</details>


  </td>
  <td><a href="https://github.com/steve-community/steve/pull/1948/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+17/-26</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Remove health checks and simplify service dependencies</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<ul><li>Adds explicit version specification (3.0)<br> <li> Removes MariaDB health check configuration<br> <li> Changes app service depends_on from health check condition to simple <br>service list<br> <li> Adds volume mount for code directory in app service<br> <li> Removes health check test, interval, timeout, and retries <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/steve-community/steve/pull/1948/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+7/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Restructure Kubernetes Dockerfile with base stage pattern</code></dd></summary>
<hr>

k8s/docker/Dockerfile

<ul><li>Renames builder stage to base and adds maintainer label<br> <li> Introduces separate build and release stages from common base<br> <li> Adds website directory to build stage copy operations<br> <li> Changes TLS protocols from TLSv1.2,TLSv1.3 to TLSv1,TLSv1.1,TLSv1.2<br> <li> Removes non-root user creation and switches back to root execution<br> <li> Simplifies runtime stage to copy artifacts and run java command</ul>


</details>


  </td>
  <td><a href="https://github.com/steve-community/steve/pull/1948/files#diff-4700607ddda1fd4eb255be5e10d7ee9e4d96a6912a82bda1383d4ef54286c13e">+19/-20</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

