### PR TITLE
close session if PingTask fails

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketLogger.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketLogger.java
@@ -82,4 +82,12 @@ public final class WebSocketLogger {
             log.error("[chargeBoxId={}, sessionId={}] Transport error", chargeBoxId, session.getId(), t);
         }
     }
+
+    public static void closingDangling(String chargeBoxId, WebSocketSession session) {
+        log.warn("[chargeBoxId={}, sessionId={}] Closing a dangling WebSocketSession", chargeBoxId, session.getId());
+    }
+
+    public static void closingDanglingError(String chargeBoxId, WebSocketSession session, Throwable t) {
+        log.error("[chargeBoxId={}, sessionId={}] Error while trying to close the WebSocketSession", chargeBoxId, session.getId(), t);
+    }
 }


### PR DESCRIPTION
we have some stations with periodic "Ping error" logs:

```
[...] Ping error
java.nio.channels.ClosedChannelException
	at org.eclipse.jetty.websocket.core.internal.WebSocketSessionState.onOutgoingFrame(WebSocketSessionState.java:184)
	at org.eclipse.jetty.websocket.core.WebSocketCoreSession.sendFrame(WebSocketCoreSession.java:509)
	at org.eclipse.jetty.websocket.core.OutgoingFrames.sendFrame(OutgoingFrames.java:42)
	at org.eclipse.jetty.websocket.common.WebSocketSession.sendPing(WebSocketSession.java:149)
	at org.springframework.web.socket.adapter.jetty.JettyWebSocketSession.lambda$sendPingMessage$0(JettyWebSocketSession.java:213)
	at org.springframework.web.socket.adapter.jetty.JettyWebSocketSession.useSession(JettyWebSocketSession.java:229)
	at org.springframework.web.socket.adapter.jetty.JettyWebSocketSession.sendPingMessage(JettyWebSocketSession.java:213)
	at org.springframework.web.socket.adapter.AbstractWebSocketSession.sendMessage(AbstractWebSocketSession.java:112)
	at org.springframework.web.socket.handler.ConcurrentWebSocketSessionDecorator.tryFlushMessageBuffer(ConcurrentWebSocketSessionDecorator.java:197)
	at org.springframework.web.socket.handler.ConcurrentWebSocketSessionDecorator.sendMessage(ConcurrentWebSocketSessionDecorator.java:170)
	at de.rwth.idsg.steve.ocpp.ws.PingTask.run(PingTask.java:47)
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at co.powerfill.management.config.TenantAwareRunnable.run(TenantAwareRunnable.java:44)
	at org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler$DelegatingRunnableScheduledFuture.run(ThreadPoolTaskScheduler.java:453)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

the underlying jetty websocket impl checks the whether the output is open before sending the ping frame, and throws this exception since it is not the case.