### PR TITLE
make profile assignment insert idempotent and warn on ignored duplicate

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ChargingProfileRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ChargingProfileRepositoryImpl.java
@@ -76,10 +76,15 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
                                                                      .where(CONNECTOR.CHARGE_BOX_ID.eq(chargeBoxId))
                                                                      .and(CONNECTOR.CONNECTOR_ID.eq(connectorId));
 
-        ctx.insertInto(CONNECTOR_CHARGING_PROFILE)
-           .set(CONNECTOR_CHARGING_PROFILE.CONNECTOR_PK, connectorPkSelect)
-           .set(CONNECTOR_CHARGING_PROFILE.CHARGING_PROFILE_PK, chargingProfilePk)
-           .execute();
+        int count = ctx.insertInto(CONNECTOR_CHARGING_PROFILE)
+                       .set(CONNECTOR_CHARGING_PROFILE.CONNECTOR_PK, connectorPkSelect)
+                       .set(CONNECTOR_CHARGING_PROFILE.CHARGING_PROFILE_PK, chargingProfilePk)
+                       .onDuplicateKeyIgnore()
+                       .execute();
+
+        if (count == 0) {
+            log.warn("Could not insert charging profile assignment (maybe duplicate?). chargeBoxId={}, connectorId={}, chargingProfilePk={}", chargeBoxId, connectorId, chargingProfilePk);
+        }
     }
 
     @Override


### PR DESCRIPTION
* use onDuplicateKeyIgnore() when inserting into connector_charging_profile
* prevent IntegrityConstraintViolationException on repeated setProfile(..) calls
* add warning log when insert is ignored (count == 0) to surface likely duplicate assignment attempts