### PR TITLE
fix: use resolved timestamp in SuspendedEV notification

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_Service.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_Service.java
@@ -177,7 +177,7 @@ public class CentralSystemService16_Service {
 
          if (parameters.getStatus() == SUSPENDED_EV) {
             applicationEventPublisher.publishEvent(new OcppStationStatusSuspendedEV(
-                    chargeBoxIdentity, parameters.getConnectorId(), parameters.getTimestamp()));
+                    chargeBoxIdentity, parameters.getConnectorId(), timestamp));
         }
 
         // https://github.com/steve-community/steve/issues/1398


### PR DESCRIPTION
The `statusNotification` handler resolves the optional timestamp field, falling back to `DateTime.now()` when the charge point doesn't set it (line 157):

    DateTime timestamp = parameters.isSetTimestamp() ? parameters.getTimestamp() : DateTime.now();

This resolved `timestamp` is correctly used for the connector status insert and the reservation cancellation path. However, the `SUSPENDED_EV` event was passing `parameters.getTimestamp()` directly — which is null when the field is unset.

I noticed this while reading through the notification flow. The `OcppStationStatusSuspendedEV` event carries the null timestamp to both `NotificationService` and `NotificationServiceForUser`, which then use it in email bodies. Depending on downstream handling, this could also cause a NullPointerException.

The fix is a one-liner: use the already-resolved `timestamp` local variable instead of `parameters.getTimestamp()`.