### PR TITLE
remove hardcoding of mysql where possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,10 @@
                     <table>schema_version</table>
 
                     <cleanDisabled>true</cleanDisabled>
-                    <driver>com.mysql.cj.jdbc.Driver</driver>
+                    <!--  By default, the driver is autodetected based on the url.
+                          See org.flywaydb.maven.AbstractFlywayMojo#driver at
+                          https://github.com/flyway/flyway/blob/main/flyway-plugins/flyway-maven-plugin/src/main/java/org/flywaydb/maven/AbstractFlywayMojo.java#L83 -->
+                    <!-- <driver>...</driver> -->
                     <url>${jdbcUrl}</url>
                     <user>${db.user}</user>
                     <password>${db.password}</password>
@@ -280,6 +283,8 @@
                     </locations>
                 </configuration>
                 <dependencies>
+                    <!-- MariaDB is supported by the same dependency.
+                         https://documentation.red-gate.com/flyway/reference/database-driver-reference/mariadb -->
                     <dependency>
                         <groupId>org.flywaydb</groupId>
                         <artifactId>flyway-mysql</artifactId>
@@ -326,7 +331,10 @@
                      http://www.jooq.org/doc/3.5/manual/code-generation/codegen-advanced/ -->
                 <configuration>
                     <jdbc>
-                        <driver>com.mysql.cj.jdbc.Driver</driver>
+                        <!-- If not set, generator infers from url.
+                             See org.jooq.codegen.GenerationTool#driverClass(org.jooq.meta.jaxb.Jdbc) at
+                             https://github.com/jOOQ/jOOQ/blob/main/jOOQ-codegen/src/main/java/org/jooq/codegen/GenerationTool.java#L1294 -->
+                        <!-- <driver>...</driver> -->
                         <url>${jdbcUrl}</url>
                         <user>${db.user}</user>
                         <password>${db.password}</password>
@@ -334,7 +342,9 @@
 
                     <generator>
                         <database>
-                            <name>org.jooq.meta.mysql.MySQLDatabase</name>
+                            <!-- The default database name, if no name is supplied, will be derived from the JDBC connection.
+                                 https://www.jooq.org/doc/latest/manual/code-generation/codegen-advanced/codegen-config-database/codegen-database-name/ -->
+                            <!-- <name>...</name> -->
                             <includes>.*</includes>
                             <excludes/>
                             <inputSchema>${db.schema}</inputSchema>

--- a/src/main/java/de/rwth/idsg/steve/config/BeanConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/BeanConfiguration.java
@@ -32,6 +32,7 @@ import org.jooq.conf.Settings;
 import org.jooq.impl.DSL;
 import org.jooq.impl.DataSourceConnectionProvider;
 import org.jooq.impl.DefaultConfiguration;
+import org.jooq.tools.jdbc.JDBCUtils;
 import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer;
 import org.springframework.boot.jdbc.autoconfigure.DataSourceProperties;
 import org.springframework.context.annotation.Bean;
@@ -40,7 +41,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -48,7 +48,7 @@ import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import tools.jackson.datatype.joda.JodaModule;
 
 import javax.sql.DataSource;
-
+import java.sql.SQLException;
 import java.time.Clock;
 
 import static tools.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
@@ -100,6 +100,26 @@ public class BeanConfiguration implements WebMvcConfigurer {
     }
 
     /**
+     * We are using the same strategy as Spring Boot's auto-detection.
+     *
+     * https://github.com/spring-projects/spring-boot/blob/main/module/spring-boot-jooq/src/main/java/org/springframework/boot/jooq/autoconfigure/SqlDialectLookup.java
+     */
+    @Bean
+    public SQLDialect jooqSqlDialect(DataSource dataSource) {
+        SQLDialect fallback = SQLDialect.MYSQL;
+
+        try (var connection = dataSource.getConnection()) {
+            var dialect = JDBCUtils.dialect(connection);
+            var dialectToReturn = (dialect == SQLDialect.DEFAULT) ? fallback : dialect;
+            log.info("Using jOOQ dialect {}", dialectToReturn);
+            return dialectToReturn;
+        } catch (SQLException e) {
+            log.warn("Could not detect database dialect. Falling back to jOOQ dialect {}.", fallback, e);
+            return fallback;
+        }
+    }
+
+    /**
      * Can we re-use DSLContext as a Spring bean (singleton)? Yes, the Spring tutorial of
      * Jooq also does it that way, but only if we do not change anything about the
      * config after the init (which we don't do anyways) and if the ConnectionProvider
@@ -113,7 +133,8 @@ public class BeanConfiguration implements WebMvcConfigurer {
      */
     @Bean
     public DSLContext dslContext(DataSource dataSource,
-                                 SteveProperties steveProperties) {
+                                 SteveProperties steveProperties,
+                                 SQLDialect jooqSqlDialect) {
         Settings settings = new Settings()
                 // Normally, the records are "attached" to the Configuration that created (i.e. fetch/insert) them.
                 // This means that they hold an internal reference to the same database connection that was used.
@@ -125,7 +146,7 @@ public class BeanConfiguration implements WebMvcConfigurer {
 
         // Configuration for JOOQ
         org.jooq.Configuration conf = new DefaultConfiguration()
-                .set(SQLDialect.MYSQL)
+                .set(jooqSqlDialect)
                 .set(new DataSourceConnectionProvider(dataSource))
                 .set(settings);
 


### PR DESCRIPTION
and let the underlying plugins/components _derive_ the database driver or dialect from JDBC url or live database connection.