### PR TITLE
Proper mariadb support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
         run: ./mvnw -B -V -Dmaven.javadoc.skip=true -Ptest,${{ matrix.database.databaseName }} clean package --file pom.xml
 
       - name: Run integration tests (*IT)
-        #if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: ./mvnw -B -V -Dmaven.javadoc.skip=true -Ptest,${{ matrix.database.databaseName }} -Dtest='*IT' test --file pom.xml
 
       - name: Start the app and visit signin web page

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,7 @@ jobs:
             command: '--innodb-use-native-aio=0'
             healthCmd: 'healthcheck.sh --connect --innodb_initialized'
     runs-on: ${{ matrix.os }}
+    name: java:${{ matrix.java }}, ${{ matrix.database.image }}
     services:
       db:
         image: ${{ matrix.database.image }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,28 +8,38 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         java: [ '21', '23', '25' ]
-        db: [ 'mysql:8.0', 'mysql:8.4', 'mariadb:10.6.25', 'mariadb:10.11.16']
+        database:
+          - image: 'mysql:8.0'
+            databaseName: 'mysql'
+          - image: 'mysql:8.4'
+            databaseName: 'mysql'
+          - image: 'mariadb:10.6.25'
+            databaseName: 'mariadb'
+          - image: 'mariadb:10.11.16'
+            databaseName: 'mariadb'
     runs-on: ${{ matrix.os }}
     services:
-      mysql:
-        image: ${{ matrix.db }}
+      db:
+        image: ${{ matrix.database.image }}
         env:
           MYSQL_ROOT_PASSWORD: root
+          MARIADB_ROOT_PASSWORD: root
           MYSQL_DATABASE: root
+          MARIADB_DATABASE: root
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Java ${{ matrix.Java }}
+      - name: Set up Java ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: maven
 
-      - name: Set up MySQL
+      - name: Set up database
         run: |
           mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "SELECT @@VERSION;"
           mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "CREATE DATABASE stevedb_test_2aa6a783d47d;" -v
@@ -37,11 +47,11 @@ jobs:
           mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "GRANT ALL PRIVILEGES ON stevedb_test_2aa6a783d47d.* TO 'steve'@'%';" -v
 
       - name: Build with Maven
-        run: ./mvnw -B -V -Dmaven.javadoc.skip=true -Ptest clean package --file pom.xml
+        run: ./mvnw -B -V -Dmaven.javadoc.skip=true -Ptest,${{ matrix.database.databaseName }} clean package --file pom.xml
 
       - name: Run integration tests (*IT)
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        run: ./mvnw -B -V -Dmaven.javadoc.skip=true -Ptest -Dtest='*IT' test --file pom.xml
+        run: ./mvnw -B -V -Dmaven.javadoc.skip=true -Ptest,${{ matrix.database.databaseName }} -Dtest='*IT' test --file pom.xml
 
       - name: Start the app and visit signin web page
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./mvnw -B -V -Dmaven.javadoc.skip=true -Ptest,${{ matrix.database.databaseName }} clean package --file pom.xml
 
       - name: Run integration tests (*IT)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        #if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: ./mvnw -B -V -Dmaven.javadoc.skip=true -Ptest,${{ matrix.database.databaseName }} -Dtest='*IT' test --file pom.xml
 
       - name: Start the app and visit signin web page

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,20 +11,33 @@ jobs:
         database:
           - image: 'mysql:8.0'
             databaseName: 'mysql'
+            command: ''
+            healthCmd: 'mysqladmin ping'
           - image: 'mysql:8.4'
             databaseName: 'mysql'
+            command: ''
+            healthCmd: 'mysqladmin ping'
           - image: 'mariadb:10.6.25'
             databaseName: 'mariadb'
+            command: '--innodb-use-native-aio=0'
+            healthCmd: 'healthcheck.sh --connect --innodb_initialized'
           - image: 'mariadb:10.11.16'
             databaseName: 'mariadb'
+            command: '--innodb-use-native-aio=0'
+            healthCmd: 'healthcheck.sh --connect --innodb_initialized'
           - image: 'mariadb:11.4.10'
             databaseName: 'mariadb'
+            command: '--innodb-use-native-aio=0'
+            healthCmd: 'healthcheck.sh --connect --innodb_initialized'
           - image: 'mariadb:11.8.6'
             databaseName: 'mariadb'
+            command: '--innodb-use-native-aio=0'
+            healthCmd: 'healthcheck.sh --connect --innodb_initialized'
     runs-on: ${{ matrix.os }}
     services:
       db:
         image: ${{ matrix.database.image }}
+        command: ${{ matrix.database.command }}
         env:
           MYSQL_ROOT_PASSWORD: root
           MARIADB_ROOT_PASSWORD: root
@@ -32,7 +45,7 @@ jobs:
           MARIADB_DATABASE: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="${{ matrix.database.healthCmd }}" --health-interval=10s --health-timeout=5s --health-retries=6
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,10 @@ jobs:
             databaseName: 'mariadb'
           - image: 'mariadb:10.11.16'
             databaseName: 'mariadb'
+          - image: 'mariadb:11.4.10'
+            databaseName: 'mariadb'
+          - image: 'mariadb:11.8.6'
+            databaseName: 'mariadb'
     runs-on: ${{ matrix.os }}
     services:
       db:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,5 @@ COPY . /code
 # Wait for the db to startup(via dockerize), then 
 # Build and run steve, requires a db to be available on port 3306
 CMD dockerize -wait tcp://mariadb:3306 -timeout 60s && \
-	./mvnw clean package -Pdocker -Djdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2" && \
+	./mvnw clean package -Pdocker,mariadb -Djdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2" && \
 	java -XX:MaxRAMPercentage=85 -jar target/steve.war
-

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See [dedicated Wiki page](https://github.com/steve-community/steve/wiki/OCPP-1.6
 SteVe requires 
 * JDK 21 or newer
 * Maven 
-* MySQL or MariaDB. You should use [one of these](.github/workflows/main.yml#L11) supported versions.
+* MySQL or MariaDB. You should use [one of these](.github/workflows/main.yml#L11-L35) supported versions.
 
 to build and run. 
 
@@ -94,7 +94,13 @@ SteVe is designed to run standalone, a java servlet container / web server (e.g.
     To compile SteVe simply use Maven. A runnable `war` file containing the application and configuration will be created in the subdirectory `steve/target`.
 
     ```
-    # ./mvnw package
+    # ./mvnw package -Pprod,mysql
+    ```
+
+    To build against MariaDB instead, use:
+
+    ```
+    # ./mvnw package -Pprod,mariadb
     ```
 
 5. Run SteVe:

--- a/k8s/docker/Dockerfile
+++ b/k8s/docker/Dockerfile
@@ -35,8 +35,8 @@ RUN sed -i 's|${server.host}|${env.SERVER_HOST}|g' pom.xml
 # Make the Maven wrapper executable
 RUN chmod +x mvnw
 
-# Build the project
-RUN ./mvnw clean package -Pkubernetes -Djdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2"
+# Build the project (assuming mariadb)
+RUN ./mvnw clean package -Pkubernetes,mariadb -Djdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2"
 
 # Release Stage
 FROM base AS release

--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,10 @@
 
         <cxf.version>4.2.0</cxf.version>
         <plugin.license-maven.version>5.0.0</plugin.license-maven.version>
-
-        <!-- In Mysql: schema == database (http://dev.mysql.com/doc/refman/5.6/en/glossary.html#glos_schema) -->
-        <jdbcUrl>jdbc:mysql://${db.ip}:${db.port}/${db.schema}?useSSL=true&amp;serverTimezone=UTC</jdbcUrl>
     </properties>
 
     <profiles>
+        <!-- Dimension 1: Env profiles -->
         <profile>
             <id>prod</id>
             <activation>
@@ -87,6 +85,38 @@
                 <envName>test</envName>
                 <skipTests>false</skipTests>
             </properties>
+        </profile>
+
+        <!-- Dimension 2: Database profiles -->
+        <profile>
+            <id>mysql</id>
+            <properties>
+                <databaseName>mysql</databaseName>
+                <!-- In Mysql: schema == database (http://dev.mysql.com/doc/refman/5.6/en/glossary.html#glos_schema) -->
+                <jdbcUrl>jdbc:mysql://${db.ip}:${db.port}/${db.schema}?useSSL=true&amp;serverTimezone=UTC</jdbcUrl>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>com.mysql</groupId>
+                    <artifactId>mysql-connector-j</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>mariadb</id>
+            <properties>
+                <databaseName>mariadb</databaseName>
+                <!-- In MariaDB: schema == database (https://mariadb.com/docs/connectors/mariadb-connector-j/about-mariadb-connector-j) -->
+                <jdbcUrl>jdbc:mariadb://${db.ip}:${db.port}/${db.schema}?useSSL=false&amp;serverTimezone=UTC</jdbcUrl>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mariadb.jdbc</groupId>
+                    <artifactId>mariadb-java-client</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 
@@ -325,6 +355,11 @@
                         <artifactId>mysql-connector-j</artifactId>
                         <version>${mysql.version}</version>
                     </dependency>
+                    <dependency>
+                        <groupId>org.mariadb.jdbc</groupId>
+                        <artifactId>mariadb-java-client</artifactId>
+                        <version>${mariadb.version}</version>
+                    </dependency>
                 </dependencies>
 
                 <!-- http://www.jooq.org/doc/3.5/manual/code-generation/codegen-configuration/
@@ -536,10 +571,6 @@
         </dependency>
 
         <!-- DB -->
-        <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>

--- a/src/main/java/de/rwth/idsg/steve/config/BeanConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/BeanConfiguration.java
@@ -18,7 +18,6 @@
  */
 package de.rwth.idsg.steve.config;
 
-import com.mysql.cj.conf.PropertyKey;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import de.rwth.idsg.steve.service.DummyReleaseCheckService;
@@ -85,13 +84,15 @@ public class BeanConfiguration implements WebMvcConfigurer {
         hc.setPassword(properties.getPassword());
 
         // set non-standard params
-        hc.addDataSourceProperty(PropertyKey.cachePrepStmts.getKeyName(), true);
-        hc.addDataSourceProperty(PropertyKey.useServerPrepStmts.getKeyName(), true);
-        hc.addDataSourceProperty(PropertyKey.prepStmtCacheSize.getKeyName(), 250);
-        hc.addDataSourceProperty(PropertyKey.prepStmtCacheSqlLimit.getKeyName(), 2048);
-        hc.addDataSourceProperty(PropertyKey.characterEncoding.getKeyName(), "utf8");
-        hc.addDataSourceProperty(PropertyKey.connectionTimeZone.getKeyName(), SteveProperties.TIME_ZONE_ID);
-        hc.addDataSourceProperty(PropertyKey.useSSL.getKeyName(), true);
+        // https://dev.mysql.com/doc/connector-j/en/connector-j-reference-configuration-properties.html
+        // https://mariadb.com/docs/connectors/mariadb-connector-j/about-mariadb-connector-j
+        hc.addDataSourceProperty("cachePrepStmts", true);
+        hc.addDataSourceProperty("useServerPrepStmts", true);
+        hc.addDataSourceProperty("prepStmtCacheSize", 250);
+        hc.addDataSourceProperty("prepStmtCacheSqlLimit", 2048);
+        hc.addDataSourceProperty("characterEncoding", "utf8");
+        hc.addDataSourceProperty("connectionTimeZone", SteveProperties.TIME_ZONE_ID);
+        hc.addDataSourceProperty("useSSL", true);
 
         // https://github.com/steve-community/steve/issues/736
         hc.setMaxLifetime(580_000);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: steve
   datasource:
-    url: jdbc:mysql://${db.ip}:${db.port}/${db.schema}
+    url: jdbc:@databaseName@://${db.ip}:${db.port}/${db.schema}
     username: ${db.user}
     password: ${db.password}
   servlet:


### PR DESCRIPTION
this PR essentially adds a new dimension of database-related maven profiles: `mysql` and `mariadb`. the choice dictates 
- the JDBC driver dependency we add, and 
- the construction of the JDBC URL: the format of JDBC URL (whether `jdbc:mysql://...` or `jdbc:mariadb://...`) is very important for underlying plugins/components derive the database driver or dialect. preparation of this aspect came with https://github.com/steve-community/steve/pull/2009.

as a consequence, builds need to reference the new profile (i.e. database choice) as well, for ex:

```
mvn package -P dev,mariadb
mvn package -P dev,mysql
mvn package -P prod,mariadb
mvn package -P prod,mysql
```

--

also somewhat related: this PR adds support for the recent mariadb LTS versions 11.4.10 and 11.8.6.

--

TODOs:
- [x] update docs and add second profile
- [x] update docker-related configurations and add second profile