### PR TITLE
improve and tighten impl of local CSR signing, improve OCPP-spec conformity

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/config/OcppConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/OcppConfiguration.java
@@ -26,13 +26,17 @@ import de.rwth.idsg.steve.ocpp.soap.LoggingFeatureProxy;
 import de.rwth.idsg.steve.ocpp.soap.MediatorInInterceptor;
 import de.rwth.idsg.steve.ocpp.soap.MessageHeaderInterceptor;
 import de.rwth.idsg.steve.ocpp.soap.MessageIdInterceptor;
+import de.rwth.idsg.steve.service.CertificateSigningService;
+import de.rwth.idsg.steve.service.CertificateSigningServiceDisabled;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.cxf.Bus;
 import org.apache.cxf.feature.Feature;
 import org.apache.cxf.interceptor.Interceptor;
 import org.apache.cxf.jaxws.EndpointImpl;
 import org.apache.cxf.message.Message;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -46,6 +50,7 @@ import java.util.List;
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 18.11.2014
  */
+@Slf4j
 @RequiredArgsConstructor
 @Configuration
 public class OcppConfiguration {
@@ -54,6 +59,14 @@ public class OcppConfiguration {
     private final MessageHeaderInterceptor messageHeaderInterceptor;
 
     private final MessageIdInterceptor messageIdInterceptor = new MessageIdInterceptor();
+
+    @Bean
+    @ConditionalOnMissingBean(CertificateSigningService.class)
+    public CertificateSigningService certificateSigningService(SteveProperties props) {
+        String provider = props.getOcpp().getSecurity().getCsrSigning().getProvider();
+        log.info("Defaulting to CertificateSigningServiceDisabled, because steve.ocpp.security.csr-signing.provider={} is not activating a Spring Bean for CertificateSigningService", provider);
+        return new CertificateSigningServiceDisabled();
+    }
 
     @Bean
     @Conditional(OcppEnabledCondition.V12.Soap.class)

--- a/src/main/java/de/rwth/idsg/steve/config/SteveProperties.java
+++ b/src/main/java/de/rwth/idsg/steve/config/SteveProperties.java
@@ -20,6 +20,7 @@ package de.rwth.idsg.steve.config;
 
 import de.rwth.idsg.steve.ocpp.ws.custom.WsSessionSelectStrategyEnum;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -88,12 +89,34 @@ public class SteveProperties {
 
         @Data
         public static class Security {
-            private int profile;
-            private int certificateValidityYears;
             private String clientCertHeaderFromProxy;
+            private CsrSigning csrSigning = new CsrSigning();
 
-            public boolean requiresTls() {
-                return profile >= 2;
+            @Data
+            public static class CsrSigning {
+                private String provider;
+                private LocalCsrSigning providerLocal = new LocalCsrSigning();
+
+                @Data
+                public static class LocalCsrSigning {
+                    private Integer certificateValidityYears;
+                    private String caCertificatePem;
+                    private String caKeyPem;
+                    private String caChainPem;
+                    private SignatureAlgorithmPolicy signatureAlgorithmPolicy = SignatureAlgorithmPolicy.AUTO;
+
+                    public enum SignatureAlgorithmPolicy {
+                        AUTO,
+                        RSA_PSS,
+                        RSA_PKCS1
+                    }
+
+                    public boolean isValid() {
+                        return certificateValidityYears != null
+                            && !StringUtils.isBlank(caCertificatePem)
+                            && !StringUtils.isBlank(caKeyPem);
+                    }
+                }
             }
         }
     }

--- a/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_Service.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_Service.java
@@ -69,6 +69,7 @@ import ocpp.cs._2015._10.StatusNotificationRequest;
 import ocpp.cs._2015._10.StatusNotificationResponse;
 import ocpp.cs._2015._10.StopTransactionRequest;
 import ocpp.cs._2015._10.StopTransactionResponse;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.joda.time.DateTime;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.TaskScheduler;
@@ -338,14 +339,12 @@ public class CentralSystemService16_Service {
 
     public SignCertificateResponse signCertificate(SignCertificate parameters, String chargeBoxIdentity) {
         try {
-            if (!certificateSigningService.isEnabled()) {
-                log.error("Certificate signing service is not enabled.");
-                return new SignCertificateResponse().withStatus(GenericStatusEnumType.REJECTED);
-            }
-
-            var csr = parameters.getCsr();
-            if (csr == null || csr.trim().isEmpty()) {
-                log.error("Empty or null CSR received from '{}'", chargeBoxIdentity);
+            PKCS10CertificationRequest csr;
+            try {
+                var csrPem = parameters.getCsr();
+                csr = certificateSigningService.validateCSR(csrPem, chargeBoxIdentity);
+            } catch (Exception e) {
+                log.error("Could not validate CSR from '{}'", chargeBoxIdentity, e);
                 return new SignCertificateResponse().withStatus(GenericStatusEnumType.REJECTED);
             }
 
@@ -357,7 +356,7 @@ public class CentralSystemService16_Service {
              * subsequent process)
              */
             taskScheduler.schedule(
-                () -> certificateSigningService.processCSR(csr, chargeBoxIdentity),
+                () -> certificateSigningService.processAndSendToStation(csr, chargeBoxIdentity),
                 Instant.now().plusSeconds(5)
             );
 

--- a/src/main/java/de/rwth/idsg/steve/service/CertificateSigningService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CertificateSigningService.java
@@ -18,9 +18,11 @@
  */
 package de.rwth.idsg.steve.service;
 
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+
 public interface CertificateSigningService {
 
-    boolean isEnabled();
+    PKCS10CertificationRequest validateCSR(String csrPem, String chargeBoxId);
 
-    void processCSR(String csrPem, String chargeBoxId);
+    void processAndSendToStation(PKCS10CertificationRequest csr, String chargeBoxId);
 }

--- a/src/main/java/de/rwth/idsg/steve/service/CertificateSigningServiceDisabled.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CertificateSigningServiceDisabled.java
@@ -18,24 +18,19 @@
  */
 package de.rwth.idsg.steve.service;
 
-import jooq.steve.db.tables.records.CertificateRecord;
-import org.slf4j.Logger;
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
-public abstract class CertificateSigningServiceAbstract implements CertificateSigningService {
+@Slf4j
+public class CertificateSigningServiceDisabled implements CertificateSigningService {
 
     @Override
-    public void processCSR(String csrPem, String chargeBoxId) {
-        try {
-            CertificateRecord record = this.signCertificate(csrPem, chargeBoxId);
-            this.sendCertificateSignedToStation(record, chargeBoxId);
-        } catch (Exception e) {
-            getLog().error(e.getMessage(), e);
-        }
+    public PKCS10CertificationRequest validateCSR(String csrPem, String chargeBoxId) {
+        throw new RuntimeException("validateCSR is not implemented");
     }
 
-    protected abstract Logger getLog();
-
-    protected abstract CertificateRecord signCertificate(String csrPem, String chargeBoxId) throws Exception;
-
-    protected abstract void sendCertificateSignedToStation(CertificateRecord record, String chargeBoxId);
+    @Override
+    public void processAndSendToStation(PKCS10CertificationRequest csr, String chargeBoxId) {
+        log.warn("processAndSendToStation is not implemented");
+    }
 }

--- a/src/main/java/de/rwth/idsg/steve/service/CertificateSigningServiceLocal.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CertificateSigningServiceLocal.java
@@ -132,13 +132,13 @@ public class CertificateSigningServiceLocal implements CertificateSigningService
         try {
             csr = CertificateUtils.parseCsr(csrPem);
         } catch (Exception e) {
-            throw new IllegalArgumentException("Cannot parse CSR from " + chargeBoxId);
+            throw new IllegalArgumentException("Cannot parse CSR from " + chargeBoxId, e);
         }
 
         try {
             validateCsr(csr, chargeBoxId);
         } catch (Exception e) {
-            throw new IllegalArgumentException("Could not validate CSR from " + chargeBoxId);
+            throw new IllegalArgumentException("Could not validate CSR from " + chargeBoxId, e);
         }
 
         return csr;
@@ -149,7 +149,7 @@ public class CertificateSigningServiceLocal implements CertificateSigningService
         try {
             processAndSendToStationInternal(csr, chargeBoxId);
         } catch (Exception e) {
-            log.error("Exception happened", e);
+            log.error("Exception happened for {}", chargeBoxId, e);
         }
     }
 

--- a/src/main/java/de/rwth/idsg/steve/service/CertificateSigningServiceLocal.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CertificateSigningServiceLocal.java
@@ -19,134 +19,156 @@
 package de.rwth.idsg.steve.service;
 
 import de.rwth.idsg.steve.config.SteveProperties;
+import de.rwth.idsg.steve.config.SteveProperties.Ocpp.Security.CsrSigning.LocalCsrSigning.SignatureAlgorithmPolicy;
 import de.rwth.idsg.steve.ocpp.OcppProtocol;
 import de.rwth.idsg.steve.repository.CertificateRepository;
 import de.rwth.idsg.steve.repository.dto.ChargePointSelect;
+import de.rwth.idsg.steve.utils.CertificateUtils;
 import de.rwth.idsg.steve.web.dto.ocpp.CertificateSignedParams;
 import jooq.steve.db.tables.records.CertificateRecord;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.operator.ContentVerifierProvider;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.springframework.boot.web.server.Ssl;
-import org.springframework.boot.web.server.autoconfigure.ServerProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.util.ResourceUtils;
 
-import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.math.BigInteger;
-import java.security.KeyStore;
 import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.SecureRandom;
-import java.security.Security;
+import java.security.Signature;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 import static de.rwth.idsg.steve.utils.CertificateUtils.certificatesToPEM;
-import static de.rwth.idsg.steve.utils.CertificateUtils.parseCsr;
+import static de.rwth.idsg.steve.utils.CertificateUtils.resolveSignatureAlgorithm;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.bouncycastle.jce.provider.BouncyCastleProvider.PROVIDER_NAME;
 
 @Slf4j
 @Service
-public class CertificateSigningServiceLocal extends CertificateSigningServiceAbstract {
+@ConditionalOnProperty(
+    value = "steve.ocpp.security.csr-signing.provider",
+    havingValue = "local"
+)
+public class CertificateSigningServiceLocal implements CertificateSigningService {
 
-    static {
-        Security.addProvider(new BouncyCastleProvider());
-    }
-
-    private static final String PROVIDER_NAME = "BC"; // represents BouncyCastle
-    private static final String SIGNATURE_ALGORITHM = "SHA256WithRSA";
-
-    private final SteveProperties.Ocpp.Security securityProperties;
-    private final CertificateRepository securityRepository;
+    private final CertificateRepository certificateRepository;
     private final ChargePointService chargePointService;
     private final ChargePointServiceClient chargePointServiceClient;
     private final CertificateValidator certificateValidator;
 
-    private final PrivateKey caPrivateKey;
     private final X509Certificate caCertificate;
-    private final boolean initialized;
+    private final PrivateKey caPrivateKey;
+    private final List<X509Certificate> issuerCertificateChain;
+    private final String certificateSignatureAlgorithm;
+    private final int certificateValidityYears;
 
     private final SecureRandom secureRandom = new SecureRandom();
 
-    public CertificateSigningServiceLocal(ServerProperties serverProperties,
-                                          SteveProperties steveProperties,
-                                          CertificateRepository securityRepository,
+    public CertificateSigningServiceLocal(CertificateRepository certificateRepository,
                                           ChargePointService chargePointService,
                                           ChargePointServiceClient chargePointServiceClient,
-                                          CertificateValidator certificateValidator) throws Exception {
-        this.securityProperties = steveProperties.getOcpp().getSecurity();
-        this.securityRepository = securityRepository;
+                                          CertificateValidator certificateValidator,
+                                          ResourceLoader resourceLoader,
+                                          SteveProperties steveProperties) throws Exception {
+        this.certificateRepository = certificateRepository;
         this.chargePointService = chargePointService;
         this.chargePointServiceClient = chargePointServiceClient;
         this.certificateValidator = certificateValidator;
 
-        Ssl ssl = serverProperties.getSsl();
-
-        if (!securityProperties.requiresTls() || ssl.getKeyStore().isEmpty()) {
-            log.info("Will not initialize (TLS not configured)");
-            this.caPrivateKey = null;
-            this.caCertificate = null;
-            this.initialized = false;
-            return;
+        var csrSigningProps = steveProperties.getOcpp().getSecurity().getCsrSigning().getProviderLocal();
+        if (!csrSigningProps.isValid()) {
+            throw new IllegalArgumentException("Local CSR signing is not fully configured");
         }
 
-        String keystorePath = ssl.getKeyStore();
-        String keystorePassword = ssl.getKeyStorePassword();
-        String keystoreType = ssl.getKeyStoreType();
+        this.caCertificate = resolveResource(resourceLoader, csrSigningProps.getCaCertificatePem(), CertificateUtils::parseCertificate);
+        this.caPrivateKey = resolveResource(resourceLoader, csrSigningProps.getCaKeyPem(), CertificateUtils::parsePrivateKeyViaBouncyCastle);
+        validateCaMaterial();
 
-        KeyStore keystore = KeyStore.getInstance(keystoreType);
-        try (FileInputStream fis = new FileInputStream(keystorePath)) {
-            keystore.load(fis, keystorePassword.toCharArray());
-        }
+        this.issuerCertificateChain = loadIssuerCertificateChain(resourceLoader, csrSigningProps.getCaChainPem());
+        validateIssuerCertificateChain();
 
-        String alias = keystore.aliases().nextElement();
-        this.caPrivateKey = (PrivateKey) keystore.getKey(alias, keystorePassword.toCharArray());
-        this.caCertificate = (X509Certificate) keystore.getCertificate(alias);
-        this.initialized = true;
+        this.certificateSignatureAlgorithm = resolveSignatureAlgorithm(caPrivateKey, csrSigningProps.getSignatureAlgorithmPolicy());
+        this.certificateValidityYears = csrSigningProps.getCertificateValidityYears();
 
-        log.info("Initialized successfully. Loaded CA certificate: {}", caCertificate.getSubjectX500Principal().getName());
+        log.info(
+            "Initialized successfully. Loaded CA certificate: {}. Signature algorithm: {}",
+            caCertificate.getSubjectX500Principal().getName(),
+            certificateSignatureAlgorithm
+        );
     }
 
     @Override
-    public boolean isEnabled() {
-        return initialized;
-    }
-
-    @Override
-    protected Logger getLog() {
-        return log;
-    }
-
-    @Override
-    protected CertificateRecord signCertificate(String csrPem, String chargeBoxId) throws Exception {
-        if (!initialized) {
-            throw new IllegalStateException("Service is not initialized. Check configuration.");
+    public PKCS10CertificationRequest validateCSR(String csrPem, String chargeBoxId) {
+        if (csrPem == null || csrPem.trim().isEmpty()) {
+            throw new IllegalArgumentException("Empty or null CSR received from " + chargeBoxId);
         }
 
-        PKCS10CertificationRequest csr = parseCsr(csrPem);
-        validateCsr(csr, chargeBoxId);
+        PKCS10CertificationRequest csr;
+        try {
+            csr = CertificateUtils.parseCsr(csrPem);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Cannot parse CSR from " + chargeBoxId);
+        }
+
+        try {
+            validateCsr(csr, chargeBoxId);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Could not validate CSR from " + chargeBoxId);
+        }
+
+        return csr;
+    }
+
+    @Override
+    public void processAndSendToStation(PKCS10CertificationRequest csr, String chargeBoxId) {
+        try {
+            processAndSendToStationInternal(csr, chargeBoxId);
+        } catch (Exception e) {
+            log.error("Exception happened", e);
+        }
+    }
+
+    private void processAndSendToStationInternal(PKCS10CertificationRequest csr, String chargeBoxId) throws Exception {
         X509Certificate signedCert = signCertificate(csr);
 
         // Chain Order: Always order certificates from end-entity → intermediates (if any) → root
-        X509Certificate[] chain = new X509Certificate[]{
-            signedCert,   // newly signed certificate (from CSR)
-            caCertificate // Root CA certificate
-        };
+        var chain = new ArrayList<X509Certificate>(1 + issuerCertificateChain.size());
+        chain.add(signedCert);
+        chain.addAll(issuerCertificateChain);
         String certificateChain = certificatesToPEM(chain);
 
-        CertificateRecord record = securityRepository.insertCertificate(signedCert, certificateChain);
+        CertificateRecord record = certificateRepository.insertCertificate(signedCert, certificateChain);
         log.info("SignCertificateRequest from '{}' processed successfully. Certificate stored with ID: {}", chargeBoxId, record.getCertificateId());
-        return record;
+
+        sendCertificateSignedToStation(record, chargeBoxId);
     }
 
-    @Override
-    protected void sendCertificateSignedToStation(CertificateRecord record, String chargeBoxId) {
+    private void sendCertificateSignedToStation(CertificateRecord record, String chargeBoxId) {
         var params = new CertificateSignedParams();
         params.setChargePointSelectList(List.of(new ChargePointSelect(OcppProtocol.V_16_JSON, chargeBoxId)));
         params.setCertificateId(record.getCertificateId());
@@ -156,7 +178,7 @@ public class CertificateSigningServiceLocal extends CertificateSigningServiceAbs
 
     private void validateCsr(PKCS10CertificationRequest csr, String chargeBoxId) throws Exception {
         {
-            ContentVerifierProvider verifierProvider = new JcaContentVerifierProviderBuilder()
+            var verifierProvider = new JcaContentVerifierProviderBuilder()
                 .setProvider(PROVIDER_NAME)
                 .build(csr.getSubjectPublicKeyInfo());
 
@@ -166,7 +188,26 @@ public class CertificateSigningServiceLocal extends CertificateSigningServiceAbs
             }
         }
 
-        X500Name subject = csr.getSubject();
+        // validate CSR public key policy
+        {
+            var publicKey = new JcaPEMKeyConverter()
+                .setProvider(PROVIDER_NAME)
+                .getPublicKey(csr.getSubjectPublicKeyInfo());
+
+            if (publicKey instanceof RSAPublicKey rsaPublicKey) {
+                int bits = rsaPublicKey.getModulus().bitLength();
+                if (bits < 2048) {
+                    throw new IllegalArgumentException("CSR RSA key length too small. Minimum is 2048, but got " + bits);
+                }
+            } else if (publicKey instanceof ECPublicKey ecPublicKey) {
+                int bits = ecPublicKey.getParams().getOrder().bitLength();
+                if (bits < 224) {
+                    throw new IllegalArgumentException("CSR EC key length too small. Minimum is 224, but got " + bits);
+                }
+            } else {
+                throw new IllegalArgumentException("Unsupported CSR public key algorithm: " + publicKey.getAlgorithm());
+            }
+        }
 
         var registration = chargePointService.getRegistrationDirect(chargeBoxId);
         if (registration.isEmpty()) {
@@ -174,7 +215,7 @@ public class CertificateSigningServiceLocal extends CertificateSigningServiceAbs
             throw new IllegalArgumentException("Cannot find chargeBoxId=" + chargeBoxId + " in database");
         }
 
-        certificateValidator.verifyOcppFields(registration.get(), subject);
+        certificateValidator.verifyOcppFields(registration.get(), csr.getSubject());
 
         log.info("CSR validated for charge point '{}'", chargeBoxId);
     }
@@ -182,14 +223,23 @@ public class CertificateSigningServiceLocal extends CertificateSigningServiceAbs
     private X509Certificate signCertificate(PKCS10CertificationRequest csr) throws Exception {
         var issuer = new X500Name(caCertificate.getSubjectX500Principal().getName());
         var serial = new BigInteger(64, secureRandom);
-        var notBefore = DateTime.now().toDate();
-        var notAfter = DateTime.now().plusYears(securityProperties.getCertificateValidityYears()).toDate();
+
+        Date now = DateTime.now().toDate();
+        Date notBefore = now.before(caCertificate.getNotBefore()) ? caCertificate.getNotBefore() : now;
+        Date configuredNotAfter = DateTime.now().plusYears(certificateValidityYears).toDate();
+        Date notAfter = configuredNotAfter.after(caCertificate.getNotAfter()) ? caCertificate.getNotAfter() : configuredNotAfter;
+        if (!notAfter.after(notBefore)) {
+            throw new IllegalStateException("Cannot issue certificate: resulting validity window is invalid");
+        }
+
         var subject = csr.getSubject();
         var publicKeyInfo = csr.getSubjectPublicKeyInfo();
+        PublicKey csrPublicKey = new JcaPEMKeyConverter().setProvider(PROVIDER_NAME).getPublicKey(publicKeyInfo);
 
         var certBuilder = new X509v3CertificateBuilder(issuer, serial, notBefore, notAfter, subject, publicKeyInfo);
+        addCertificateExtensions(certBuilder, publicKeyInfo, csrPublicKey);
 
-        var signer = new JcaContentSignerBuilder(SIGNATURE_ALGORITHM)
+        var signer = new JcaContentSignerBuilder(certificateSignatureAlgorithm)
             .setProvider(PROVIDER_NAME)
             .build(caPrivateKey);
 
@@ -198,5 +248,118 @@ public class CertificateSigningServiceLocal extends CertificateSigningServiceAbs
         return new JcaX509CertificateConverter()
             .setProvider(PROVIDER_NAME)
             .getCertificate(certHolder);
+    }
+
+    private void addCertificateExtensions(X509v3CertificateBuilder certBuilder,
+                                          SubjectPublicKeyInfo publicKeyInfo,
+                                          PublicKey csrPublicKey) throws Exception {
+        int keyUsageFlags = KeyUsage.digitalSignature;
+        if (csrPublicKey instanceof RSAPublicKey) {
+            keyUsageFlags |= KeyUsage.keyEncipherment;
+        } else if (csrPublicKey instanceof ECPublicKey) {
+            keyUsageFlags |= KeyUsage.keyAgreement;
+        }
+
+        var extensionUtils = new JcaX509ExtensionUtils();
+
+        // From OCPP spec: For all certificates the X.509 Key Usage extension [9] SHOULD be used to restrict the
+        // usage of the certificate to the operations for which it will be used.
+        certBuilder.addExtension(Extension.keyUsage, true, new KeyUsage(keyUsageFlags));
+
+        // the rest are coming from X.509/RFC rules
+        certBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
+        certBuilder.addExtension(Extension.extendedKeyUsage, false, new ExtendedKeyUsage(KeyPurposeId.id_kp_clientAuth));
+        certBuilder.addExtension(Extension.subjectKeyIdentifier, false, extensionUtils.createSubjectKeyIdentifier(publicKeyInfo));
+        certBuilder.addExtension(Extension.authorityKeyIdentifier, false, extensionUtils.createAuthorityKeyIdentifier(caCertificate.getPublicKey()));
+    }
+
+    private void validateCaMaterial() throws Exception {
+        if (caCertificate.getBasicConstraints() < 0) {
+            throw new IllegalArgumentException("Configured CA certificate is not a CA certificate (basicConstraints CA=true required)");
+        }
+
+        boolean[] keyUsage = caCertificate.getKeyUsage();
+        if (keyUsage == null || keyUsage.length <= 5 || !keyUsage[5]) {
+            throw new IllegalArgumentException("Configured CA certificate must allow keyCertSign in keyUsage");
+        }
+
+        String checkAlgorithm = resolveSignatureAlgorithm(caPrivateKey, SignatureAlgorithmPolicy.RSA_PKCS1);
+        byte[] probe = new byte[32];
+        secureRandom.nextBytes(probe);
+
+        Signature signer = Signature.getInstance(checkAlgorithm);
+        signer.initSign(caPrivateKey);
+        signer.update(probe);
+        byte[] signature = signer.sign();
+
+        Signature verifier = Signature.getInstance(checkAlgorithm);
+        verifier.initVerify(caCertificate.getPublicKey());
+        verifier.update(probe);
+
+        if (!verifier.verify(signature)) {
+            throw new IllegalArgumentException("Configured CA private key does not match configured CA certificate public key");
+        }
+    }
+
+    private List<X509Certificate> loadIssuerCertificateChain(ResourceLoader resourceLoader, String caChainPem) throws Exception {
+        return StringUtils.isBlank(caChainPem)
+            ? List.of(caCertificate)
+            : resolveResource(resourceLoader, caChainPem, CertificateUtils::parseCertificates);
+    }
+
+    private void validateIssuerCertificateChain() throws Exception {
+        if (issuerCertificateChain.isEmpty()) {
+            throw new IllegalArgumentException("Configured issuer certificate chain is empty");
+        }
+
+        if (!Arrays.equals(issuerCertificateChain.getFirst().getEncoded(), caCertificate.getEncoded())) {
+            throw new IllegalArgumentException("Configured issuer certificate chain must start with the configured CA certificate");
+        }
+
+        for (int i = 0; i < issuerCertificateChain.size() - 1; i++) {
+            var child = issuerCertificateChain.get(i);
+            var issuer = issuerCertificateChain.get(i + 1);
+
+            String messagePrefix = "Configured issuer certificate chain contains non-CA issuer at position " + (i + 1);
+
+            if (issuer.getBasicConstraints() < 0) {
+                throw new IllegalArgumentException(messagePrefix + " (basicConstraints CA=true required)");
+            }
+
+            boolean[] keyUsage = issuer.getKeyUsage();
+            if (keyUsage != null && (keyUsage.length <= 5 || !keyUsage[5])) {
+                throw new IllegalArgumentException(messagePrefix + " (keyCertSign required when keyUsage is present)");
+            }
+
+            if (!child.getIssuerX500Principal().equals(issuer.getSubjectX500Principal())) {
+                throw new IllegalArgumentException("Configured issuer certificate chain is not ordered correctly at position " + i);
+            }
+
+            try {
+                child.verify(issuer.getPublicKey());
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Configured issuer certificate chain has invalid signature link at position " + i, e);
+            }
+        }
+    }
+
+    private static <T> T resolveResource(ResourceLoader resourceLoader, String location, ThrowingFunction<String, T> converter) throws Exception {
+        var resource = ResourceUtils.isUrl(location)
+            ? resourceLoader.getResource(location)
+            : resourceLoader.getResource("file:" + location);
+
+        if (!resource.exists()) {
+            throw new IllegalArgumentException("Signing certificate PEM resource does not exist: " + location);
+        }
+
+        try (var reader = new InputStreamReader(resource.getInputStream(), UTF_8)) {
+            var pem = FileCopyUtils.copyToString(reader);
+            return converter.apply(pem);
+        }
+    }
+
+    @FunctionalInterface
+    interface ThrowingFunction<T, R> {
+        R apply(T t) throws Exception;
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/service/CertificateSigningServiceLocal.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CertificateSigningServiceLocal.java
@@ -37,6 +37,7 @@ import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
@@ -221,7 +222,10 @@ public class CertificateSigningServiceLocal implements CertificateSigningService
     }
 
     private X509Certificate signCertificate(PKCS10CertificationRequest csr) throws Exception {
-        var issuer = new X500Name(caCertificate.getSubjectX500Principal().getName());
+        // Preserve exact issuer DN encoding from the configured CA certificate.
+        // Rebuilding from String can alter RDN ordering/encoding and break issuer matching in TLS.
+        // https://stackoverflow.com/a/12645265
+        var issuer = new JcaX509CertificateHolder(caCertificate).getSubject();
         var serial = new BigInteger(64, secureRandom);
 
         Date now = DateTime.now().toDate();

--- a/src/main/java/de/rwth/idsg/steve/service/CertificateValidator.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CertificateValidator.java
@@ -122,12 +122,17 @@ public class CertificateValidator {
         // in the subject field of the certificate contains the CPO name.
         {
             String organizationName = CertificateUtils.getOrganization(subject);
+            if (StringUtils.isEmpty(organizationName)) {
+                throw new IllegalArgumentException("Validation failed: O (organizationName) is empty");
+            }
+
             String cpoName = chargePointRegistration.cpoName();
             if (StringUtils.isEmpty(cpoName)) {
                 throw new IllegalArgumentException("CPO name is not set for chargeBoxId: " + chargePointRegistration.chargeBoxId());
             }
-            if (!cpoName.equals(organizationName)) {
-                throw new IllegalArgumentException("Validation failed: organizationName is not equal to CPO name");
+
+            if (!organizationName.contains(cpoName)) {
+                throw new IllegalArgumentException("Validation failed: organizationName does not contain CPO name");
             }
         }
 
@@ -137,12 +142,17 @@ public class CertificateValidator {
         // contains the unique Serial Number of the Charge Point
         {
             String commonName = CertificateUtils.getCommonName(subject);
+            if (StringUtils.isEmpty(commonName)) {
+                throw new IllegalArgumentException("Validation failed: CN (commonName) is empty");
+            }
+
             String serialNumber = chargePointRegistration.serialNumber();
             if (StringUtils.isEmpty(serialNumber)) {
                 throw new IllegalArgumentException("Serial number is not set for chargeBoxId: " + chargePointRegistration.chargeBoxId());
             }
-            if (!serialNumber.equals(commonName)) {
-                throw new IllegalArgumentException("Validation failed: commonName is not equal to Serial Number of the Charge Point");
+
+            if (StringUtils.isEmpty(commonName) || !commonName.contains(serialNumber)) {
+                throw new IllegalArgumentException("Validation failed: commonName does not contain Serial Number of the Charge Point");
             }
         }
     }

--- a/src/main/java/de/rwth/idsg/steve/utils/CertificateUtils.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/CertificateUtils.java
@@ -23,6 +23,7 @@ import jooq.steve.db.enums.CertificateSignatureAlgorithm;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -238,6 +239,8 @@ public class CertificateUtils {
     }
 
     private static String normalizePemInput(String pem) {
+        if (pem == null) return null;
+
         String normalized = pem;
         // Nginx/proxy headers can be URL-encoded; PEM files typically are not.
         if (pem.contains("%")) {

--- a/src/main/java/de/rwth/idsg/steve/utils/CertificateUtils.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/CertificateUtils.java
@@ -18,16 +18,21 @@
  */
 package de.rwth.idsg.steve.utils;
 
+import de.rwth.idsg.steve.config.SteveProperties.Ocpp.Security.CsrSigning.LocalCsrSigning.SignatureAlgorithmPolicy;
 import jooq.steve.db.enums.CertificateSignatureAlgorithm;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.Certificate;
 import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
@@ -36,6 +41,8 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.security.Security;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -43,20 +50,24 @@ import java.security.interfaces.DSAPublicKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.ECParameterSpec;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.bouncycastle.jce.provider.BouncyCastleProvider.PROVIDER_NAME;
 
 @Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CertificateUtils {
 
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
     private static final String BEGIN_CERTIFICATE = "-----BEGIN CERTIFICATE-----";
     private static final String END_CERTIFICATE = "-----END CERTIFICATE-----";
 
     public static X509Certificate parseCertificate(String certPem) throws Exception {
-        // Nginx sends URL-encoded PEM, decode it
-        String decoded = URLDecoder.decode(certPem, StandardCharsets.UTF_8);
-
-        // Remove URL encoding artifacts and normalize
-        decoded = decoded.replace("\t", "\n");
+        String decoded = normalizePemInput(certPem);
 
         // Ensure proper PEM format
         if (!decoded.contains(BEGIN_CERTIFICATE)) {
@@ -67,6 +78,29 @@ public class CertificateUtils {
         try (ByteArrayInputStream bais = new ByteArrayInputStream(decoded.getBytes(StandardCharsets.UTF_8))) {
             return (X509Certificate) cf.generateCertificate(bais);
         }
+    }
+
+    public static List<X509Certificate> parseCertificates(String certPemBundle) throws Exception {
+        String decoded = normalizePemInput(certPemBundle);
+        if (!decoded.contains(BEGIN_CERTIFICATE)) {
+            return List.of(parseCertificate(decoded));
+        }
+
+        var cf = CertificateFactory.getInstance("X.509");
+        List<X509Certificate> certificates = new ArrayList<>();
+        try (var bais = new ByteArrayInputStream(decoded.getBytes(StandardCharsets.UTF_8))) {
+            for (var cert : cf.generateCertificates(bais)) {
+                if (!(cert instanceof X509Certificate x509Cert)) {
+                    throw new IllegalArgumentException("Configured certificate bundle contains non-X509 certificate");
+                }
+                certificates.add(x509Cert);
+            }
+        }
+
+        if (certificates.isEmpty()) {
+            throw new IllegalArgumentException("Configured certificate bundle does not contain any certificate");
+        }
+        return certificates;
     }
 
     public static PKCS10CertificationRequest parseCsr(String csrPem) throws Exception {
@@ -82,7 +116,50 @@ public class CertificateUtils {
         }
     }
 
-    public static String certificatesToPEM(X509Certificate... chain) throws Exception {
+    public static PrivateKey parsePrivateKeyViaBouncyCastle(String privateKeyPem) throws Exception {
+        try (var reader = new StringReader(privateKeyPem);
+             var pemParser = new PEMParser(reader)) {
+            var parsedObj = pemParser.readObject();
+
+            if (parsedObj == null) {
+                throw new IllegalArgumentException("Private key PEM is empty");
+            }
+
+            var converter = new JcaPEMKeyConverter().setProvider(PROVIDER_NAME);
+            if (parsedObj instanceof PrivateKeyInfo privateKeyInfo) {
+                return converter.getPrivateKey(privateKeyInfo);
+            }
+            if (parsedObj instanceof PEMKeyPair keyPair) {
+                return converter.getKeyPair(keyPair).getPrivate();
+            }
+
+            throw new IllegalArgumentException("Unsupported private key PEM format");
+        }
+    }
+
+    public static String resolveSignatureAlgorithm(PrivateKey privateKey,
+                                                   SignatureAlgorithmPolicy signatureAlgorithmPolicy) {
+        var policy = (signatureAlgorithmPolicy == null)
+            ? SignatureAlgorithmPolicy.AUTO
+            : signatureAlgorithmPolicy;
+
+        String keyAlgorithm = privateKey.getAlgorithm();
+        if ("RSA".equalsIgnoreCase(keyAlgorithm)) {
+            return switch (policy) {
+                case AUTO, RSA_PSS -> "SHA256withRSAandMGF1";
+                case RSA_PKCS1 -> "SHA256WithRSA";
+            };
+        }
+        if ("EC".equalsIgnoreCase(keyAlgorithm) || "ECDSA".equalsIgnoreCase(keyAlgorithm)) {
+            return "SHA256withECDSA";
+        }
+        if ("DSA".equalsIgnoreCase(keyAlgorithm)) {
+            return "SHA256withDSA";
+        }
+        throw new IllegalArgumentException("Unsupported signing private key algorithm: " + keyAlgorithm);
+    }
+
+    public static String certificatesToPEM(List<X509Certificate> chain) throws Exception {
         var sw = new StringWriter();
         try (var pemWriter = new JcaPEMWriter(sw)) {
             for (var cert : chain) {
@@ -158,5 +235,14 @@ public class CertificateUtils {
         } catch (CertificateEncodingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static String normalizePemInput(String pem) {
+        String normalized = pem;
+        // Nginx/proxy headers can be URL-encoded; PEM files typically are not.
+        if (pem.contains("%")) {
+            normalized = URLDecoder.decode(pem, StandardCharsets.UTF_8);
+        }
+        return normalized.replace("\t", "\n");
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,14 +57,25 @@ steve:
       v15: { soap: true, json: true }
       v16: { soap: true, json: true }
 
-    # OCPP 1.6 Security Profiles Configuration
-    # Other settings will be taken from server.ssl
+    # OCPP 1.6 security config.
+    # Note: security profile (0..3) is a per-charge-point state in DB, not a global application property.
     security:
-      # Profile 0: No HTTP basic authentication, no TLS
-      # Profile 1: HTTP basic authentication, no TLS
-      # Profile 2: HTTP basic authentication, TLS with server-side certificate
-      # Profile 3: TLS with client-side certificate, TLS with server-side certificate -> mutual TLS (mTLS)
-      profile: 0
-      certificate-validity-years: 1
+      # Relevant for stations with profile 3
       # See de.rwth.idsg.steve.service.CertificateValidator for documentation
       client-cert-header-from-proxy:
+      # Relevant for stations with profile 3
+      csr-signing:
+        provider:
+        # CSR signing configuration for provider=local. This is intentionally separate from server.ssl.
+        provider-local:
+          certificate-validity-years: 1
+          ca-certificate-pem:
+          ca-key-pem:
+          # Optional PEM bundle for issuer chain in order:
+          # signing cert -> intermediate(s) -> root
+          # If omitted, only ca-certificate-pem is sent as issuer chain.
+          ca-chain-pem:
+          # Signature algorithm policy for locally signed charge point certificates:
+          # - auto: RSA => RSA-PSS (SHA256withRSAandMGF1), EC => ECDSA (SHA256withECDSA)
+          # - rsa-pkcs1: RSA => PKCS#1 v1.5 (SHA256WithRSA), EC => ECDSA (SHA256withECDSA)
+          signature-algorithm-policy: auto


### PR DESCRIPTION
- Separate config domain from `server.ssl`: moved local CSR signer settings under `steve.ocpp.security.csr-signing`.
- Added `steve.ocpp.security.csr-signing.provider` to select a custom provider impl. Fallback to CertificateSigningServiceDisabled if none found.
- Switched to PEM-based CA inputs (`ca-certificate-pem`, `ca-key-pem`, optional `ca-chain-pem`) instead of reusing server keystore config.
- Added CA material sanity checks: check basicConstraints, check keyUsage keyCertSign, match private key and CA cert public key
- Replaced hardcoded signer algorithm with key-aware algorithm resolution
- Added signature algorithm policy handling (`auto`, `rsa-pkcs1`, etc.) via enum-backed config.
- Added CSR validation improvements: verify CSR signature, enforce public-key policy (RSA min bits, EC min bits), improve OCPP subject field checks (use contains instead of equals)
- Improved issued certificate generation:
  + validity bounded by CA validity window.
  + required X.509 extensions added (`BasicConstraints(false)`, `KeyUsage`, `ExtendedKeyUsage(clientAuth)`, SKI, AKI).
- Added issuer chain support for `CertificateSigned` payload:
  + optional configured chain (`ca-chain-pem`).
  + chain validation (ordering + signature linkage).
  + check that chain starts with configured signing cert.
  + CA capability checks for issuer certs in chain.