### PR TITLE
refactor and simplify initial RegistrationStatus

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/ocpp/converter/Server15to16Impl.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/converter/Server15to16Impl.java
@@ -18,6 +18,7 @@
  */
 package de.rwth.idsg.steve.ocpp.converter;
 
+import lombok.extern.slf4j.Slf4j;
 import ocpp.cs._2012._06.AuthorizationStatus;
 import ocpp.cs._2012._06.AuthorizeResponse;
 import ocpp.cs._2012._06.BootNotificationResponse;
@@ -62,6 +63,7 @@ import java.util.stream.Collectors;
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 13.03.2018
  */
+@Slf4j
 public enum Server15to16Impl implements Server15to16 {
     SINGLETON;
 
@@ -177,7 +179,7 @@ public enum Server15to16Impl implements Server15to16 {
         return new BootNotificationResponse()
                 .withCurrentTime(response.getCurrentTime())
                 .withHeartbeatInterval(response.getInterval())
-                .withStatus(RegistrationStatus.fromValue(response.getStatus().value()));
+                .withStatus(mapRegistrationStatus(response.getStatus()));
     }
 
     @Override
@@ -237,6 +239,17 @@ public enum Server15to16Impl implements Server15to16 {
     // -------------------------------------------------------------------------
     // Custom mapping, for situations where a unique mapping does not exists
     // -------------------------------------------------------------------------
+
+    private static RegistrationStatus mapRegistrationStatus(ocpp.cs._2015._10.RegistrationStatus status) {
+        return switch (status) {
+            case ACCEPTED -> RegistrationStatus.ACCEPTED;
+            case PENDING -> {
+                log.warn("RegistrationStatus.PENDING does not exist in OCPP 1.2/1.5. Mapping to RegistrationStatus.REJECTED");
+                yield RegistrationStatus.REJECTED;
+            }
+            case REJECTED -> RegistrationStatus.REJECTED;
+        };
+    }
 
     /**
      * OCCUPIED was replaced with several more specific values. For now it will be replaced with "CHARGING",

--- a/src/main/java/de/rwth/idsg/steve/ocpp/converter/Server15to16Impl.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/converter/Server15to16Impl.java
@@ -241,6 +241,9 @@ public enum Server15to16Impl implements Server15to16 {
     // -------------------------------------------------------------------------
 
     private static RegistrationStatus mapRegistrationStatus(ocpp.cs._2015._10.RegistrationStatus status) {
+        if (status == null) {
+            return null;
+        }
         return switch (status) {
             case ACCEPTED -> RegistrationStatus.ACCEPTED;
             case PENDING -> {

--- a/src/main/java/de/rwth/idsg/steve/ocpp/soap/MessageHeaderInterceptor.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/soap/MessageHeaderInterceptor.java
@@ -87,7 +87,7 @@ public class MessageHeaderInterceptor extends AbstractPhaseInterceptor<Message> 
 
         if (!BOOT_OPERATION_NAME.equals(opName.getLocalPart())) {
             Optional<RegistrationStatus> status = chargePointService.getRegistrationStatus(chargeBoxId);
-            boolean allow = status.isPresent() && status.get() != RegistrationStatus.REJECTED;
+            boolean allow = status.isPresent() && status.get() == RegistrationStatus.ACCEPTED;
             if (!allow) {
                 throw createAuthFault(opName);
             }

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
@@ -399,7 +399,7 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
                        .set(CHARGE_BOX.CHARGE_BOX_ID, form.getChargeBoxId())
                        .set(CHARGE_BOX.DESCRIPTION, form.getDescription())
                        .set(CHARGE_BOX.INSERT_CONNECTOR_STATUS_AFTER_TRANSACTION_MSG, form.getInsertConnectorStatusAfterTransactionMsg())
-                       .set(CHARGE_BOX.REGISTRATION_STATUS, form.getRegistrationStatus())
+                       .set(CHARGE_BOX.REGISTRATION_STATUS, form.getRegistrationStatus().value())
                        .set(CHARGE_BOX.NOTE, form.getNote())
                        .set(CHARGE_BOX.ADMIN_ADDRESS, form.getAdminAddress())
                        .set(CHARGE_BOX.SECURITY_PROFILE, form.getSecurityProfile().getValue());
@@ -418,7 +418,7 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
        var query = ctx.update(CHARGE_BOX)
                       .set(CHARGE_BOX.DESCRIPTION, form.getDescription())
                       .set(CHARGE_BOX.INSERT_CONNECTOR_STATUS_AFTER_TRANSACTION_MSG, form.getInsertConnectorStatusAfterTransactionMsg())
-                      .set(CHARGE_BOX.REGISTRATION_STATUS, form.getRegistrationStatus())
+                      .set(CHARGE_BOX.REGISTRATION_STATUS, form.getRegistrationStatus().value())
                       .set(CHARGE_BOX.NOTE, form.getNote())
                       .set(CHARGE_BOX.ADMIN_ADDRESS, form.getAdminAddress())
                       .set(CHARGE_BOX.SECURITY_PROFILE, form.getSecurityProfile().getValue());

--- a/src/main/java/de/rwth/idsg/steve/utils/mapper/ChargePointDetailsMapper.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/mapper/ChargePointDetailsMapper.java
@@ -24,6 +24,7 @@ import de.rwth.idsg.steve.web.dto.ChargePointForm;
 import jooq.steve.db.tables.records.ChargeBoxRecord;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import ocpp.cs._2015._10.RegistrationStatus;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -43,7 +44,7 @@ public final class ChargePointDetailsMapper {
         form.setDescription(chargeBox.getDescription());
         form.setInsertConnectorStatusAfterTransactionMsg(chargeBox.getInsertConnectorStatusAfterTransactionMsg());
         form.setAdminAddress(chargeBox.getAdminAddress());
-        form.setRegistrationStatus(chargeBox.getRegistrationStatus());
+        form.setRegistrationStatus(RegistrationStatus.fromValue(chargeBox.getRegistrationStatus()));
         form.setAddress(AddressMapper.recordToDto(cp.getAddress()));
 
         form.setSecurityProfile(OcppSecurityProfile.fromValue(chargeBox.getSecurityProfile()));

--- a/src/main/java/de/rwth/idsg/steve/web/controller/ChargePointsController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/controller/ChargePointsController.java
@@ -18,7 +18,6 @@
  */
 package de.rwth.idsg.steve.web.controller;
 
-import de.rwth.idsg.steve.ocpp.OcppProtocol;
 import de.rwth.idsg.steve.repository.dto.ChargePoint;
 import de.rwth.idsg.steve.service.ChargePointService;
 import de.rwth.idsg.steve.utils.ControllerHelper;
@@ -26,7 +25,6 @@ import de.rwth.idsg.steve.utils.mapper.ChargePointDetailsMapper;
 import de.rwth.idsg.steve.web.dto.ChargePointBatchInsertForm;
 import de.rwth.idsg.steve.web.dto.ChargePointForm;
 import de.rwth.idsg.steve.web.dto.ChargePointQueryForm;
-import jooq.steve.db.tables.records.ChargeBoxRecord;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -56,10 +54,6 @@ public class ChargePointsController {
     protected final ChargePointService chargePointService;
 
     protected static final String PARAMS = "params";
-
-    private static final List<String> upToOcpp15RegistrationStatusList = Arrays.stream(ocpp.cs._2012._06.RegistrationStatus.values())
-                                                                               .map(ocpp.cs._2012._06.RegistrationStatus::value)
-                                                                               .collect(Collectors.toList());
 
     private static final List<String> ocpp16RegistrationStatusList = Arrays.stream(ocpp.cs._2015._10.RegistrationStatus.values())
                                                                            .map(ocpp.cs._2015._10.RegistrationStatus::value)
@@ -114,27 +108,10 @@ public class ChargePointsController {
 
         model.addAttribute("chargePointForm", form);
         model.addAttribute("cp", cp);
-        model.addAttribute("registrationStatusList", getRegistrationStatusList(cp.getChargeBox()));
+        model.addAttribute("registrationStatusList", ocpp16RegistrationStatusList);
         addCountryCodes(model);
 
         return "data-man/chargepointDetails";
-    }
-
-    private List<String> getRegistrationStatusList(ChargeBoxRecord chargeBoxRecord) {
-        if (chargeBoxRecord.getOcppProtocol() == null) {
-            return upToOcpp15RegistrationStatusList;
-        }
-
-        OcppProtocol protocol = OcppProtocol.fromCompositeValue(chargeBoxRecord.getOcppProtocol());
-        switch (protocol.getVersion()) {
-            case V_12:
-            case V_15:
-                return upToOcpp15RegistrationStatusList;
-            case V_16:
-                return ocpp16RegistrationStatusList;
-            default:
-                throw new IllegalArgumentException("Unknown OCPP version: " + protocol.getVersion());
-        }
     }
 
     @GetMapping(ADD_PATH)
@@ -230,8 +207,7 @@ public class ChargePointsController {
     private void setCommonAttributesForSingleAdd(Model model) {
         addCountryCodes(model);
         model.addAttribute("batchChargePointForm", new ChargePointBatchInsertForm());
-        // we don't know the protocol yet. but, a list with only "accepted" and "rejected" is a good starting point.
-        model.addAttribute("registrationStatusList", upToOcpp15RegistrationStatusList);
+        model.addAttribute("registrationStatusList", ocpp16RegistrationStatusList);
     }
 
     private void add(ChargePointForm form) {

--- a/src/main/java/de/rwth/idsg/steve/web/controller/ChargePointsController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/controller/ChargePointsController.java
@@ -36,10 +36,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import jakarta.validation.Valid;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  *
@@ -54,10 +52,6 @@ public class ChargePointsController {
     protected final ChargePointService chargePointService;
 
     protected static final String PARAMS = "params";
-
-    private static final List<String> ocpp16RegistrationStatusList = Arrays.stream(ocpp.cs._2015._10.RegistrationStatus.values())
-                                                                           .map(ocpp.cs._2015._10.RegistrationStatus::value)
-                                                                           .collect(Collectors.toList());
 
     // -------------------------------------------------------------------------
     // Paths
@@ -108,7 +102,6 @@ public class ChargePointsController {
 
         model.addAttribute("chargePointForm", form);
         model.addAttribute("cp", cp);
-        model.addAttribute("registrationStatusList", ocpp16RegistrationStatusList);
         addCountryCodes(model);
 
         return "data-man/chargepointDetails";
@@ -207,7 +200,6 @@ public class ChargePointsController {
     private void setCommonAttributesForSingleAdd(Model model) {
         addCountryCodes(model);
         model.addAttribute("batchChargePointForm", new ChargePointBatchInsertForm());
-        model.addAttribute("registrationStatusList", ocpp16RegistrationStatusList);
     }
 
     private void add(ChargePointForm form) {

--- a/src/main/java/de/rwth/idsg/steve/web/dto/ChargePointForm.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ChargePointForm.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import ocpp.cs._2015._10.RegistrationStatus;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.URL;
 
@@ -51,8 +52,11 @@ public class ChargePointForm {
     @ChargeBoxId
     private String chargeBoxId;
 
-    @NotBlank(message = "Registration status is required")
-    private String registrationStatus;
+    /**
+     * https://github.com/steve-community/steve/pull/2030 switched from String to enum
+     */
+    @NotNull(message = "Registration status is required")
+    private RegistrationStatus registrationStatus;
 
     @NotNull
     private Boolean insertConnectorStatusAfterTransactionMsg;

--- a/src/main/webapp/WEB-INF/views/data-man/chargepointAdd.jsp
+++ b/src/main/webapp/WEB-INF/views/data-man/chargepointAdd.jsp
@@ -102,7 +102,9 @@
                     </td>
                 </tr>
                 <tr><td>Registration status:</td><td>
-                    <form:select path="registrationStatus" items="${registrationStatusList}"/>
+                    <form:select path="registrationStatus">
+                        <form:options items="${registrationStatus}" itemLabel="value"/>
+                    </form:select>
                 </td></tr>
                 <tr>
                     <td>Security Profile:</td>

--- a/src/main/webapp/WEB-INF/views/data-man/chargepointDetails.jsp
+++ b/src/main/webapp/WEB-INF/views/data-man/chargepointDetails.jsp
@@ -111,7 +111,9 @@
                         </td>
                     </tr>
                     <tr><td>Registration status:</td><td>
-                        <form:select path="registrationStatus" items="${registrationStatusList}"/>
+                        <form:select path="registrationStatus">
+                            <form:options items="${registrationStatus}" itemLabel="value"/>
+                        </form:select>
                     </td></tr>
                     <tr>
                         <td>Security Profile:</td>

--- a/src/test/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImplIT.java
+++ b/src/test/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImplIT.java
@@ -24,6 +24,7 @@ import de.rwth.idsg.steve.web.dto.Address;
 import de.rwth.idsg.steve.web.dto.ChargePointForm;
 import de.rwth.idsg.steve.web.dto.ChargePointQueryForm;
 import de.rwth.idsg.steve.web.dto.ConnectorStatusForm;
+import ocpp.cs._2015._10.RegistrationStatus;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -167,7 +168,7 @@ public class ChargePointRepositoryImplIT extends AbstractRepositoryITBase {
     private static ChargePointForm chargePointForm(String chargeBoxId) {
         var form = new ChargePointForm();
         form.setChargeBoxId(chargeBoxId);
-        form.setRegistrationStatus("Accepted");
+        form.setRegistrationStatus(RegistrationStatus.ACCEPTED);
         form.setInsertConnectorStatusAfterTransactionMsg(true);
         form.setAddress(new Address());
         return form;


### PR DESCRIPTION
status Pending was added in ocpp 1.6. therefore, we were using only Accepted and Rejected as common denominator when adding stations for compatibility with ocpp 1.2 and 1.5. going forward, we can assume ocpp 1.6 as baseline. so, we allow users to set all 3 status values. but, during version-specific translation of ocpp messages, we can still map Pending to Rejected. therefore, backwards compatibility is not affected.