### PR TITLE
1371 mysql jdbc driver truncates milliseconds when using with mariadb

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ jobs:
         image: ${{ matrix.database.image }}
         command: ${{ matrix.database.command }}
         env:
+          TZ: +00:00
           MYSQL_ROOT_PASSWORD: root
           MARIADB_ROOT_PASSWORD: root
           MYSQL_DATABASE: root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - 3306:3306
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+      TZ: +00:00
       MYSQL_DATABASE: stevedb
       MYSQL_USER: steve
       MYSQL_PASSWORD: changeme

--- a/src/test/java/de/rwth/idsg/steve/FractionalSecondsTest.java
+++ b/src/test/java/de/rwth/idsg/steve/FractionalSecondsTest.java
@@ -1,0 +1,105 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2024 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve;
+
+import de.rwth.idsg.steve.config.BeanConfiguration;
+import jooq.steve.db.tables.records.ChargeBoxRecord;
+import org.joda.time.DateTime;
+import org.jooq.DSLContext;
+import org.jooq.Result;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static jooq.steve.db.Tables.CHARGE_BOX;
+
+/**
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 21.01.2024
+ */
+public class FractionalSecondsTest {
+
+    @BeforeAll
+    public static void initClass() {
+        Assertions.assertEquals(ApplicationProfile.TEST, SteveConfiguration.CONFIG.getProfile());
+    }
+
+    public static Stream<String> provideInputDateTimes() {
+        return Stream.of(
+            "2024-01-21T05:06:07.000Z",
+            "2024-01-21T05:06:07.123Z"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInputDateTimes")
+    public void testPrecisionInJava(String dateTimeString) {
+        DateTime dtIn = DateTime.parse(dateTimeString);
+        Assertions.assertEquals(dateTimeString, dtIn.toString());
+
+        DateTime dtOut = DateTime.parse(dtIn.toString());
+        Assertions.assertEquals(dateTimeString, dtOut.toString());
+
+        Assertions.assertEquals(dtIn, dtOut);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInputDateTimes")
+    public void testPrecisionWithDatabase(String dateTimeString) {
+        DateTime dtIn = DateTime.parse(dateTimeString);
+        DateTime dtOut = insertAndGetDateTime(dtIn);
+
+        Assertions.assertTrue(dtIn.isEqual(dtOut), () -> "Expected: " + dtIn + " vs actual: " + dtOut);
+    }
+
+    /**
+     * Persist some DateTime in some table in DB (just to have DB evaluate it) and
+     * get the evaluated version back for further checks.
+     */
+    private static DateTime insertAndGetDateTime(DateTime dtIn) {
+        String chargeBoxId = UUID.randomUUID().toString();
+
+        DSLContext ctx = new BeanConfiguration().dslContext();
+
+        // 1. insert
+        ctx.insertInto(CHARGE_BOX)
+            .set(CHARGE_BOX.CHARGE_BOX_ID, chargeBoxId)
+            .set(CHARGE_BOX.LAST_HEARTBEAT_TIMESTAMP, dtIn)
+            .execute();
+
+        // 2. read
+        Result<ChargeBoxRecord> rows = ctx.selectFrom(CHARGE_BOX)
+            .where(CHARGE_BOX.CHARGE_BOX_ID.eq(chargeBoxId))
+            .fetch();
+
+        ChargeBoxRecord chargeBoxRecord = rows.get(0);
+
+        // 2. clean-up
+        ctx.deleteFrom(CHARGE_BOX)
+            .where(CHARGE_BOX.CHARGE_BOX_ID.eq(chargeBoxId))
+            .execute();
+
+        return chargeBoxRecord.getLastHeartbeatTimestamp();
+    }
+}

--- a/src/test/java/de/rwth/idsg/steve/issues/Issue1371Test.java
+++ b/src/test/java/de/rwth/idsg/steve/issues/Issue1371Test.java
@@ -23,7 +23,9 @@ import jooq.steve.db.tables.records.ChargeBoxRecord;
 import org.joda.time.DateTime;
 import org.jooq.DSLContext;
 import org.jooq.Result;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +34,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import static jooq.steve.db.Tables.CHARGE_BOX;
@@ -53,6 +54,20 @@ public class Issue1371Test {
 
     @Autowired
     private DSLContext dslContext;
+
+    private static final String TEST_CHARGE_BOX_ID = "CB-A5EK1234";
+
+    @BeforeEach
+    public void setup() {
+        dslContext.deleteFrom(CHARGE_BOX)
+            .where(CHARGE_BOX.CHARGE_BOX_ID.eq(TEST_CHARGE_BOX_ID))
+            .execute();
+    }
+
+    @AfterEach
+    public void teardown() {
+        setup();
+    }
 
     public static Stream<String> provideInputDateTimes() {
         return Stream.of(
@@ -87,25 +102,20 @@ public class Issue1371Test {
      * get the evaluated version back for further checks.
      */
     private DateTime insertAndGetDateTime(DateTime dtIn) {
-        String chargeBoxId = UUID.randomUUID().toString();
-
         // 1. insert
         dslContext.insertInto(CHARGE_BOX)
-            .set(CHARGE_BOX.CHARGE_BOX_ID, chargeBoxId)
+            .set(CHARGE_BOX.CHARGE_BOX_ID, TEST_CHARGE_BOX_ID)
             .set(CHARGE_BOX.LAST_HEARTBEAT_TIMESTAMP, dtIn)
             .execute();
 
         // 2. read
         Result<ChargeBoxRecord> rows = dslContext.selectFrom(CHARGE_BOX)
-            .where(CHARGE_BOX.CHARGE_BOX_ID.eq(chargeBoxId))
+            .where(CHARGE_BOX.CHARGE_BOX_ID.eq(TEST_CHARGE_BOX_ID))
             .fetch();
+        Assertions.assertNotNull(rows);
 
         ChargeBoxRecord chargeBoxRecord = rows.get(0);
-
-        // 2. clean-up
-        dslContext.deleteFrom(CHARGE_BOX)
-            .where(CHARGE_BOX.CHARGE_BOX_ID.eq(chargeBoxId))
-            .execute();
+        Assertions.assertNotNull(chargeBoxRecord);
 
         return chargeBoxRecord.getLastHeartbeatTimestamp();
     }

--- a/src/test/java/de/rwth/idsg/steve/issues/Issue1371Test.java
+++ b/src/test/java/de/rwth/idsg/steve/issues/Issue1371Test.java
@@ -1,6 +1,6 @@
 /*
  * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
- * Copyright (C) 2013-2024 SteVe Community Team
+ * Copyright (C) 2013-2026 SteVe Community Team
  * All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -16,34 +16,43 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-package de.rwth.idsg.steve;
+package de.rwth.idsg.steve.issues;
 
-import de.rwth.idsg.steve.config.BeanConfiguration;
+import de.rwth.idsg.testconfig.JooqOnlyTestConfiguration;
 import jooq.steve.db.tables.records.ChargeBoxRecord;
 import org.joda.time.DateTime;
 import org.jooq.DSLContext;
 import org.jooq.Result;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import java.util.UUID;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static jooq.steve.db.Tables.CHARGE_BOX;
 
 /**
+ * Tests about fractional seconds: https://github.com/steve-community/steve/issues/1371
+ *
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 21.01.2024
  */
-public class FractionalSecondsTest {
+@ActiveProfiles(profiles = "test")
+@SpringJUnitConfig
+@ContextConfiguration(
+    classes = JooqOnlyTestConfiguration.class,
+    initializers = ConfigDataApplicationContextInitializer.class
+)
+public class Issue1371Test {
 
-    @BeforeAll
-    public static void initClass() {
-        Assertions.assertEquals(ApplicationProfile.TEST, SteveConfiguration.CONFIG.getProfile());
-    }
+    @Autowired
+    private DSLContext dslContext;
 
     public static Stream<String> provideInputDateTimes() {
         return Stream.of(
@@ -77,26 +86,24 @@ public class FractionalSecondsTest {
      * Persist some DateTime in some table in DB (just to have DB evaluate it) and
      * get the evaluated version back for further checks.
      */
-    private static DateTime insertAndGetDateTime(DateTime dtIn) {
+    private DateTime insertAndGetDateTime(DateTime dtIn) {
         String chargeBoxId = UUID.randomUUID().toString();
 
-        DSLContext ctx = new BeanConfiguration().dslContext();
-
         // 1. insert
-        ctx.insertInto(CHARGE_BOX)
+        dslContext.insertInto(CHARGE_BOX)
             .set(CHARGE_BOX.CHARGE_BOX_ID, chargeBoxId)
             .set(CHARGE_BOX.LAST_HEARTBEAT_TIMESTAMP, dtIn)
             .execute();
 
         // 2. read
-        Result<ChargeBoxRecord> rows = ctx.selectFrom(CHARGE_BOX)
+        Result<ChargeBoxRecord> rows = dslContext.selectFrom(CHARGE_BOX)
             .where(CHARGE_BOX.CHARGE_BOX_ID.eq(chargeBoxId))
             .fetch();
 
         ChargeBoxRecord chargeBoxRecord = rows.get(0);
 
         // 2. clean-up
-        ctx.deleteFrom(CHARGE_BOX)
+        dslContext.deleteFrom(CHARGE_BOX)
             .where(CHARGE_BOX.CHARGE_BOX_ID.eq(chargeBoxId))
             .execute();
 

--- a/src/test/java/de/rwth/idsg/testconfig/JooqOnlyTestConfiguration.java
+++ b/src/test/java/de/rwth/idsg/testconfig/JooqOnlyTestConfiguration.java
@@ -1,0 +1,69 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.testconfig;
+
+import com.zaxxer.hikari.HikariDataSource;
+import de.rwth.idsg.steve.config.BeanConfiguration;
+import de.rwth.idsg.steve.config.SteveProperties;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+/**
+ * Test configuration for tests that need the real Spring Boot property binding and
+ * production jOOQ/DataSource bean wiring, but do not need to start the full SteVe
+ * application context.
+ *
+ * This class intentionally lives outside {@code de.rwth.idsg.steve}. The
+ * production {@link BeanConfiguration} component-scans that package, and full
+ * {@code @SpringBootTest} tests would otherwise discover this helper as an
+ * additional configuration class. That would register duplicate beans such as
+ * {@code dataSource} when the full application context is started.
+ *
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 01.05.2026
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties({DataSourceProperties.class, SteveProperties.class})
+public class JooqOnlyTestConfiguration {
+
+    private final BeanConfiguration beanConfiguration = new BeanConfiguration();
+
+    @Bean
+    HikariDataSource dataSource(DataSourceProperties properties) {
+        return beanConfiguration.dataSource(properties);
+    }
+
+    @Bean
+    SQLDialect jooqSqlDialect(DataSource dataSource) {
+        return beanConfiguration.jooqSqlDialect(dataSource);
+    }
+
+    @Bean
+    DSLContext dslContext(DataSource dataSource,
+                          SteveProperties steveProperties,
+                          SQLDialect jooqSqlDialect) {
+        return beanConfiguration.dslContext(dataSource, steveProperties, jooqSqlDialect);
+    }
+}


### PR DESCRIPTION
this PR is just adding tests for validation. behaviour change (and real fix) came with proper mariadb support in https://github.com/steve-community/steve/pull/2010