### PR TITLE
2040 preparation introduce evse

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/ocpp/model/ConnectorFormat.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/model/ConnectorFormat.java
@@ -1,0 +1,42 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.ocpp.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 13.05.2026
+ */
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ConnectorFormat {
+
+    SOCKET("Socket"),
+    CABLE("Cable");
+
+    private final String text;
+
+    public static ConnectorFormat fromNullable(String enumName) {
+        return StringUtils.isEmpty(enumName) ? null : ConnectorFormat.valueOf(enumName);
+    }
+}

--- a/src/main/java/de/rwth/idsg/steve/ocpp/model/ConnectorType.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/model/ConnectorType.java
@@ -1,0 +1,80 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.ocpp.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 13.05.2026
+ */
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ConnectorType {
+
+    CHADEMO("CHAdeMO"),
+    CHAOJI("ChaoJi"),
+    DOMESTIC_A("Domestic A"),
+    DOMESTIC_B("Domestic B"),
+    DOMESTIC_C("Domestic C"),
+    DOMESTIC_D("Domestic D"),
+    DOMESTIC_E("Domestic E"),
+    DOMESTIC_F("Domestic F"),
+    DOMESTIC_G("Domestic G"),
+    DOMESTIC_H("Domestic H"),
+    DOMESTIC_I("Domestic I"),
+    DOMESTIC_J("Domestic J"),
+    DOMESTIC_K("Domestic K"),
+    DOMESTIC_L("Domestic L"),
+    DOMESTIC_M("Domestic M"),
+    DOMESTIC_N("Domestic N"),
+    DOMESTIC_O("Domestic O"),
+    GBT_AC("Guobiao AC"),
+    GBT_DC("Guobiao DC"),
+    IEC_60309_2_single_16("IEC 60309-2 1-Single 16A"),
+    IEC_60309_2_three_16("IEC 60309-2 3-Phase 16A"),
+    IEC_60309_2_three_32("IEC 60309-2 3-Phase 32A"),
+    IEC_60309_2_three_64("IEC 60309-2 3-Phase 64A"),
+    IEC_62196_T1("IEC 62196 Type 1"),
+    IEC_62196_T1_COMBO("IEC 62196 Type 1 Combo DC"),
+    IEC_62196_T2("IEC 62196 Type 2"),
+    IEC_62196_T2_COMBO("IEC 62196 Type 2 Combo DC"),
+    IEC_62196_T3A("IEC 62196 Type 3A"),
+    IEC_62196_T3C("IEC 62196 Type 3C"),
+    NEMA_5_20("NEMA 5-20"),
+    NEMA_6_30("NEMA 6-30"),
+    NEMA_6_50("NEMA 6-50"),
+    NEMA_10_30("NEMA 10-30"),
+    NEMA_10_50("NEMA 10-50"),
+    NEMA_14_30("NEMA 14-30"),
+    NEMA_14_50("NEMA 14-50"),
+    PANTOGRAPH_BOTTOM_UP("Pantograph Bottom-Up"),
+    PANTOGRAPH_TOP_DOWN("Pantograph Top-Down"),
+    TESLA_R("Tesla Roadster"),
+    TESLA_S("Tesla Model S");
+
+    private final String text;
+
+    public static ConnectorType fromNullable(String enumName) {
+        return StringUtils.isEmpty(enumName) ? null : ConnectorType.valueOf(enumName);
+    }
+}

--- a/src/main/java/de/rwth/idsg/steve/ocpp/model/PowerType.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/model/PowerType.java
@@ -1,0 +1,45 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.ocpp.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 13.05.2026
+ */
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum PowerType {
+
+    AC_1_PHASE("AC 1-Phase"),
+    AC_2_PHASE("AC 2-Phase"),
+    AC_2_PHASE_SPLIT("AC 2-Phase Split"),
+    AC_3_PHASE("AC 3-Phase"),
+    DC("DC");
+
+    private final String text;
+
+    public static PowerType fromNullable(String enumName) {
+        return StringUtils.isEmpty(enumName) ? null : PowerType.valueOf(enumName);
+    }
+}

--- a/src/main/java/de/rwth/idsg/steve/repository/dto/ChargePoint.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/dto/ChargePoint.java
@@ -22,10 +22,16 @@ import de.rwth.idsg.steve.utils.JsonUtils;
 import de.rwth.idsg.steve.web.dto.ocpp.ConfigurationKeyEnum;
 import jooq.steve.db.tables.records.AddressRecord;
 import jooq.steve.db.tables.records.ChargeBoxRecord;
+import jooq.steve.db.tables.records.EvseConnectorRecord;
+import jooq.steve.db.tables.records.EvseRecord;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.joda.time.DateTime;
+import org.jooq.Result;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -47,6 +53,8 @@ public final class ChargePoint {
     public static final class Details {
         private final ChargeBoxRecord chargeBox;
         private final AddressRecord address;
+        private final List<EvseRecord> evses;
+        private final Map<Integer, Result<EvseConnectorRecord>> evseConnectorsByEvsePk;
 
         public String getCpoName() {
             return JsonUtils.getPropertyValueAsString(chargeBox.getOcppConfiguration(), ConfigurationKeyEnum.CpoName.name());

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
@@ -32,6 +32,7 @@ import de.rwth.idsg.steve.utils.JsonUtils;
 import de.rwth.idsg.steve.web.dto.ChargePointForm;
 import de.rwth.idsg.steve.web.dto.ChargePointQueryForm;
 import de.rwth.idsg.steve.web.dto.ConnectorStatusForm;
+import jooq.steve.db.enums.EvseTopologySource;
 import jooq.steve.db.tables.records.AddressRecord;
 import jooq.steve.db.tables.records.ChargeBoxRecord;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +55,7 @@ import org.jooq.impl.DSL;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.CollectionUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -62,7 +64,7 @@ import java.util.stream.Collectors;
 import static de.rwth.idsg.steve.utils.CustomDSL.date;
 import static de.rwth.idsg.steve.utils.CustomDSL.includes;
 import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
-import static jooq.steve.db.tables.Connector.CONNECTOR;
+import static jooq.steve.db.tables.Evse.EVSE;
 import static jooq.steve.db.tables.ConnectorStatus.CONNECTOR_STATUS;
 
 /**
@@ -257,53 +259,53 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
     @Override
     public List<ConnectorStatus> getChargePointConnectorStatus(ConnectorStatusForm form) {
         // find out the latest timestamp for each connector
-        Field<Integer> t1Pk = CONNECTOR_STATUS.CONNECTOR_PK.as("t1_pk");
+        Field<Integer> t1Pk = CONNECTOR_STATUS.EVSE_PK.as("t1_pk");
         Field<DateTime> t1TsMax = DSL.max(CONNECTOR_STATUS.STATUS_TIMESTAMP).as("t1_ts_max");
         Table<?> t1 = ctx.select(t1Pk, t1TsMax)
                          .from(CONNECTOR_STATUS)
-                         .groupBy(CONNECTOR_STATUS.CONNECTOR_PK)
+                         .groupBy(CONNECTOR_STATUS.EVSE_PK)
                          .asTable("t1");
 
         // get the status table with latest timestamps only
-        Field<Integer> t2Pk = CONNECTOR_STATUS.CONNECTOR_PK.as("t2_pk");
+        Field<Integer> t2Pk = CONNECTOR_STATUS.EVSE_PK.as("t2_pk");
         Field<DateTime> t2Ts = CONNECTOR_STATUS.STATUS_TIMESTAMP.as("t2_ts");
         Field<String> t2Status = CONNECTOR_STATUS.STATUS.as("t2_status");
         Field<String> t2Error = CONNECTOR_STATUS.ERROR_CODE.as("t2_error");
         Table<?> t2 = ctx.selectDistinct(t2Pk, t2Ts, t2Status, t2Error)
                          .from(CONNECTOR_STATUS)
                          .join(t1)
-                            .on(CONNECTOR_STATUS.CONNECTOR_PK.equal(t1.field(t1Pk)))
+                            .on(CONNECTOR_STATUS.EVSE_PK.equal(t1.field(t1Pk)))
                             .and(CONNECTOR_STATUS.STATUS_TIMESTAMP.equal(t1.field(t1TsMax)))
                          .asTable("t2");
 
+        List<Condition> conditions = new ArrayList<>();
+        conditions.add(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1));
+
         // https://github.com/steve-community/steve/issues/691
-        Condition chargeBoxCondition = CHARGE_BOX.REGISTRATION_STATUS.eq(RegistrationStatus.ACCEPTED.value());
+        conditions.add(CHARGE_BOX.REGISTRATION_STATUS.eq(RegistrationStatus.ACCEPTED.value()));
 
         if (form != null && form.getChargeBoxId() != null) {
-            chargeBoxCondition = chargeBoxCondition.and(CHARGE_BOX.CHARGE_BOX_ID.eq(form.getChargeBoxId()));
+            conditions.add(CHARGE_BOX.CHARGE_BOX_ID.eq(form.getChargeBoxId()));
         }
 
-        final Condition statusCondition;
-        if (form == null || form.getStatus() == null) {
-            statusCondition = DSL.noCondition();
-        } else {
-            statusCondition = t2.field(t2Status).eq(form.getStatus());
+        if (form != null && form.getStatus() != null) {
+            conditions.add(t2.field(t2Status).eq(form.getStatus()));
         }
 
         return ctx.select(
                         CHARGE_BOX.CHARGE_BOX_PK,
-                        CONNECTOR.CHARGE_BOX_ID,
-                        CONNECTOR.CONNECTOR_ID,
+                        EVSE.CHARGE_BOX_ID,
+                        EVSE.EVSE_ID,
                         t2.field(t2Ts),
                         t2.field(t2Status),
                         t2.field(t2Error),
                         CHARGE_BOX.OCPP_PROTOCOL)
                   .from(t2)
-                  .join(CONNECTOR)
-                        .on(CONNECTOR.CONNECTOR_PK.eq(t2.field(t2Pk)))
+                  .join(EVSE)
+                        .on(EVSE.EVSE_PK.eq(t2.field(t2Pk)))
                   .join(CHARGE_BOX)
-                        .on(CHARGE_BOX.CHARGE_BOX_ID.eq(CONNECTOR.CHARGE_BOX_ID))
-                  .where(chargeBoxCondition, statusCondition)
+                        .on(CHARGE_BOX.CHARGE_BOX_ID.eq(EVSE.CHARGE_BOX_ID))
+                  .where(conditions)
                   .orderBy(t2.field(t2Ts).desc())
                   .fetch()
                   .map(r -> ConnectorStatus.builder()
@@ -321,11 +323,12 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
 
     @Override
     public List<Integer> getNonZeroConnectorIds(String chargeBoxId) {
-        return ctx.select(CONNECTOR.CONNECTOR_ID)
-                  .from(CONNECTOR)
-                  .where(CONNECTOR.CHARGE_BOX_ID.equal(chargeBoxId))
-                  .and(CONNECTOR.CONNECTOR_ID.notEqual(0))
-                  .fetch(CONNECTOR.CONNECTOR_ID);
+        return ctx.select(EVSE.EVSE_ID)
+                  .from(EVSE)
+                  .where(EVSE.CHARGE_BOX_ID.equal(chargeBoxId))
+                  .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+                  .and(EVSE.EVSE_ID.notEqual(0))
+                  .fetch(EVSE.EVSE_ID);
     }
 
     @Override

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
@@ -33,8 +33,9 @@ import de.rwth.idsg.steve.web.dto.ChargePointForm;
 import de.rwth.idsg.steve.web.dto.ChargePointQueryForm;
 import de.rwth.idsg.steve.web.dto.ConnectorStatusForm;
 import jooq.steve.db.enums.EvseTopologySource;
-import jooq.steve.db.tables.records.AddressRecord;
 import jooq.steve.db.tables.records.ChargeBoxRecord;
+import jooq.steve.db.tables.records.EvseConnectorRecord;
+import jooq.steve.db.tables.records.EvseRecord;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import ocpp.cs._2015._10.RegistrationStatus;
@@ -56,6 +57,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -64,8 +66,9 @@ import java.util.stream.Collectors;
 import static de.rwth.idsg.steve.utils.CustomDSL.date;
 import static de.rwth.idsg.steve.utils.CustomDSL.includes;
 import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
-import static jooq.steve.db.tables.Evse.EVSE;
 import static jooq.steve.db.tables.ConnectorStatus.CONNECTOR_STATUS;
+import static jooq.steve.db.tables.Evse.EVSE;
+import static jooq.steve.db.tables.EvseConnector.EVSE_CONNECTOR;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -251,9 +254,24 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
             throw new SteveException("Charge point not found");
         }
 
-        AddressRecord ar = addressRepository.get(ctx, cbr.getAddressPk());
+        var address = addressRepository.get(ctx, cbr.getAddressPk());
 
-        return new ChargePoint.Details(cbr, ar);
+        var evses = ctx.selectFrom(EVSE)
+            .where(EVSE.CHARGE_BOX_ID.equal(cbr.getChargeBoxId()))
+            .and(EVSE.EVSE_ID.notEqual(0)) // this is a virtual EVSE reserved to represent the whole station
+            .orderBy(EVSE.TOPOLOGY_SOURCE, EVSE.EVSE_PK)
+            .fetch();
+
+        var evsePks = evses.stream().map(EvseRecord::getEvsePk).toList();
+
+        Map<Integer, Result<EvseConnectorRecord>> evseConnectorsByEvsePk = evsePks.isEmpty()
+            ? Collections.emptyMap()
+            : ctx.selectFrom(EVSE_CONNECTOR)
+                 .where(EVSE_CONNECTOR.EVSE_PK.in(evsePks))
+                 .orderBy(EVSE_CONNECTOR.EVSE_PK, EVSE_CONNECTOR.CONNECTOR_ID)
+                 .fetchGroups(EVSE_CONNECTOR.EVSE_PK);
+
+        return new ChargePoint.Details(cbr, address, evses, evseConnectorsByEvsePk);
     }
 
     @Override
@@ -364,6 +382,7 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
             try {
                 Integer addressId = addressRepository.updateOrInsert(ctx, form.getAddress());
                 updateChargePointInternal(ctx, form, addressId);
+                updateDeviceModel(ctx, form);
 
             } catch (DataAccessException e) {
                 throw new SteveException("Failed to update the charge point with chargeBoxId '%s'",
@@ -416,7 +435,7 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
                     .getChargeBoxPk();
     }
 
-    private void updateChargePointInternal(DSLContext ctx, ChargePointForm form, Integer addressPk) {
+    private static void updateChargePointInternal(DSLContext ctx, ChargePointForm form, Integer addressPk) {
        var query = ctx.update(CHARGE_BOX)
                       .set(CHARGE_BOX.DESCRIPTION, form.getDescription())
                       .set(CHARGE_BOX.INSERT_CONNECTOR_STATUS_AFTER_TRANSACTION_MSG, form.getInsertConnectorStatusAfterTransactionMsg())
@@ -434,10 +453,69 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
              .execute();
     }
 
+    private static void updateDeviceModel(DSLContext ctx, ChargePointForm form) {
+        var evses = form.getDeviceModelForm().getEvses();
+        if (CollectionUtils.isEmpty(evses)) {
+            return;
+        }
+
+        // chargeBoxId comes from a readonly form input and can still be tampered with in the request. A submit with
+        // chargeBoxPk for station A and chargeBoxId for station B would update station A's normal fields while applying
+        // device-model changes to station B's EVSEs/connectors. Let's make sure that chargeBox ID and PK belong to the
+        // same station.
+        String chargeBoxId = ctx.select(CHARGE_BOX.CHARGE_BOX_ID)
+            .from(CHARGE_BOX)
+            .where(CHARGE_BOX.CHARGE_BOX_PK.eq(form.getChargeBoxPk()))
+            .and(CHARGE_BOX.CHARGE_BOX_ID.eq(form.getChargeBoxId()))
+            .fetchOne(CHARGE_BOX.CHARGE_BOX_ID);
+
+        if (chargeBoxId == null) {
+            return;
+        }
+
+        // to prevent evsePk claims in this form not belonging to the parent chargeBoxId
+        var evsePkSelect = ctx.select(EVSE.EVSE_PK)
+            .from(EVSE)
+            .where(EVSE.CHARGE_BOX_ID.eq(chargeBoxId));
+
+        for (var evse : evses) {
+            ctx.update(EVSE)
+                .set(EVSE.EVSE_ID_EXTERNAL, blankToNull(evse.getEvseIdExternal()))
+                .where(EVSE.EVSE_PK.eq(evse.getEvsePk()))
+                .and(EVSE.CHARGE_BOX_ID.eq(chargeBoxId))
+                .execute();
+
+            if (evse.getConnectors() == null) {
+                continue;
+            }
+
+            for (var connector : evse.getConnectors()) {
+                ctx.update(EVSE_CONNECTOR)
+                    .set(EVSE_CONNECTOR.CONNECTOR_TYPE, getNameSafely(connector.getConnectorType()))
+                    .set(EVSE_CONNECTOR.CONNECTOR_FORMAT, getNameSafely(connector.getConnectorFormat()))
+                    .set(EVSE_CONNECTOR.POWER_TYPE, getNameSafely(connector.getPowerType()))
+                    .set(EVSE_CONNECTOR.MAX_VOLTAGE, connector.getMaxVoltage())
+                    .set(EVSE_CONNECTOR.MAX_AMPERAGE, connector.getMaxAmperage())
+                    .set(EVSE_CONNECTOR.MAX_ELECTRIC_POWER, connector.getMaxElectricPower())
+                    .where(EVSE_CONNECTOR.EVSE_CONNECTOR_PK.eq(connector.getEvseConnectorPk()))
+                    .and(EVSE_CONNECTOR.EVSE_PK.eq(evse.getEvsePk()))
+                    .and(EVSE_CONNECTOR.EVSE_PK.in(evsePkSelect))
+                    .execute();
+            }
+        }
+    }
+
     private void deleteChargePointInternal(DSLContext ctx, int chargeBoxPk) {
         ctx.delete(CHARGE_BOX)
            .where(CHARGE_BOX.CHARGE_BOX_PK.equal(chargeBoxPk))
            .execute();
     }
 
+    private static String getNameSafely(Enum<?> enumType) {
+        return enumType == null ? null : enumType.name();
+    }
+
+    private static String blankToNull(String value) {
+        return StringUtils.isBlank(value) ? null : value;
+    }
 }

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ChargingProfileRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ChargingProfileRepositoryImpl.java
@@ -25,6 +25,7 @@ import de.rwth.idsg.steve.repository.dto.ChargingProfileAssignment;
 import de.rwth.idsg.steve.web.dto.ChargingProfileAssignmentQueryForm;
 import de.rwth.idsg.steve.web.dto.ChargingProfileForm;
 import de.rwth.idsg.steve.web.dto.ChargingProfileQueryForm;
+import jooq.steve.db.enums.EvseTopologySource;
 import jooq.steve.db.tables.records.ChargingProfileRecord;
 import jooq.steve.db.tables.records.ChargingSchedulePeriodRecord;
 import lombok.RequiredArgsConstructor;
@@ -48,8 +49,8 @@ import java.util.stream.Collectors;
 import static de.rwth.idsg.steve.utils.CustomDSL.includes;
 import static jooq.steve.db.Tables.CHARGING_PROFILE;
 import static jooq.steve.db.Tables.CHARGING_SCHEDULE_PERIOD;
-import static jooq.steve.db.Tables.CONNECTOR;
 import static jooq.steve.db.Tables.CONNECTOR_CHARGING_PROFILE;
+import static jooq.steve.db.Tables.EVSE;
 import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
 
 /**
@@ -71,13 +72,14 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
     public void setProfile(int chargingProfilePk, String chargeBoxId, int connectorId) {
         OcppServerRepositoryImpl.insertIgnoreConnector(ctx, chargeBoxId, connectorId);
 
-        SelectConditionStep<Record1<Integer>> connectorPkSelect = ctx.select(CONNECTOR.CONNECTOR_PK)
-                                                                     .from(CONNECTOR)
-                                                                     .where(CONNECTOR.CHARGE_BOX_ID.eq(chargeBoxId))
-                                                                     .and(CONNECTOR.CONNECTOR_ID.eq(connectorId));
+        SelectConditionStep<Record1<Integer>> connectorPkSelect = ctx.select(EVSE.EVSE_PK)
+                                                                     .from(EVSE)
+                                                                     .where(EVSE.CHARGE_BOX_ID.eq(chargeBoxId))
+                                                                     .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+                                                                     .and(EVSE.EVSE_ID.eq(connectorId));
 
         int count = ctx.insertInto(CONNECTOR_CHARGING_PROFILE)
-                       .set(CONNECTOR_CHARGING_PROFILE.CONNECTOR_PK, connectorPkSelect)
+                       .set(CONNECTOR_CHARGING_PROFILE.EVSE_PK, connectorPkSelect)
                        .set(CONNECTOR_CHARGING_PROFILE.CHARGING_PROFILE_PK, chargingProfilePk)
                        .onDuplicateKeyIgnore()
                        .execute();
@@ -89,12 +91,13 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
 
     @Override
     public void clearProfile(int chargingProfilePk, String chargeBoxId) {
-        SelectConditionStep<Record1<Integer>> connectorPkSelect = ctx.select(CONNECTOR.CONNECTOR_PK)
-                                                                     .from(CONNECTOR)
-                                                                     .where(CONNECTOR.CHARGE_BOX_ID.eq(chargeBoxId));
+        SelectConditionStep<Record1<Integer>> connectorPkSelect = ctx.select(EVSE.EVSE_PK)
+                                                                     .from(EVSE)
+                                                                     .where(EVSE.CHARGE_BOX_ID.eq(chargeBoxId))
+                                                                     .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1));
 
         ctx.delete(CONNECTOR_CHARGING_PROFILE)
-           .where(CONNECTOR_CHARGING_PROFILE.CONNECTOR_PK.in(connectorPkSelect))
+           .where(CONNECTOR_CHARGING_PROFILE.EVSE_PK.in(connectorPkSelect))
            .and(CONNECTOR_CHARGING_PROFILE.CHARGING_PROFILE_PK.eq(chargingProfilePk))
            .execute();
     }
@@ -109,11 +112,12 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
         // Connector select
         // -------------------------------------------------------------------------
 
-        Condition connectorIdCondition = (connectorId == null) ? DSL.trueCondition() : CONNECTOR.CONNECTOR_ID.eq(connectorId);
+        Condition connectorIdCondition = (connectorId == null) ? DSL.trueCondition() : EVSE.EVSE_ID.eq(connectorId);
 
-        SelectConditionStep<Record1<Integer>> connectorPkSelect = ctx.select(CONNECTOR.CONNECTOR_PK)
-                                                                     .from(CONNECTOR)
-                                                                     .where(CONNECTOR.CHARGE_BOX_ID.eq(chargeBoxId))
+        SelectConditionStep<Record1<Integer>> connectorPkSelect = ctx.select(EVSE.EVSE_PK)
+                                                                     .from(EVSE)
+                                                                     .where(EVSE.CHARGE_BOX_ID.eq(chargeBoxId))
+                                                                     .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
                                                                      .and(connectorIdCondition);
 
         // -------------------------------------------------------------------------
@@ -142,7 +146,7 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
         // -------------------------------------------------------------------------
 
         ctx.delete(CONNECTOR_CHARGING_PROFILE)
-           .where(CONNECTOR_CHARGING_PROFILE.CONNECTOR_PK.in(connectorPkSelect))
+           .where(CONNECTOR_CHARGING_PROFILE.EVSE_PK.in(connectorPkSelect))
            .and(profilePkCondition)
            .execute();
     }
@@ -153,7 +157,7 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
 
     @Override
     public List<ChargingProfileAssignment> getAssignments(ChargingProfileAssignmentQueryForm query) {
-        Condition conditions = DSL.trueCondition();
+        Condition conditions = EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1);
 
         if (query.getChargeBoxId() != null) {
             conditions = conditions.and(CHARGE_BOX.CHARGE_BOX_ID.eq(query.getChargeBoxId()));
@@ -170,20 +174,20 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
         return ctx.select(
                         CHARGE_BOX.CHARGE_BOX_PK,
                         CHARGE_BOX.CHARGE_BOX_ID,
-                        CONNECTOR.CONNECTOR_ID,
+                        EVSE.EVSE_ID,
                         CONNECTOR_CHARGING_PROFILE.CHARGING_PROFILE_PK,
                         CHARGING_PROFILE.DESCRIPTION)
                   .from(CONNECTOR_CHARGING_PROFILE)
-                  .join(CONNECTOR)
-                    .on(CONNECTOR.CONNECTOR_PK.eq(CONNECTOR_CHARGING_PROFILE.CONNECTOR_PK))
+                  .join(EVSE)
+                    .on(EVSE.EVSE_PK.eq(CONNECTOR_CHARGING_PROFILE.EVSE_PK))
                   .join(CHARGING_PROFILE)
                     .on(CHARGING_PROFILE.CHARGING_PROFILE_PK.eq(CONNECTOR_CHARGING_PROFILE.CHARGING_PROFILE_PK))
                   .join(CHARGE_BOX)
-                    .on(CHARGE_BOX.CHARGE_BOX_ID.eq(CONNECTOR.CHARGE_BOX_ID))
+                    .on(CHARGE_BOX.CHARGE_BOX_ID.eq(EVSE.CHARGE_BOX_ID))
                   .where(conditions)
                   .orderBy(
                           CHARGE_BOX.CHARGE_BOX_ID,
-                          CONNECTOR.CONNECTOR_ID,
+                          EVSE.EVSE_ID,
                           CONNECTOR_CHARGING_PROFILE.CHARGING_PROFILE_PK)
                   .fetch()
                   .map(k -> ChargingProfileAssignment.builder()
@@ -374,12 +378,12 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
     }
 
     private void checkProfileUsage(int chargingProfilePk) {
-        List<String> r = ctx.select(CONNECTOR.CHARGE_BOX_ID)
+        List<String> r = ctx.select(EVSE.CHARGE_BOX_ID)
                             .from(CONNECTOR_CHARGING_PROFILE)
-                            .join(CONNECTOR)
-                            .on(CONNECTOR.CONNECTOR_PK.eq(CONNECTOR_CHARGING_PROFILE.CONNECTOR_PK))
+                            .join(EVSE)
+                            .on(EVSE.EVSE_PK.eq(CONNECTOR_CHARGING_PROFILE.EVSE_PK))
                             .where(CONNECTOR_CHARGING_PROFILE.CHARGING_PROFILE_PK.eq(chargingProfilePk))
-                            .fetch(CONNECTOR.CHARGE_BOX_ID);
+                            .fetch(EVSE.CHARGE_BOX_ID);
         if (!r.isEmpty()) {
             throw new SteveException("Cannot modify this charging profile, since the following stations are still using it: %s", r);
         }

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ChargingProfileRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ChargingProfileRepositoryImpl.java
@@ -70,16 +70,10 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
 
     @Override
     public void setProfile(int chargingProfilePk, String chargeBoxId, int connectorId) {
-        OcppServerRepositoryImpl.insertIgnoreConnector(ctx, chargeBoxId, connectorId, false);
-
-        SelectConditionStep<Record1<Integer>> connectorPkSelect = ctx.select(EVSE.EVSE_PK)
-                                                                     .from(EVSE)
-                                                                     .where(EVSE.CHARGE_BOX_ID.eq(chargeBoxId))
-                                                                     .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
-                                                                     .and(EVSE.EVSE_ID.eq(connectorId));
+        int evsePk = Ocpp1ConnectorEvseBridge.insertIgnoreConnector(ctx, chargeBoxId, connectorId, false);
 
         int count = ctx.insertInto(CONNECTOR_CHARGING_PROFILE)
-                       .set(CONNECTOR_CHARGING_PROFILE.EVSE_PK, connectorPkSelect)
+                       .set(CONNECTOR_CHARGING_PROFILE.EVSE_PK, evsePk)
                        .set(CONNECTOR_CHARGING_PROFILE.CHARGING_PROFILE_PK, chargingProfilePk)
                        .onDuplicateKeyIgnore()
                        .execute();
@@ -91,13 +85,10 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
 
     @Override
     public void clearProfile(int chargingProfilePk, String chargeBoxId) {
-        SelectConditionStep<Record1<Integer>> connectorPkSelect = ctx.select(EVSE.EVSE_PK)
-                                                                     .from(EVSE)
-                                                                     .where(EVSE.CHARGE_BOX_ID.eq(chargeBoxId))
-                                                                     .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1));
+        var evsePkSelect = Ocpp1ConnectorEvseBridge.evsePkSelect(ctx, chargeBoxId);
 
         ctx.delete(CONNECTOR_CHARGING_PROFILE)
-           .where(CONNECTOR_CHARGING_PROFILE.EVSE_PK.in(connectorPkSelect))
+           .where(CONNECTOR_CHARGING_PROFILE.EVSE_PK.in(evsePkSelect))
            .and(CONNECTOR_CHARGING_PROFILE.CHARGING_PROFILE_PK.eq(chargingProfilePk))
            .execute();
     }
@@ -112,13 +103,7 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
         // Connector select
         // -------------------------------------------------------------------------
 
-        Condition connectorIdCondition = (connectorId == null) ? DSL.trueCondition() : EVSE.EVSE_ID.eq(connectorId);
-
-        SelectConditionStep<Record1<Integer>> connectorPkSelect = ctx.select(EVSE.EVSE_PK)
-                                                                     .from(EVSE)
-                                                                     .where(EVSE.CHARGE_BOX_ID.eq(chargeBoxId))
-                                                                     .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
-                                                                     .and(connectorIdCondition);
+        var evsePkSelect = Ocpp1ConnectorEvseBridge.evsePkSelect(ctx, chargeBoxId, connectorId);
 
         // -------------------------------------------------------------------------
         // Profile select
@@ -146,7 +131,7 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
         // -------------------------------------------------------------------------
 
         ctx.delete(CONNECTOR_CHARGING_PROFILE)
-           .where(CONNECTOR_CHARGING_PROFILE.EVSE_PK.in(connectorPkSelect))
+           .where(CONNECTOR_CHARGING_PROFILE.EVSE_PK.in(evsePkSelect))
            .and(profilePkCondition)
            .execute();
     }

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ChargingProfileRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ChargingProfileRepositoryImpl.java
@@ -70,7 +70,7 @@ public class ChargingProfileRepositoryImpl implements ChargingProfileRepository 
 
     @Override
     public void setProfile(int chargingProfilePk, String chargeBoxId, int connectorId) {
-        OcppServerRepositoryImpl.insertIgnoreConnector(ctx, chargeBoxId, connectorId);
+        OcppServerRepositoryImpl.insertIgnoreConnector(ctx, chargeBoxId, connectorId, false);
 
         SelectConditionStep<Record1<Integer>> connectorPkSelect = ctx.select(EVSE.EVSE_PK)
                                                                      .from(EVSE)

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/Ocpp1ConnectorEvseBridge.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/Ocpp1ConnectorEvseBridge.java
@@ -1,0 +1,128 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.repository.impl;
+
+import de.rwth.idsg.steve.SteveException;
+import jooq.steve.db.Tables;
+import jooq.steve.db.enums.EvseTopologySource;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Nullable;
+import org.jooq.Condition;
+import org.jooq.DSLContext;
+import org.jooq.Record1;
+import org.jooq.SelectConditionStep;
+import org.jooq.impl.DSL;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
+import static jooq.steve.db.tables.Evse.EVSE;
+import static jooq.steve.db.tables.EvseConnector.EVSE_CONNECTOR;
+
+/**
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 13.05.2026
+ */
+@Slf4j
+public class Ocpp1ConnectorEvseBridge {
+
+    public static SelectConditionStep<Record1<Integer>> evsePkSelect(DSLContext ctx, String chargeBoxId) {
+        return evsePkSelect2(ctx, chargeBoxId, null);
+    }
+
+    public static SelectConditionStep<Record1<Integer>> evsePkSelect(DSLContext ctx, String chargeBoxId, @Nullable Integer connectorId) {
+        Set<Integer> connectorIds = (connectorId == null) ? Collections.emptySet() : Set.of(connectorId);
+        return evsePkSelect2(ctx, chargeBoxId, connectorIds);
+    }
+
+    public static SelectConditionStep<Record1<Integer>> evsePkSelect2(DSLContext ctx, String chargeBoxId, Set<Integer> connectorIds) {
+        Condition evseIdCondition = CollectionUtils.isEmpty(connectorIds)
+            ? DSL.trueCondition()
+            : Tables.EVSE.EVSE_ID.in(connectorIds);
+
+        return ctx.select(EVSE.EVSE_PK)
+            .from(EVSE)
+            .where(EVSE.CHARGE_BOX_ID.eq(chargeBoxId))
+            .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+            .and(evseIdCondition);
+    }
+
+    /**
+     * If the connector information was not received before, insert it. Otherwise, ignore.
+     *
+     * @return evsePk
+     */
+    public static int insertIgnoreConnector(DSLContext ctx, String chargeBoxIdentity, int connectorId, boolean inTransactionAlready) {
+        if (inTransactionAlready) {
+            return insertIgnoreConnectorInternal(ctx, chargeBoxIdentity, connectorId);
+        } else {
+            return ctx.transactionResult(configuration ->
+                insertIgnoreConnectorInternal(DSL.using(configuration), chargeBoxIdentity, connectorId)
+            );
+        }
+    }
+
+    private static int insertIgnoreConnectorInternal(DSLContext ctx, String chargeBoxIdentity, int connectorId) {
+        var topology = ctx.select(EVSE.EVSE_PK, EVSE_CONNECTOR.EVSE_CONNECTOR_PK)
+            .from(CHARGE_BOX)
+            .leftJoin(EVSE)
+                .on(EVSE.CHARGE_BOX_ID.eq(CHARGE_BOX.CHARGE_BOX_ID))
+                .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+                .and(EVSE.EVSE_ID.eq(connectorId))
+            .leftJoin(EVSE_CONNECTOR)
+                .on(EVSE_CONNECTOR.EVSE_PK.eq(EVSE.EVSE_PK))
+                .and(EVSE_CONNECTOR.CONNECTOR_ID.eq(1))
+            .where(CHARGE_BOX.CHARGE_BOX_ID.eq(chargeBoxIdentity))
+            .forUpdate()
+            .fetchOne();
+
+        if (topology == null) {
+            throw new SteveException("Charge box with id '%s' not found", chargeBoxIdentity); // should not happen
+        }
+
+        Integer evsePk = topology.value1();
+        Integer evseConnectorPk = topology.value2();
+
+        if (evsePk == null) {
+            evsePk = ctx.insertInto(EVSE)
+                .set(EVSE.CHARGE_BOX_ID, chargeBoxIdentity)
+                .set(EVSE.TOPOLOGY_SOURCE, EvseTopologySource.ocpp1)
+                .set(EVSE.EVSE_ID, connectorId)
+                .returning(EVSE.EVSE_PK)
+                .fetchOne(EVSE.EVSE_PK);
+
+            log.debug("The connector {}/{} is NEW, and inserted into DB.", chargeBoxIdentity, connectorId);
+        }
+
+        if (connectorId != 0 && evseConnectorPk == null) {
+            final int defaultEvseConnectorId = 1;
+
+            ctx.insertInto(EVSE_CONNECTOR)
+                .set(EVSE_CONNECTOR.EVSE_PK, evsePk)
+                .set(EVSE_CONNECTOR.CONNECTOR_ID, defaultEvseConnectorId)
+                .execute();
+
+            log.debug("The evse_connector {}/{}/{} is NEW, and inserted into DB.", chargeBoxIdentity, connectorId, defaultEvseConnectorId);
+        }
+
+        return evsePk;
+    }
+}

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImpl.java
@@ -29,6 +29,7 @@ import de.rwth.idsg.steve.repository.dto.InsertTransactionParams;
 import de.rwth.idsg.steve.repository.dto.TransactionStatusUpdate;
 import de.rwth.idsg.steve.repository.dto.UpdateChargeboxParams;
 import de.rwth.idsg.steve.repository.dto.UpdateTransactionParams;
+import jooq.steve.db.enums.EvseTopologySource;
 import jooq.steve.db.enums.TransactionStopEventActor;
 import jooq.steve.db.enums.TransactionStopFailedEventActor;
 import jooq.steve.db.tables.records.ConnectorMeterValueRecord;
@@ -53,9 +54,9 @@ import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
 
 import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
-import static jooq.steve.db.tables.Connector.CONNECTOR;
 import static jooq.steve.db.tables.ConnectorMeterValue.CONNECTOR_METER_VALUE;
 import static jooq.steve.db.tables.ConnectorStatus.CONNECTOR_STATUS;
+import static jooq.steve.db.tables.Evse.EVSE;
 import static jooq.steve.db.tables.OcppTag.OCPP_TAG;
 import static jooq.steve.db.tables.Transaction.TRANSACTION;
 import static jooq.steve.db.tables.TransactionStart.TRANSACTION_START;
@@ -153,10 +154,11 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
             // -------------------------------------------------------------------------
 
             ctx.insertInto(CONNECTOR_STATUS)
-               .set(CONNECTOR_STATUS.CONNECTOR_PK, DSL.select(CONNECTOR.CONNECTOR_PK)
-                                                      .from(CONNECTOR)
-                                                      .where(CONNECTOR.CHARGE_BOX_ID.equal(p.getChargeBoxId()))
-                                                      .and(CONNECTOR.CONNECTOR_ID.equal(p.getConnectorId()))
+               .set(CONNECTOR_STATUS.EVSE_PK, DSL.select(EVSE.EVSE_PK)
+                                                      .from(EVSE)
+                                                      .where(EVSE.CHARGE_BOX_ID.equal(p.getChargeBoxId()))
+                                                      .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+                                                      .and(EVSE.EVSE_ID.equal(p.getConnectorId()))
                )
                .set(CONNECTOR_STATUS.STATUS_TIMESTAMP, p.getTimestamp())
                .set(CONNECTOR_STATUS.STATUS, p.getStatus())
@@ -201,7 +203,7 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
         }
 
         try {
-            batchInsertMeterValues(ctx, list, transaction.getConnectorPk(), transaction.getTransactionPk());
+            batchInsertMeterValues(ctx, list, transaction.getEvsePk(), transaction.getTransactionPk());
         } catch (Exception e) {
             log.error("Exception occurred", e);
         }
@@ -212,13 +214,14 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
     public TransactionRecord getTransaction(@NotNull String chargeBoxId, @Nullable Integer connectorId, int transactionId) {
         Condition connectorIdCondition = (connectorId == null)
             ? DSL.noCondition()
-            : DSL.condition(CONNECTOR.CONNECTOR_ID.eq(connectorId));
+            : DSL.condition(EVSE.EVSE_ID.eq(connectorId));
 
         var records = ctx.select(TRANSACTION.fields())
             .from(TRANSACTION)
-            .join(CONNECTOR).on(TRANSACTION.CONNECTOR_PK.eq(CONNECTOR.CONNECTOR_PK))
+            .join(EVSE).on(TRANSACTION.EVSE_PK.eq(EVSE.EVSE_PK))
             .where(TRANSACTION.TRANSACTION_PK.eq(transactionId))
-            .and(CONNECTOR.CHARGE_BOX_ID.eq(chargeBoxId))
+            .and(EVSE.CHARGE_BOX_ID.eq(chargeBoxId))
+            .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
             .and(connectorIdCondition)
             .orderBy(TRANSACTION.START_TIMESTAMP.desc())
             .fetchInto(TRANSACTION);
@@ -239,10 +242,11 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
     public int insertTransaction(InsertTransactionParams p) {
 
         SelectConditionStep<Record1<Integer>> connectorPkQuery =
-                DSL.select(CONNECTOR.CONNECTOR_PK)
-                   .from(CONNECTOR)
-                   .where(CONNECTOR.CHARGE_BOX_ID.equal(p.getChargeBoxId()))
-                   .and(CONNECTOR.CONNECTOR_ID.equal(p.getConnectorId()));
+                DSL.select(EVSE.EVSE_PK)
+                   .from(EVSE)
+                   .where(EVSE.CHARGE_BOX_ID.equal(p.getChargeBoxId()))
+                   .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+                   .and(EVSE.EVSE_ID.equal(p.getConnectorId()));
 
         // -------------------------------------------------------------------------
         // Step 1: Insert connector and idTag, if they are new to us
@@ -317,7 +321,7 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
 
         if (shouldInsertConnectorStatusAfterTransactionMsg(p.getChargeBoxId())) {
             SelectConditionStep<Record1<Integer>> connectorPkQuery =
-                    DSL.select(TRANSACTION_START.CONNECTOR_PK)
+                    DSL.select(TRANSACTION_START.EVSE_PK)
                        .from(TRANSACTION_START)
                        .where(TRANSACTION_START.TRANSACTION_PK.equal(p.getTransactionId()));
 
@@ -367,7 +371,7 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
         try {
             Record1<Integer> r = ctx.select(TRANSACTION_START.TRANSACTION_PK)
                                     .from(TRANSACTION_START)
-                                    .where(TRANSACTION_START.CONNECTOR_PK.eq(connectorPkQuery))
+                                    .where(TRANSACTION_START.EVSE_PK.eq(connectorPkQuery))
                                     .and(TRANSACTION_START.ID_TAG.eq(p.getIdTag()))
                                     .and(TRANSACTION_START.START_TIMESTAMP.eq(p.getStartTimestamp()))
                                     .and(TRANSACTION_START.START_VALUE.eq(p.getStartMeterValue()))
@@ -379,7 +383,7 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
 
             Integer transactionId = ctx.insertInto(TRANSACTION_START)
                                        .set(TRANSACTION_START.EVENT_TIMESTAMP, p.getEventTimestamp())
-                                       .set(TRANSACTION_START.CONNECTOR_PK, connectorPkQuery)
+                                       .set(TRANSACTION_START.EVSE_PK, connectorPkQuery)
                                        .set(TRANSACTION_START.ID_TAG, p.getIdTag())
                                        .set(TRANSACTION_START.START_TIMESTAMP, p.getStartTimestamp())
                                        .set(TRANSACTION_START.START_VALUE, p.getStartMeterValue())
@@ -413,7 +417,7 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
                                        TransactionStatusUpdate statusUpdate) {
         try {
             ctx.insertInto(CONNECTOR_STATUS)
-               .set(CONNECTOR_STATUS.CONNECTOR_PK, connectorPkQuery)
+               .set(CONNECTOR_STATUS.EVSE_PK, connectorPkQuery)
                .set(CONNECTOR_STATUS.STATUS_TIMESTAMP, timestamp)
                .set(CONNECTOR_STATUS.STATUS, statusUpdate.getStatus())
                .set(CONNECTOR_STATUS.ERROR_CODE, statusUpdate.getErrorCode())
@@ -427,9 +431,9 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
      * If the connector information was not received before, insert it. Otherwise, ignore.
      */
     public static void insertIgnoreConnector(DSLContext ctx, String chargeBoxIdentity, int connectorId) {
-        int count = ctx.insertInto(CONNECTOR,
-                            CONNECTOR.CHARGE_BOX_ID, CONNECTOR.CONNECTOR_ID)
-                       .values(chargeBoxIdentity, connectorId)
+        int count = ctx.insertInto(EVSE,
+                            EVSE.CHARGE_BOX_ID, EVSE.EVSE_ID, EVSE.TOPOLOGY_SOURCE)
+                       .values(chargeBoxIdentity, connectorId, EvseTopologySource.ocpp1)
                        .onDuplicateKeyIgnore() // Important detail
                        .execute();
 
@@ -468,10 +472,11 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
     }
 
     private int getConnectorPkFromConnector(DSLContext ctx, String chargeBoxIdentity, int connectorId) {
-        return ctx.select(CONNECTOR.CONNECTOR_PK)
-                  .from(CONNECTOR)
-                  .where(CONNECTOR.CHARGE_BOX_ID.equal(chargeBoxIdentity))
-                  .and(CONNECTOR.CONNECTOR_ID.equal(connectorId))
+        return ctx.select(EVSE.EVSE_PK)
+                  .from(EVSE)
+                  .where(EVSE.CHARGE_BOX_ID.equal(chargeBoxIdentity))
+                  .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+                  .and(EVSE.EVSE_ID.equal(connectorId))
                   .fetchOne()
                   .value1();
     }
@@ -482,7 +487,7 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
                     .flatMap(t -> t.getSampledValue()
                                    .stream()
                                    .map(k -> ctx.newRecord(CONNECTOR_METER_VALUE)
-                                                .setConnectorPk(connectorPk)
+                                                .setEvsePk(connectorPk)
                                                 .setTransactionPk(transactionId)
                                                 .setValueTimestamp(t.getTimestamp())
                                                 .setValue(k.getValue())

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImpl.java
@@ -57,6 +57,7 @@ import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
 import static jooq.steve.db.tables.ConnectorMeterValue.CONNECTOR_METER_VALUE;
 import static jooq.steve.db.tables.ConnectorStatus.CONNECTOR_STATUS;
 import static jooq.steve.db.tables.Evse.EVSE;
+import static jooq.steve.db.tables.EvseConnector.EVSE_CONNECTOR;
 import static jooq.steve.db.tables.OcppTag.OCPP_TAG;
 import static jooq.steve.db.tables.Transaction.TRANSACTION;
 import static jooq.steve.db.tables.TransactionStart.TRANSACTION_START;
@@ -147,7 +148,7 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
             DSLContext ctx = DSL.using(configuration);
 
             // Step 1
-            insertIgnoreConnector(ctx, p.getChargeBoxId(), p.getConnectorId());
+            insertIgnoreConnector(ctx, p.getChargeBoxId(), p.getConnectorId(), true);
 
             // -------------------------------------------------------------------------
             // Step 2: We store a log of connector statuses
@@ -182,7 +183,7 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
             try {
                 DSLContext ctx = DSL.using(configuration);
 
-                insertIgnoreConnector(ctx, chargeBoxIdentity, connectorId);
+                insertIgnoreConnector(ctx, chargeBoxIdentity, connectorId, true);
                 int connectorPk = getConnectorPkFromConnector(ctx, chargeBoxIdentity, connectorId);
                 batchInsertMeterValues(ctx, list, connectorPk, transactionId);
             } catch (Exception e) {
@@ -252,7 +253,7 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
         // Step 1: Insert connector and idTag, if they are new to us
         // -------------------------------------------------------------------------
 
-        insertIgnoreConnector(ctx, p.getChargeBoxId(), p.getConnectorId());
+        insertIgnoreConnector(ctx, p.getChargeBoxId(), p.getConnectorId(), false);
 
         // it is important to insert idTag before transaction, since the transaction table references it
         boolean unknownTagInserted = insertIgnoreIdTag(ctx, p);
@@ -430,15 +431,57 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
     /**
      * If the connector information was not received before, insert it. Otherwise, ignore.
      */
-    public static void insertIgnoreConnector(DSLContext ctx, String chargeBoxIdentity, int connectorId) {
-        int count = ctx.insertInto(EVSE,
-                            EVSE.CHARGE_BOX_ID, EVSE.EVSE_ID, EVSE.TOPOLOGY_SOURCE)
-                       .values(chargeBoxIdentity, connectorId, EvseTopologySource.ocpp1)
-                       .onDuplicateKeyIgnore() // Important detail
-                       .execute();
+    public static void insertIgnoreConnector(DSLContext ctx, String chargeBoxIdentity, int connectorId, boolean inTransactionAlready) {
+        if (inTransactionAlready) {
+            insertIgnoreConnectorInternal(ctx, chargeBoxIdentity, connectorId);
+        } else {
+            ctx.transaction(configuration ->
+                insertIgnoreConnectorInternal(DSL.using(configuration), chargeBoxIdentity, connectorId)
+            );
+        }
+    }
 
-        if (count == 1) {
-            log.info("The connector {}/{} is NEW, and inserted into DB.", chargeBoxIdentity, connectorId);
+    private static void insertIgnoreConnectorInternal(DSLContext ctx, String chargeBoxIdentity, int connectorId) {
+        var topology = ctx.select(EVSE.EVSE_PK, EVSE_CONNECTOR.EVSE_CONNECTOR_PK)
+            .from(CHARGE_BOX)
+            .leftJoin(EVSE)
+                .on(EVSE.CHARGE_BOX_ID.eq(CHARGE_BOX.CHARGE_BOX_ID))
+                .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+                .and(EVSE.EVSE_ID.eq(connectorId))
+            .leftJoin(EVSE_CONNECTOR)
+                .on(EVSE_CONNECTOR.EVSE_PK.eq(EVSE.EVSE_PK))
+                .and(EVSE_CONNECTOR.CONNECTOR_ID.eq(1))
+            .where(CHARGE_BOX.CHARGE_BOX_ID.eq(chargeBoxIdentity))
+            .forUpdate()
+            .fetchOne();
+
+        if (topology == null) {
+            throw new SteveException("Charge box with id '%s' not found", chargeBoxIdentity); // should not happen
+        }
+
+        Integer evsePk = topology.value1();
+        Integer evseConnectorPk = topology.value2();
+
+        if (evsePk == null) {
+            evsePk = ctx.insertInto(EVSE)
+                .set(EVSE.CHARGE_BOX_ID, chargeBoxIdentity)
+                .set(EVSE.TOPOLOGY_SOURCE, EvseTopologySource.ocpp1)
+                .set(EVSE.EVSE_ID, connectorId)
+                .returning(EVSE.EVSE_PK)
+                .fetchOne(EVSE.EVSE_PK);
+
+            log.debug("The connector {}/{} is NEW, and inserted into DB.", chargeBoxIdentity, connectorId);
+        }
+
+        if (connectorId != 0 && evseConnectorPk == null) {
+            final int defaultEvseConnectorId = 1;
+
+            ctx.insertInto(EVSE_CONNECTOR)
+                .set(EVSE_CONNECTOR.EVSE_PK, evsePk)
+                .set(EVSE_CONNECTOR.CONNECTOR_ID, defaultEvseConnectorId)
+                .execute();
+
+            log.debug("The evse_connector {}/{}/{} is NEW, and inserted into DB.", chargeBoxIdentity, connectorId, defaultEvseConnectorId);
         }
     }
 

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImpl.java
@@ -26,7 +26,6 @@ import de.rwth.idsg.steve.repository.OcppServerRepository;
 import de.rwth.idsg.steve.repository.ReservationRepository;
 import de.rwth.idsg.steve.repository.dto.InsertConnectorStatusParams;
 import de.rwth.idsg.steve.repository.dto.InsertTransactionParams;
-import de.rwth.idsg.steve.repository.dto.TransactionStatusUpdate;
 import de.rwth.idsg.steve.repository.dto.UpdateChargeboxParams;
 import de.rwth.idsg.steve.repository.dto.UpdateTransactionParams;
 import jooq.steve.db.enums.EvseTopologySource;
@@ -44,7 +43,6 @@ import org.joda.time.DateTime;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Record1;
-import org.jooq.SelectConditionStep;
 import org.jooq.impl.DSL;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.CollectionUtils;
@@ -57,7 +55,6 @@ import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
 import static jooq.steve.db.tables.ConnectorMeterValue.CONNECTOR_METER_VALUE;
 import static jooq.steve.db.tables.ConnectorStatus.CONNECTOR_STATUS;
 import static jooq.steve.db.tables.Evse.EVSE;
-import static jooq.steve.db.tables.EvseConnector.EVSE_CONNECTOR;
 import static jooq.steve.db.tables.OcppTag.OCPP_TAG;
 import static jooq.steve.db.tables.Transaction.TRANSACTION;
 import static jooq.steve.db.tables.TransactionStart.TRANSACTION_START;
@@ -148,19 +145,14 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
             DSLContext ctx = DSL.using(configuration);
 
             // Step 1
-            insertIgnoreConnector(ctx, p.getChargeBoxId(), p.getConnectorId(), true);
+            var evsePk = Ocpp1ConnectorEvseBridge.insertIgnoreConnector(ctx, p.getChargeBoxId(), p.getConnectorId(), true);
 
             // -------------------------------------------------------------------------
             // Step 2: We store a log of connector statuses
             // -------------------------------------------------------------------------
 
             ctx.insertInto(CONNECTOR_STATUS)
-               .set(CONNECTOR_STATUS.EVSE_PK, DSL.select(EVSE.EVSE_PK)
-                                                      .from(EVSE)
-                                                      .where(EVSE.CHARGE_BOX_ID.equal(p.getChargeBoxId()))
-                                                      .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
-                                                      .and(EVSE.EVSE_ID.equal(p.getConnectorId()))
-               )
+               .set(CONNECTOR_STATUS.EVSE_PK, evsePk)
                .set(CONNECTOR_STATUS.STATUS_TIMESTAMP, p.getTimestamp())
                .set(CONNECTOR_STATUS.STATUS, p.getStatus())
                .set(CONNECTOR_STATUS.ERROR_CODE, p.getErrorCode())
@@ -183,9 +175,8 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
             try {
                 DSLContext ctx = DSL.using(configuration);
 
-                insertIgnoreConnector(ctx, chargeBoxIdentity, connectorId, true);
-                int connectorPk = getConnectorPkFromConnector(ctx, chargeBoxIdentity, connectorId);
-                batchInsertMeterValues(ctx, list, connectorPk, transactionId);
+                var evsePk = Ocpp1ConnectorEvseBridge.insertIgnoreConnector(ctx, chargeBoxIdentity, connectorId, true);
+                batchInsertMeterValues(ctx, list, evsePk, transactionId);
             } catch (Exception e) {
                 log.error("Exception occurred", e);
             }
@@ -242,18 +233,11 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
     @Override
     public int insertTransaction(InsertTransactionParams p) {
 
-        SelectConditionStep<Record1<Integer>> connectorPkQuery =
-                DSL.select(EVSE.EVSE_PK)
-                   .from(EVSE)
-                   .where(EVSE.CHARGE_BOX_ID.equal(p.getChargeBoxId()))
-                   .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
-                   .and(EVSE.EVSE_ID.equal(p.getConnectorId()));
-
         // -------------------------------------------------------------------------
         // Step 1: Insert connector and idTag, if they are new to us
         // -------------------------------------------------------------------------
 
-        insertIgnoreConnector(ctx, p.getChargeBoxId(), p.getConnectorId(), false);
+        var evsePk = Ocpp1ConnectorEvseBridge.insertIgnoreConnector(ctx, p.getChargeBoxId(), p.getConnectorId(), false);
 
         // it is important to insert idTag before transaction, since the transaction table references it
         boolean unknownTagInserted = insertIgnoreIdTag(ctx, p);
@@ -262,7 +246,7 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
         // Step 2: Insert transaction if it does not exist already
         // -------------------------------------------------------------------------
 
-        TransactionDataHolder data = insertIgnoreTransaction(p, connectorPkQuery);
+        TransactionDataHolder data = insertIgnoreTransaction(p, evsePk);
         int transactionId = data.transactionId;
 
         if (data.existsAlready) {
@@ -287,7 +271,16 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
         // -------------------------------------------------------------------------
 
         if (shouldInsertConnectorStatusAfterTransactionMsg(p.getChargeBoxId())) {
-            insertConnectorStatus(ctx, connectorPkQuery, p.getStartTimestamp(), p.getStatusUpdate());
+            try {
+                ctx.insertInto(CONNECTOR_STATUS)
+                    .set(CONNECTOR_STATUS.EVSE_PK, evsePk)
+                    .set(CONNECTOR_STATUS.STATUS_TIMESTAMP, p.getStartTimestamp())
+                    .set(CONNECTOR_STATUS.STATUS, p.getStatusUpdate().getStatus())
+                    .set(CONNECTOR_STATUS.ERROR_CODE, p.getStatusUpdate().getErrorCode())
+                    .execute();
+            } catch (Exception e) {
+                log.error("Exception occurred", e);
+            }
         }
 
         return transactionId;
@@ -321,12 +314,20 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
         // -------------------------------------------------------------------------
 
         if (shouldInsertConnectorStatusAfterTransactionMsg(p.getChargeBoxId())) {
-            SelectConditionStep<Record1<Integer>> connectorPkQuery =
-                    DSL.select(TRANSACTION_START.EVSE_PK)
-                       .from(TRANSACTION_START)
-                       .where(TRANSACTION_START.TRANSACTION_PK.equal(p.getTransactionId()));
+            var evsePkQuery = DSL.select(TRANSACTION_START.EVSE_PK)
+                .from(TRANSACTION_START)
+                .where(TRANSACTION_START.TRANSACTION_PK.equal(p.getTransactionId()));
 
-            insertConnectorStatus(ctx, connectorPkQuery, p.getStopTimestamp(), p.getStatusUpdate());
+            try {
+                ctx.insertInto(CONNECTOR_STATUS)
+                    .set(CONNECTOR_STATUS.EVSE_PK, evsePkQuery)
+                    .set(CONNECTOR_STATUS.STATUS_TIMESTAMP, p.getStopTimestamp())
+                    .set(CONNECTOR_STATUS.STATUS, p.getStatusUpdate().getStatus())
+                    .set(CONNECTOR_STATUS.ERROR_CODE, p.getStatusUpdate().getErrorCode())
+                    .execute();
+            } catch (Exception e) {
+                log.error("Exception occurred", e);
+            }
         }
     }
 
@@ -365,14 +366,13 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
      * problems the response of StartTransaction could not be delivered and station tries again later), we do not want
      * to insert this into database multiple times.
      */
-    private TransactionDataHolder insertIgnoreTransaction(InsertTransactionParams p,
-                                                          SelectConditionStep<Record1<Integer>> connectorPkQuery) {
+    private TransactionDataHolder insertIgnoreTransaction(InsertTransactionParams p, int evsePk) {
         Lock l = transactionTableLocks.get(p.getChargeBoxId());
         l.lock();
         try {
             Record1<Integer> r = ctx.select(TRANSACTION_START.TRANSACTION_PK)
                                     .from(TRANSACTION_START)
-                                    .where(TRANSACTION_START.EVSE_PK.eq(connectorPkQuery))
+                                    .where(TRANSACTION_START.EVSE_PK.eq(evsePk))
                                     .and(TRANSACTION_START.ID_TAG.eq(p.getIdTag()))
                                     .and(TRANSACTION_START.START_TIMESTAMP.eq(p.getStartTimestamp()))
                                     .and(TRANSACTION_START.START_VALUE.eq(p.getStartMeterValue()))
@@ -384,7 +384,7 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
 
             Integer transactionId = ctx.insertInto(TRANSACTION_START)
                                        .set(TRANSACTION_START.EVENT_TIMESTAMP, p.getEventTimestamp())
-                                       .set(TRANSACTION_START.EVSE_PK, connectorPkQuery)
+                                       .set(TRANSACTION_START.EVSE_PK, evsePk)
                                        .set(TRANSACTION_START.ID_TAG, p.getIdTag())
                                        .set(TRANSACTION_START.START_TIMESTAMP, p.getStartTimestamp())
                                        .set(TRANSACTION_START.START_VALUE, p.getStartMeterValue())
@@ -400,88 +400,6 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
             return new TransactionDataHolder(false, transactionId);
         } finally {
             l.unlock();
-        }
-    }
-
-    /**
-     * After a transaction start/stop event, a charging station _might_ send a connector status notification, but it is
-     * not required. With this, we make sure that the status is updated accordingly. Since we use the timestamp of the
-     * transaction data, we do not necessarily insert a "most recent" status.
-     *
-     * If the station sends a notification, we will have a more recent timestamp, and therefore the status of the
-     * notification will be used as current. Or, if this transaction data was sent to us for a failed push from the past
-     * and we have a "more recent" status, it will still be the current status.
-     */
-    private void insertConnectorStatus(DSLContext ctx,
-                                       SelectConditionStep<Record1<Integer>> connectorPkQuery,
-                                       DateTime timestamp,
-                                       TransactionStatusUpdate statusUpdate) {
-        try {
-            ctx.insertInto(CONNECTOR_STATUS)
-               .set(CONNECTOR_STATUS.EVSE_PK, connectorPkQuery)
-               .set(CONNECTOR_STATUS.STATUS_TIMESTAMP, timestamp)
-               .set(CONNECTOR_STATUS.STATUS, statusUpdate.getStatus())
-               .set(CONNECTOR_STATUS.ERROR_CODE, statusUpdate.getErrorCode())
-               .execute();
-        } catch (Exception e) {
-            log.error("Exception occurred", e);
-        }
-    }
-
-    /**
-     * If the connector information was not received before, insert it. Otherwise, ignore.
-     */
-    public static void insertIgnoreConnector(DSLContext ctx, String chargeBoxIdentity, int connectorId, boolean inTransactionAlready) {
-        if (inTransactionAlready) {
-            insertIgnoreConnectorInternal(ctx, chargeBoxIdentity, connectorId);
-        } else {
-            ctx.transaction(configuration ->
-                insertIgnoreConnectorInternal(DSL.using(configuration), chargeBoxIdentity, connectorId)
-            );
-        }
-    }
-
-    private static void insertIgnoreConnectorInternal(DSLContext ctx, String chargeBoxIdentity, int connectorId) {
-        var topology = ctx.select(EVSE.EVSE_PK, EVSE_CONNECTOR.EVSE_CONNECTOR_PK)
-            .from(CHARGE_BOX)
-            .leftJoin(EVSE)
-                .on(EVSE.CHARGE_BOX_ID.eq(CHARGE_BOX.CHARGE_BOX_ID))
-                .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
-                .and(EVSE.EVSE_ID.eq(connectorId))
-            .leftJoin(EVSE_CONNECTOR)
-                .on(EVSE_CONNECTOR.EVSE_PK.eq(EVSE.EVSE_PK))
-                .and(EVSE_CONNECTOR.CONNECTOR_ID.eq(1))
-            .where(CHARGE_BOX.CHARGE_BOX_ID.eq(chargeBoxIdentity))
-            .forUpdate()
-            .fetchOne();
-
-        if (topology == null) {
-            throw new SteveException("Charge box with id '%s' not found", chargeBoxIdentity); // should not happen
-        }
-
-        Integer evsePk = topology.value1();
-        Integer evseConnectorPk = topology.value2();
-
-        if (evsePk == null) {
-            evsePk = ctx.insertInto(EVSE)
-                .set(EVSE.CHARGE_BOX_ID, chargeBoxIdentity)
-                .set(EVSE.TOPOLOGY_SOURCE, EvseTopologySource.ocpp1)
-                .set(EVSE.EVSE_ID, connectorId)
-                .returning(EVSE.EVSE_PK)
-                .fetchOne(EVSE.EVSE_PK);
-
-            log.debug("The connector {}/{} is NEW, and inserted into DB.", chargeBoxIdentity, connectorId);
-        }
-
-        if (connectorId != 0 && evseConnectorPk == null) {
-            final int defaultEvseConnectorId = 1;
-
-            ctx.insertInto(EVSE_CONNECTOR)
-                .set(EVSE_CONNECTOR.EVSE_PK, evsePk)
-                .set(EVSE_CONNECTOR.CONNECTOR_ID, defaultEvseConnectorId)
-                .execute();
-
-            log.debug("The evse_connector {}/{}/{} is NEW, and inserted into DB.", chargeBoxIdentity, connectorId, defaultEvseConnectorId);
         }
     }
 
@@ -504,6 +422,15 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
         return count == 1;
     }
 
+    /**
+     * After a transaction start/stop event, a charging station _might_ send a connector status notification, but it is
+     * not required. With this, we make sure that the status is updated accordingly. Since we use the timestamp of the
+     * transaction data, we do not necessarily insert a "most recent" status.
+     *
+     * If the station sends a notification, we will have a more recent timestamp, and therefore the status of the
+     * notification will be used as current. Or, if this transaction data was sent to us for a failed push from the past
+     * and we have a "more recent" status, it will still be the current status.
+     */
     private boolean shouldInsertConnectorStatusAfterTransactionMsg(String chargeBoxId) {
         Record1<Integer> r = ctx.selectOne()
                                 .from(CHARGE_BOX)
@@ -514,23 +441,13 @@ public class OcppServerRepositoryImpl implements OcppServerRepository {
         return (r != null) && (r.value1() == 1);
     }
 
-    private int getConnectorPkFromConnector(DSLContext ctx, String chargeBoxIdentity, int connectorId) {
-        return ctx.select(EVSE.EVSE_PK)
-                  .from(EVSE)
-                  .where(EVSE.CHARGE_BOX_ID.equal(chargeBoxIdentity))
-                  .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
-                  .and(EVSE.EVSE_ID.equal(connectorId))
-                  .fetchOne()
-                  .value1();
-    }
-
-    private void batchInsertMeterValues(DSLContext ctx, List<MeterValue> list, int connectorPk, Integer transactionId) {
+    private void batchInsertMeterValues(DSLContext ctx, List<MeterValue> list, int evsePk, Integer transactionId) {
         List<ConnectorMeterValueRecord> batch =
                 list.stream()
                     .flatMap(t -> t.getSampledValue()
                                    .stream()
                                    .map(k -> ctx.newRecord(CONNECTOR_METER_VALUE)
-                                                .setEvsePk(connectorPk)
+                                                .setEvsePk(evsePk)
                                                 .setTransactionPk(transactionId)
                                                 .setValueTimestamp(t.getTimestamp())
                                                 .setValue(k.getValue())

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ReservationRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ReservationRepositoryImpl.java
@@ -134,7 +134,7 @@ public class ReservationRepositoryImpl implements ReservationRepository {
         // Check overlapping
         //isOverlapping(startTimestamp, expiryTimestamp, chargeBoxId);
 
-        OcppServerRepositoryImpl.insertIgnoreConnector(ctx, params.getChargeBoxId(), params.getConnectorId());
+        OcppServerRepositoryImpl.insertIgnoreConnector(ctx, params.getChargeBoxId(), params.getConnectorId(), false);
 
         SelectConditionStep<Record1<Integer>> connectorPkQuery =
                 DSL.select(EVSE.EVSE_PK)

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ReservationRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ReservationRepositoryImpl.java
@@ -25,6 +25,7 @@ import de.rwth.idsg.steve.repository.dto.InsertReservationParams;
 import de.rwth.idsg.steve.repository.dto.Reservation;
 import de.rwth.idsg.steve.utils.DateTimeUtils;
 import de.rwth.idsg.steve.web.dto.ReservationQueryForm;
+import jooq.steve.db.enums.EvseTopologySource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -33,7 +34,6 @@ import org.jooq.DSLContext;
 import org.jooq.Record1;
 import org.jooq.Record10;
 import org.jooq.RecordMapper;
-import org.jooq.Select;
 import org.jooq.SelectConditionStep;
 import org.jooq.SelectQuery;
 import org.jooq.exception.DataAccessException;
@@ -44,7 +44,7 @@ import java.util.List;
 
 import static de.rwth.idsg.steve.repository.impl.RepositoryUtils.ocppTagByUserIdQuery;
 import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
-import static jooq.steve.db.tables.Connector.CONNECTOR;
+import static jooq.steve.db.tables.Evse.EVSE;
 import static jooq.steve.db.tables.OcppTag.OCPP_TAG;
 import static jooq.steve.db.tables.Reservation.RESERVATION;
 
@@ -65,8 +65,8 @@ public class ReservationRepositoryImpl implements ReservationRepository {
         SelectQuery selectQuery = ctx.selectQuery();
         selectQuery.addFrom(RESERVATION);
         selectQuery.addJoin(OCPP_TAG, OCPP_TAG.ID_TAG.eq(RESERVATION.ID_TAG));
-        selectQuery.addJoin(CONNECTOR, CONNECTOR.CONNECTOR_PK.eq(RESERVATION.CONNECTOR_PK));
-        selectQuery.addJoin(CHARGE_BOX, CONNECTOR.CHARGE_BOX_ID.eq(CHARGE_BOX.CHARGE_BOX_ID));
+        selectQuery.addJoin(EVSE, EVSE.EVSE_PK.eq(RESERVATION.EVSE_PK));
+        selectQuery.addJoin(CHARGE_BOX, EVSE.CHARGE_BOX_ID.eq(CHARGE_BOX.CHARGE_BOX_ID));
 
         selectQuery.addSelect(
                 RESERVATION.RESERVATION_PK,
@@ -78,7 +78,7 @@ public class ReservationRepositoryImpl implements ReservationRepository {
                 RESERVATION.START_DATETIME,
                 RESERVATION.EXPIRY_DATETIME,
                 RESERVATION.STATUS,
-                CONNECTOR.CONNECTOR_ID
+                EVSE.EVSE_ID
         );
 
         if (form.isReservationIdSet()) {
@@ -106,6 +106,8 @@ public class ReservationRepositoryImpl implements ReservationRepository {
             selectQuery.addConditions(RESERVATION.STATUS.eq(form.getStatus().name()));
         }
 
+        selectQuery.addConditions(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1));
+
         processType(selectQuery, form);
 
         // Default order
@@ -118,9 +120,10 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     public List<Integer> getActiveReservationIds(String chargeBoxId) {
         return ctx.select(RESERVATION.RESERVATION_PK)
                   .from(RESERVATION)
-                  .where(RESERVATION.CONNECTOR_PK.in(DSL.select(CONNECTOR.CONNECTOR_PK)
-                                                        .from(CONNECTOR)
-                                                        .where(CONNECTOR.CHARGE_BOX_ID.equal(chargeBoxId))))
+                  .where(RESERVATION.EVSE_PK.in(DSL.select(EVSE.EVSE_PK)
+                                                   .from(EVSE)
+                                                   .where(EVSE.CHARGE_BOX_ID.equal(chargeBoxId))
+                                                   .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))))
                   .and(RESERVATION.EXPIRY_DATETIME.greaterThan(DateTime.now()))
                   .and(RESERVATION.STATUS.equal(ReservationStatus.ACCEPTED.name()))
                   .fetch(RESERVATION.RESERVATION_PK);
@@ -134,13 +137,14 @@ public class ReservationRepositoryImpl implements ReservationRepository {
         OcppServerRepositoryImpl.insertIgnoreConnector(ctx, params.getChargeBoxId(), params.getConnectorId());
 
         SelectConditionStep<Record1<Integer>> connectorPkQuery =
-                DSL.select(CONNECTOR.CONNECTOR_PK)
-                   .from(CONNECTOR)
-                   .where(CONNECTOR.CHARGE_BOX_ID.equal(params.getChargeBoxId()))
-                   .and(CONNECTOR.CONNECTOR_ID.equal(params.getConnectorId()));
+                DSL.select(EVSE.EVSE_PK)
+                   .from(EVSE)
+                   .where(EVSE.CHARGE_BOX_ID.equal(params.getChargeBoxId()))
+                   .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+                   .and(EVSE.EVSE_ID.equal(params.getConnectorId()));
 
         int reservationId = ctx.insertInto(RESERVATION)
-                               .set(RESERVATION.CONNECTOR_PK, connectorPkQuery)
+                               .set(RESERVATION.EVSE_PK, connectorPkQuery)
                                .set(RESERVATION.ID_TAG, params.getIdTag())
                                .set(RESERVATION.START_DATETIME, params.getStartTimestamp())
                                .set(RESERVATION.EXPIRY_DATETIME, params.getExpiryTimestamp())
@@ -194,12 +198,13 @@ public class ReservationRepositoryImpl implements ReservationRepository {
         // TC_049_CSMS: Reservation of a Charge Point
         // -------------------------------------------------------------------------
 
-        var chargePointWideConnectorPk = DSL.select(CONNECTOR.CONNECTOR_PK)
-                                            .from(CONNECTOR)
-                                            .where(CONNECTOR.CHARGE_BOX_ID.eq(chargeBoxId))
-                                            .and(CONNECTOR.CONNECTOR_ID.in(0, connectorId));
+        var chargePointWideConnectorPk = DSL.select(EVSE.EVSE_PK)
+                                            .from(EVSE)
+                                            .where(EVSE.CHARGE_BOX_ID.eq(chargeBoxId))
+                                            .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+                                            .and(EVSE.EVSE_ID.in(0, connectorId));
 
-        var connectorCondition = RESERVATION.CONNECTOR_PK.in(chargePointWideConnectorPk);
+        var connectorCondition = RESERVATION.EVSE_PK.in(chargePointWideConnectorPk);
 
         // -------------------------------------------------------------------------
         // Execute
@@ -223,17 +228,18 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     @Override
     public void cancelActiveReservations(String chargeBoxId, @NotNull Integer connectorId) {
         try {
-            var connectorSelect = DSL.select(CONNECTOR.CONNECTOR_PK)
-                                     .from(CONNECTOR)
-                                     .where(CONNECTOR.CHARGE_BOX_ID.equal(chargeBoxId));
+            var connectorSelect = DSL.select(EVSE.EVSE_PK)
+                                     .from(EVSE)
+                                     .where(EVSE.CHARGE_BOX_ID.equal(chargeBoxId))
+                                     .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1));
 
             if (connectorId != 0) {
-                connectorSelect = connectorSelect.and(CONNECTOR.CONNECTOR_ID.equal(connectorId));
+                connectorSelect = connectorSelect.and(EVSE.EVSE_ID.equal(connectorId));
             }
 
             int count = ctx.update(RESERVATION)
                            .set(RESERVATION.STATUS, ReservationStatus.CANCELLED.name())
-                           .where(RESERVATION.CONNECTOR_PK.in(connectorSelect))
+                           .where(RESERVATION.EVSE_PK.in(connectorSelect))
                            .and(RESERVATION.STATUS.equal(ReservationStatus.ACCEPTED.name()))
                            .and(RESERVATION.EXPIRY_DATETIME.greaterThan(DateTime.now()))
                            .execute();

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ReservationRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ReservationRepositoryImpl.java
@@ -31,16 +31,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTime;
 import org.jooq.DSLContext;
-import org.jooq.Record1;
 import org.jooq.Record10;
 import org.jooq.RecordMapper;
-import org.jooq.SelectConditionStep;
 import org.jooq.SelectQuery;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 
 import static de.rwth.idsg.steve.repository.impl.RepositoryUtils.ocppTagByUserIdQuery;
 import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
@@ -118,12 +117,11 @@ public class ReservationRepositoryImpl implements ReservationRepository {
 
     @Override
     public List<Integer> getActiveReservationIds(String chargeBoxId) {
+        var evsePkSelect = Ocpp1ConnectorEvseBridge.evsePkSelect(ctx, chargeBoxId);
+
         return ctx.select(RESERVATION.RESERVATION_PK)
                   .from(RESERVATION)
-                  .where(RESERVATION.EVSE_PK.in(DSL.select(EVSE.EVSE_PK)
-                                                   .from(EVSE)
-                                                   .where(EVSE.CHARGE_BOX_ID.equal(chargeBoxId))
-                                                   .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))))
+                  .where(RESERVATION.EVSE_PK.in(evsePkSelect))
                   .and(RESERVATION.EXPIRY_DATETIME.greaterThan(DateTime.now()))
                   .and(RESERVATION.STATUS.equal(ReservationStatus.ACCEPTED.name()))
                   .fetch(RESERVATION.RESERVATION_PK);
@@ -134,17 +132,10 @@ public class ReservationRepositoryImpl implements ReservationRepository {
         // Check overlapping
         //isOverlapping(startTimestamp, expiryTimestamp, chargeBoxId);
 
-        OcppServerRepositoryImpl.insertIgnoreConnector(ctx, params.getChargeBoxId(), params.getConnectorId(), false);
-
-        SelectConditionStep<Record1<Integer>> connectorPkQuery =
-                DSL.select(EVSE.EVSE_PK)
-                   .from(EVSE)
-                   .where(EVSE.CHARGE_BOX_ID.equal(params.getChargeBoxId()))
-                   .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
-                   .and(EVSE.EVSE_ID.equal(params.getConnectorId()));
+        var evsePk = Ocpp1ConnectorEvseBridge.insertIgnoreConnector(ctx, params.getChargeBoxId(), params.getConnectorId(), false);
 
         int reservationId = ctx.insertInto(RESERVATION)
-                               .set(RESERVATION.EVSE_PK, connectorPkQuery)
+                               .set(RESERVATION.EVSE_PK, evsePk)
                                .set(RESERVATION.ID_TAG, params.getIdTag())
                                .set(RESERVATION.START_DATETIME, params.getStartTimestamp())
                                .set(RESERVATION.EXPIRY_DATETIME, params.getExpiryTimestamp())
@@ -198,13 +189,9 @@ public class ReservationRepositoryImpl implements ReservationRepository {
         // TC_049_CSMS: Reservation of a Charge Point
         // -------------------------------------------------------------------------
 
-        var chargePointWideConnectorPk = DSL.select(EVSE.EVSE_PK)
-                                            .from(EVSE)
-                                            .where(EVSE.CHARGE_BOX_ID.eq(chargeBoxId))
-                                            .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
-                                            .and(EVSE.EVSE_ID.in(0, connectorId));
+        var chargePointWideEvsePk = Ocpp1ConnectorEvseBridge.evsePkSelect2(ctx, chargeBoxId, Set.of(0, connectorId));
 
-        var connectorCondition = RESERVATION.EVSE_PK.in(chargePointWideConnectorPk);
+        var evseCondition = RESERVATION.EVSE_PK.in(chargePointWideEvsePk);
 
         // -------------------------------------------------------------------------
         // Execute
@@ -215,7 +202,7 @@ public class ReservationRepositoryImpl implements ReservationRepository {
                        .set(RESERVATION.TRANSACTION_PK, transactionId)
                        .where(RESERVATION.RESERVATION_PK.equal(reservationId))
                        .and(idTagCondition)
-                       .and(connectorCondition)
+                       .and(evseCondition)
                        .and(RESERVATION.STATUS.eq(ReservationStatus.ACCEPTED.name()))
                        .execute();
 
@@ -228,18 +215,13 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     @Override
     public void cancelActiveReservations(String chargeBoxId, @NotNull Integer connectorId) {
         try {
-            var connectorSelect = DSL.select(EVSE.EVSE_PK)
-                                     .from(EVSE)
-                                     .where(EVSE.CHARGE_BOX_ID.equal(chargeBoxId))
-                                     .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1));
-
-            if (connectorId != 0) {
-                connectorSelect = connectorSelect.and(EVSE.EVSE_ID.equal(connectorId));
-            }
+            var evsePkSelect = (connectorId == 0)
+                ? Ocpp1ConnectorEvseBridge.evsePkSelect(ctx, chargeBoxId)
+                : Ocpp1ConnectorEvseBridge.evsePkSelect(ctx, chargeBoxId, connectorId);
 
             int count = ctx.update(RESERVATION)
                            .set(RESERVATION.STATUS, ReservationStatus.CANCELLED.name())
-                           .where(RESERVATION.EVSE_PK.in(connectorSelect))
+                           .where(RESERVATION.EVSE_PK.in(evsePkSelect))
                            .and(RESERVATION.STATUS.equal(ReservationStatus.ACCEPTED.name()))
                            .and(RESERVATION.EXPIRY_DATETIME.greaterThan(DateTime.now()))
                            .execute();

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/TransactionRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/TransactionRepositoryImpl.java
@@ -26,6 +26,7 @@ import de.rwth.idsg.steve.utils.DateTimeUtils;
 import de.rwth.idsg.steve.utils.TransactionStopServiceHelper;
 import de.rwth.idsg.steve.web.dto.QueryPeriodType;
 import de.rwth.idsg.steve.web.dto.TransactionQueryForm;
+import jooq.steve.db.enums.EvseTopologySource;
 import jooq.steve.db.tables.records.TransactionRecord;
 import jooq.steve.db.tables.records.TransactionStartRecord;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +45,7 @@ import java.util.List;
 import static de.rwth.idsg.steve.utils.CustomDSL.getTimeCondition;
 import static jooq.steve.db.Tables.USER_OCPP_TAG;
 import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
-import static jooq.steve.db.tables.Connector.CONNECTOR;
+import static jooq.steve.db.tables.Evse.EVSE;
 import static jooq.steve.db.tables.ConnectorMeterValue.CONNECTOR_METER_VALUE;
 import static jooq.steve.db.tables.OcppTag.OCPP_TAG;
 import static jooq.steve.db.tables.Transaction.TRANSACTION;
@@ -70,8 +71,8 @@ public class TransactionRepositoryImpl implements TransactionRepository {
 
         return ctx.select(
                 TRANSACTION.TRANSACTION_PK,
-                CONNECTOR.CHARGE_BOX_ID,
-                CONNECTOR.CONNECTOR_ID,
+                EVSE.CHARGE_BOX_ID,
+                EVSE.EVSE_ID,
                 TRANSACTION.ID_TAG,
                 TRANSACTION.START_TIMESTAMP,
                 TRANSACTION.START_VALUE,
@@ -83,8 +84,8 @@ public class TransactionRepositoryImpl implements TransactionRepository {
                 TRANSACTION.STOP_EVENT_ACTOR,
                 USER_OCPP_TAG.USER_PK)
             .from(TRANSACTION)
-            .join(CONNECTOR).on(TRANSACTION.CONNECTOR_PK.eq(CONNECTOR.CONNECTOR_PK))
-            .join(CHARGE_BOX).on(CHARGE_BOX.CHARGE_BOX_ID.eq(CONNECTOR.CHARGE_BOX_ID))
+            .join(EVSE).on(TRANSACTION.EVSE_PK.eq(EVSE.EVSE_PK))
+            .join(CHARGE_BOX).on(CHARGE_BOX.CHARGE_BOX_ID.eq(EVSE.CHARGE_BOX_ID))
             .join(OCPP_TAG).on(OCPP_TAG.ID_TAG.eq(TRANSACTION.ID_TAG))
             .leftJoin(USER_OCPP_TAG).on(USER_OCPP_TAG.OCPP_TAG_PK.eq(OCPP_TAG.OCPP_TAG_PK))
             .where(conditions)
@@ -116,8 +117,8 @@ public class TransactionRepositoryImpl implements TransactionRepository {
 
         ctx.select(
                 TRANSACTION.TRANSACTION_PK,
-                CONNECTOR.CHARGE_BOX_ID,
-                CONNECTOR.CONNECTOR_ID,
+                EVSE.CHARGE_BOX_ID,
+                EVSE.EVSE_ID,
                 TRANSACTION.ID_TAG,
                 USER_OCPP_TAG.USER_PK,
                 TRANSACTION.START_TIMESTAMP,
@@ -125,8 +126,8 @@ public class TransactionRepositoryImpl implements TransactionRepository {
                 TRANSACTION.STOP_TIMESTAMP,
                 TRANSACTION.STOP_VALUE)
             .from(TRANSACTION)
-            .join(CONNECTOR).on(TRANSACTION.CONNECTOR_PK.eq(CONNECTOR.CONNECTOR_PK))
-            .join(CHARGE_BOX).on(CHARGE_BOX.CHARGE_BOX_ID.eq(CONNECTOR.CHARGE_BOX_ID))
+            .join(EVSE).on(TRANSACTION.EVSE_PK.eq(EVSE.EVSE_PK))
+            .join(CHARGE_BOX).on(CHARGE_BOX.CHARGE_BOX_ID.eq(EVSE.CHARGE_BOX_ID))
             .join(OCPP_TAG).on(OCPP_TAG.ID_TAG.eq(TRANSACTION.ID_TAG))
             .leftJoin(USER_OCPP_TAG).on(USER_OCPP_TAG.OCPP_TAG_PK.eq(OCPP_TAG.OCPP_TAG_PK))
             .where(conditions)
@@ -139,9 +140,10 @@ public class TransactionRepositoryImpl implements TransactionRepository {
     public List<Integer> getActiveTransactionIds(String chargeBoxId) {
         return ctx.select(TRANSACTION.TRANSACTION_PK)
                   .from(TRANSACTION)
-                  .join(CONNECTOR)
-                    .on(TRANSACTION.CONNECTOR_PK.equal(CONNECTOR.CONNECTOR_PK))
-                    .and(CONNECTOR.CHARGE_BOX_ID.equal(chargeBoxId))
+                  .join(EVSE)
+                    .on(TRANSACTION.EVSE_PK.equal(EVSE.EVSE_PK))
+                    .and(EVSE.CHARGE_BOX_ID.equal(chargeBoxId))
+                    .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
                   .where(TRANSACTION.STOP_TIMESTAMP.isNull())
                   .fetch(TRANSACTION.TRANSACTION_PK);
     }
@@ -187,10 +189,11 @@ public class TransactionRepositoryImpl implements TransactionRepository {
             //
             // "what is the subsequent transaction at the same chargebox and connector?"
             nextTx = ctx.selectFrom(TRANSACTION_START)
-                        .where(TRANSACTION_START.CONNECTOR_PK.eq(ctx.select(CONNECTOR.CONNECTOR_PK)
-                                                                    .from(CONNECTOR)
-                                                                    .where(CONNECTOR.CHARGE_BOX_ID.equal(chargeBoxId))
-                                                                    .and(CONNECTOR.CONNECTOR_ID.equal(connectorId))))
+                        .where(TRANSACTION_START.EVSE_PK.eq(ctx.select(EVSE.EVSE_PK)
+                                                                    .from(EVSE)
+                                                                    .where(EVSE.CHARGE_BOX_ID.equal(chargeBoxId))
+                                                                    .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+                                                                    .and(EVSE.EVSE_ID.equal(connectorId))))
                         .and(TRANSACTION_START.START_TIMESTAMP.greaterThan(startTimestamp))
                         .orderBy(TRANSACTION_START.START_TIMESTAMP)
                         .limit(1)
@@ -213,10 +216,11 @@ public class TransactionRepositoryImpl implements TransactionRepository {
         Condition unitCondition = CONNECTOR_METER_VALUE.UNIT.isNull()
             .or(CONNECTOR_METER_VALUE.UNIT.in("", UnitOfMeasure.WH.value(), UnitOfMeasure.K_WH.value()));
 
-        var connectorPkQuery = ctx.select(CONNECTOR.CONNECTOR_PK)
-            .from(CONNECTOR)
-            .where(CONNECTOR.CHARGE_BOX_ID.eq(chargeBoxId))
-            .and(CONNECTOR.CONNECTOR_ID.eq(connectorId));
+        var connectorPkQuery = ctx.select(EVSE.EVSE_PK)
+            .from(EVSE)
+            .where(EVSE.CHARGE_BOX_ID.eq(chargeBoxId))
+            .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+            .and(EVSE.EVSE_ID.eq(connectorId));
 
         // Case 1: Ideal and most accurate case. Station sends meter values with transaction id set.
         //
@@ -227,7 +231,7 @@ public class TransactionRepositoryImpl implements TransactionRepository {
         var selectionCriteria = CONNECTOR_METER_VALUE.TRANSACTION_PK.eq(transactionPk)
             .or(timestampCondition
                 .and(CONNECTOR_METER_VALUE.TRANSACTION_PK.isNull()
-                .and(CONNECTOR_METER_VALUE.CONNECTOR_PK.eq(connectorPkQuery))
+                .and(CONNECTOR_METER_VALUE.EVSE_PK.eq(connectorPkQuery))
                 )
             );
 
@@ -274,16 +278,18 @@ public class TransactionRepositoryImpl implements TransactionRepository {
     private List<Condition> getConditions(TransactionQueryForm form) {
         List<Condition> conditions = new ArrayList<>();
 
+        conditions.add(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1));
+
         if (form.isTransactionPkSet()) {
             conditions.add(TRANSACTION.TRANSACTION_PK.in(form.getTransactionPk()));
         }
 
         if (form.isChargeBoxIdSet()) {
-            conditions.add(CONNECTOR.CHARGE_BOX_ID.in(form.getChargeBoxId()));
+            conditions.add(EVSE.CHARGE_BOX_ID.in(form.getChargeBoxId()));
         }
 
         if (form.isConnectorIdSet()) {
-            conditions.add(CONNECTOR.CONNECTOR_ID.eq(form.getConnectorId()));
+            conditions.add(EVSE.EVSE_ID.eq(form.getConnectorId()));
         }
 
         if (form.isOcppIdTagSet()) {

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/TransactionRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/TransactionRepositoryImpl.java
@@ -179,6 +179,8 @@ public class TransactionRepositoryImpl implements TransactionRepository {
         Condition timestampCondition;
         TransactionStartRecord nextTx = null;
 
+        var evsePkSelect = Ocpp1ConnectorEvseBridge.evsePkSelect(ctx, chargeBoxId, connectorId);
+
         if (stopTimestamp == null && stopValue == null) {
 
             // https://github.com/steve-community/steve/issues/97
@@ -189,11 +191,7 @@ public class TransactionRepositoryImpl implements TransactionRepository {
             //
             // "what is the subsequent transaction at the same chargebox and connector?"
             nextTx = ctx.selectFrom(TRANSACTION_START)
-                        .where(TRANSACTION_START.EVSE_PK.eq(ctx.select(EVSE.EVSE_PK)
-                                                                    .from(EVSE)
-                                                                    .where(EVSE.CHARGE_BOX_ID.equal(chargeBoxId))
-                                                                    .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
-                                                                    .and(EVSE.EVSE_ID.equal(connectorId))))
+                        .where(TRANSACTION_START.EVSE_PK.eq(evsePkSelect))
                         .and(TRANSACTION_START.START_TIMESTAMP.greaterThan(startTimestamp))
                         .orderBy(TRANSACTION_START.START_TIMESTAMP)
                         .limit(1)
@@ -216,12 +214,6 @@ public class TransactionRepositoryImpl implements TransactionRepository {
         Condition unitCondition = CONNECTOR_METER_VALUE.UNIT.isNull()
             .or(CONNECTOR_METER_VALUE.UNIT.in("", UnitOfMeasure.WH.value(), UnitOfMeasure.K_WH.value()));
 
-        var connectorPkQuery = ctx.select(EVSE.EVSE_PK)
-            .from(EVSE)
-            .where(EVSE.CHARGE_BOX_ID.eq(chargeBoxId))
-            .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
-            .and(EVSE.EVSE_ID.eq(connectorId));
-
         // Case 1: Ideal and most accurate case. Station sends meter values with transaction id set.
         //
         // Case 2: Fall back to filtering according to time windows. Timestamp fallback only considers rows
@@ -231,7 +223,7 @@ public class TransactionRepositoryImpl implements TransactionRepository {
         var selectionCriteria = CONNECTOR_METER_VALUE.TRANSACTION_PK.eq(transactionPk)
             .or(timestampCondition
                 .and(CONNECTOR_METER_VALUE.TRANSACTION_PK.isNull()
-                .and(CONNECTOR_METER_VALUE.EVSE_PK.eq(connectorPkQuery))
+                .and(CONNECTOR_METER_VALUE.EVSE_PK.eq(evsePkSelect))
                 )
             );
 

--- a/src/main/java/de/rwth/idsg/steve/service/DataImportExportService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/DataImportExportService.java
@@ -56,7 +56,7 @@ import static jooq.steve.db.Tables.CHARGE_BOX_LOG_UPLOAD_JOB;
 import static jooq.steve.db.Tables.CHARGE_BOX_SECURITY_EVENT;
 import static jooq.steve.db.Tables.CHARGING_PROFILE;
 import static jooq.steve.db.Tables.CHARGING_SCHEDULE_PERIOD;
-import static jooq.steve.db.Tables.CONNECTOR;
+import static jooq.steve.db.Tables.EVSE;
 import static jooq.steve.db.Tables.CONNECTOR_CHARGING_PROFILE;
 import static jooq.steve.db.Tables.CONNECTOR_METER_VALUE;
 import static jooq.steve.db.Tables.CONNECTOR_STATUS;
@@ -86,7 +86,7 @@ public class DataImportExportService {
         CHARGE_BOX_CERTIFICATE_SIGNED,
         CHARGING_PROFILE,
         CHARGING_SCHEDULE_PERIOD,
-        CONNECTOR,
+        EVSE,
         CONNECTOR_CHARGING_PROFILE,
         OCPP_TAG,
         SETTINGS,

--- a/src/main/java/de/rwth/idsg/steve/service/DataImportExportService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/DataImportExportService.java
@@ -57,6 +57,7 @@ import static jooq.steve.db.Tables.CHARGE_BOX_SECURITY_EVENT;
 import static jooq.steve.db.Tables.CHARGING_PROFILE;
 import static jooq.steve.db.Tables.CHARGING_SCHEDULE_PERIOD;
 import static jooq.steve.db.Tables.EVSE;
+import static jooq.steve.db.Tables.EVSE_CONNECTOR;
 import static jooq.steve.db.Tables.CONNECTOR_CHARGING_PROFILE;
 import static jooq.steve.db.Tables.CONNECTOR_METER_VALUE;
 import static jooq.steve.db.Tables.CONNECTOR_STATUS;
@@ -87,6 +88,7 @@ public class DataImportExportService {
         CHARGING_PROFILE,
         CHARGING_SCHEDULE_PERIOD,
         EVSE,
+        EVSE_CONNECTOR,
         CONNECTOR_CHARGING_PROFILE,
         OCPP_TAG,
         SETTINGS,

--- a/src/main/java/de/rwth/idsg/steve/utils/mapper/ChargePointDetailsMapper.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/mapper/ChargePointDetailsMapper.java
@@ -19,13 +19,24 @@
 package de.rwth.idsg.steve.utils.mapper;
 
 import de.rwth.idsg.steve.ocpp.OcppSecurityProfile;
+import de.rwth.idsg.steve.ocpp.model.ConnectorFormat;
+import de.rwth.idsg.steve.ocpp.model.ConnectorType;
+import de.rwth.idsg.steve.ocpp.model.PowerType;
 import de.rwth.idsg.steve.repository.dto.ChargePoint;
+import de.rwth.idsg.steve.web.dto.ChargePointDeviceModelForm;
+import de.rwth.idsg.steve.web.dto.ChargePointDeviceModelForm.EvseConnectorForm;
 import de.rwth.idsg.steve.web.dto.ChargePointForm;
 import jooq.steve.db.tables.records.ChargeBoxRecord;
+import jooq.steve.db.tables.records.EvseConnectorRecord;
+import jooq.steve.db.tables.records.EvseRecord;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import ocpp.cs._2015._10.RegistrationStatus;
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -51,6 +62,48 @@ public final class ChargePointDetailsMapper {
         form.setAuthPassword(null); // make sure that the pwd from record does not escape
         form.setHasAuthPassword(!StringUtils.isEmpty(chargeBox.getAuthPassword()));
 
+        form.setDeviceModelForm(createDeviceModelForm(cp));
+        return form;
+    }
+
+    private static ChargePointDeviceModelForm createDeviceModelForm(ChargePoint.Details cp) {
+        var evses = cp.getEvses()
+            .stream()
+            .map(evseRecord -> {
+                var evseConnectorRecords = cp.getEvseConnectorsByEvsePk().get(evseRecord.getEvsePk());
+                return toEvseForm(evseRecord, evseConnectorRecords);
+            }).toList();
+
+        var deviceModelForm = new ChargePointDeviceModelForm();
+        deviceModelForm.setEvses(evses);
+        return deviceModelForm;
+    }
+
+    private static ChargePointDeviceModelForm.EvseForm toEvseForm(EvseRecord evseRecord,
+                                                                  @Nullable List<EvseConnectorRecord> connectorRecords) {
+        List<EvseConnectorForm> connectors = (connectorRecords == null)
+            ? Collections.emptyList()
+            : connectorRecords.stream().map(ChargePointDetailsMapper::toEvseConnectorForm).toList();
+
+        var form = new ChargePointDeviceModelForm.EvseForm();
+        form.setEvsePk(evseRecord.getEvsePk());
+        form.setEvseId(evseRecord.getEvseId());
+        form.setTopologySource(evseRecord.getTopologySource());
+        form.setEvseIdExternal(evseRecord.getEvseIdExternal());
+        form.setConnectors(connectors);
+        return form;
+    }
+
+    private static EvseConnectorForm toEvseConnectorForm(EvseConnectorRecord rec) {
+        var form = new EvseConnectorForm();
+        form.setEvseConnectorPk(rec.getEvseConnectorPk());
+        form.setConnectorId(rec.getConnectorId());
+        form.setConnectorType(ConnectorType.fromNullable(rec.getConnectorType()));
+        form.setConnectorFormat(ConnectorFormat.fromNullable(rec.getConnectorFormat()));
+        form.setPowerType(PowerType.fromNullable(rec.getPowerType()));
+        form.setMaxVoltage(rec.getMaxVoltage());
+        form.setMaxAmperage(rec.getMaxAmperage());
+        form.setMaxElectricPower(rec.getMaxElectricPower());
         return form;
     }
 

--- a/src/main/java/de/rwth/idsg/steve/web/controller/ChargePointsController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/controller/ChargePointsController.java
@@ -146,6 +146,7 @@ public class ChargePointsController {
         if (result.hasErrors()) {
             setCommonAttributesForSingleAdd(model);
             model.addAttribute("chargePointForm", chargePointForm);
+            model.addAttribute("cp", chargePointService.getDetails(chargePointForm.getChargeBoxPk()));
             return "data-man/chargepointDetails";
         }
 

--- a/src/main/java/de/rwth/idsg/steve/web/dto/ChargePointDeviceModelForm.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ChargePointDeviceModelForm.java
@@ -1,0 +1,96 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.web.dto;
+
+import de.rwth.idsg.steve.ocpp.model.ConnectorFormat;
+import de.rwth.idsg.steve.ocpp.model.ConnectorType;
+import de.rwth.idsg.steve.ocpp.model.PowerType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.AccessMode;
+import jooq.steve.db.enums.EvseTopologySource;
+import lombok.Getter;
+import lombok.Setter;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 13.05.2026
+ */
+@Getter
+@Setter
+public class ChargePointDeviceModelForm {
+
+    @Valid
+    private List<EvseForm> evses = new ArrayList<>();
+
+    @Getter
+    @Setter
+    public static class EvseForm {
+
+        // Internal database id
+        @NotNull(message = "evsePk is required")
+        @Schema(accessMode = AccessMode.READ_ONLY)
+        private Integer evsePk;
+
+        @Schema(accessMode = AccessMode.READ_ONLY)
+        private Integer evseId;
+
+        @Schema(accessMode = AccessMode.READ_ONLY)
+        private EvseTopologySource topologySource;
+
+        // the only editable field
+        private String evseIdExternal;
+
+        @Valid
+        private List<EvseConnectorForm> connectors = new ArrayList<>();
+    }
+
+    @Getter
+    @Setter
+    public static class EvseConnectorForm {
+
+        // Internal database id
+        @NotNull(message = "evseConnectorPk is required")
+        @Schema(accessMode = AccessMode.READ_ONLY)
+        private Integer evseConnectorPk;
+
+        @Schema(accessMode = AccessMode.READ_ONLY)
+        private Integer connectorId;
+
+        // editable fields
+
+        private ConnectorType connectorType;
+        private ConnectorFormat connectorFormat;
+        private PowerType powerType;
+
+        @Positive
+        private Integer maxVoltage;
+
+        @Positive
+        private Integer maxAmperage;
+
+        @Positive
+        private Integer maxElectricPower;
+    }
+}

--- a/src/main/java/de/rwth/idsg/steve/web/dto/ChargePointForm.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ChargePointForm.java
@@ -85,4 +85,7 @@ public class ChargePointForm {
 
     @Schema(accessMode = Schema.AccessMode.READ_ONLY)
     private boolean hasAuthPassword;
+
+    @Valid
+    private ChargePointDeviceModelForm deviceModelForm = new ChargePointDeviceModelForm();
 }

--- a/src/main/resources/db/migration/V1_1_4__update.sql
+++ b/src/main/resources/db/migration/V1_1_4__update.sql
@@ -1,0 +1,104 @@
+START TRANSACTION;
+
+--
+-- Step 1: Refactor existing connector
+-- * CONNECTOR table to EVSE
+-- * CONNECTOR_PK/CONNECTOR_ID columns to EVSE_PK/EVSE_ID columns in EVSE table
+-- * CONNECTOR_PK references to EVSE_PK in other tables
+--
+
+DROP VIEW IF EXISTS `transaction`;
+
+ALTER TABLE connector_charging_profile
+    DROP FOREIGN KEY FK_connector_charging_profile_connector_pk;
+
+ALTER TABLE connector_meter_value
+    DROP FOREIGN KEY FK_pk_cm;
+
+ALTER TABLE connector_status
+    DROP FOREIGN KEY FK_cs_pk;
+
+ALTER TABLE reservation
+    DROP FOREIGN KEY FK_connector_pk_reserv;
+
+ALTER TABLE transaction_start
+    DROP FOREIGN KEY FK_connector_pk_t;
+
+ALTER TABLE connector
+    DROP FOREIGN KEY FK_connector_charge_box_cbid;
+
+RENAME TABLE connector TO evse;
+
+ALTER TABLE evse
+    CHANGE COLUMN connector_pk evse_pk int(11) unsigned NOT NULL AUTO_INCREMENT,
+    CHANGE COLUMN connector_id evse_id int(11) NOT NULL,
+    ADD COLUMN evse_id_external varchar(255) DEFAULT NULL AFTER evse_id,
+    ADD COLUMN topology_source enum('ocpp1', 'ocpp2') NOT NULL DEFAULT 'ocpp1' AFTER evse_id_external,
+    ADD COLUMN created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    ADD COLUMN updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    DROP INDEX connector_pk_UNIQUE,
+    DROP INDEX connector_cbid_cid_UNIQUE,
+    ADD UNIQUE KEY evse_pk_UNIQUE (evse_pk),
+    ADD UNIQUE KEY evse_cbid_source_eid_UNIQUE (charge_box_id, topology_source, evse_id),
+    ADD CONSTRAINT FK_evse_charge_box_cbid FOREIGN KEY (charge_box_id)
+        REFERENCES charge_box (charge_box_id) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+ALTER TABLE evse
+    ALTER COLUMN topology_source DROP DEFAULT;
+
+ALTER TABLE connector_charging_profile
+    CHANGE COLUMN connector_pk evse_pk int(11) unsigned NOT NULL,
+    DROP INDEX UQ_connector_charging_profile,
+    ADD UNIQUE KEY UQ_connector_charging_profile (evse_pk, charging_profile_pk),
+    ADD CONSTRAINT FK_connector_charging_profile_evse_pk FOREIGN KEY (evse_pk)
+        REFERENCES evse (evse_pk) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+ALTER TABLE connector_meter_value
+    CHANGE COLUMN connector_pk evse_pk int(11) unsigned NOT NULL,
+    DROP INDEX FK_cm_pk_idx,
+    ADD KEY FK_cmv_evse_pk_idx (evse_pk),
+    ADD CONSTRAINT FK_cmv_evse_pk FOREIGN KEY (evse_pk)
+        REFERENCES evse (evse_pk) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+ALTER TABLE connector_status
+    CHANGE COLUMN connector_pk evse_pk int(11) unsigned NOT NULL,
+    DROP INDEX FK_cs_pk_idx,
+    DROP INDEX connector_status_cpk_st_idx,
+    ADD KEY FK_cs_evse_pk_idx (evse_pk),
+    ADD KEY connector_status_epk_st_idx (evse_pk, status_timestamp),
+    ADD CONSTRAINT FK_cs_evse_pk FOREIGN KEY (evse_pk)
+        REFERENCES evse (evse_pk) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+ALTER TABLE reservation
+    CHANGE COLUMN connector_pk evse_pk int(11) unsigned NOT NULL AFTER reservation_pk,
+    DROP INDEX FK_connector_pk_reserv_idx,
+    ADD KEY FK_evse_pk_reserv_idx (evse_pk),
+    ADD CONSTRAINT FK_evse_pk_reserv FOREIGN KEY (evse_pk)
+        REFERENCES evse (evse_pk) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+ALTER TABLE transaction_start
+    CHANGE COLUMN connector_pk evse_pk int(11) unsigned NOT NULL,
+    DROP INDEX connector_pk_idx,
+    ADD KEY evse_pk_idx (evse_pk),
+    ADD CONSTRAINT FK_evse_pk_t FOREIGN KEY (evse_pk)
+        REFERENCES evse (evse_pk) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+CREATE OR REPLACE VIEW `transaction` AS
+SELECT
+    tx1.transaction_pk,
+    tx1.evse_pk,
+    tx1.id_tag,
+    tx1.event_timestamp as 'start_event_timestamp',
+    tx1.start_timestamp,
+    tx1.start_value,
+    tx2.event_actor as 'stop_event_actor',
+    tx2.event_timestamp as 'stop_event_timestamp',
+    tx2.stop_timestamp,
+    tx2.stop_value,
+    tx2.stop_reason
+FROM transaction_start tx1
+LEFT JOIN transaction_stop tx2
+    ON tx1.transaction_pk = tx2.transaction_pk
+    AND tx2.event_timestamp = (SELECT MAX(event_timestamp) FROM transaction_stop s2 WHERE tx2.transaction_pk = s2.transaction_pk);
+
+COMMIT;

--- a/src/main/resources/db/migration/V1_1_4__update.sql
+++ b/src/main/resources/db/migration/V1_1_4__update.sql
@@ -4,7 +4,6 @@ START TRANSACTION;
 -- Step 1: Refactor existing connector
 -- * CONNECTOR table to EVSE
 -- * CONNECTOR_PK/CONNECTOR_ID columns to EVSE_PK/EVSE_ID columns in EVSE table
--- * CONNECTOR_PK references to EVSE_PK in other tables
 --
 
 DROP VIEW IF EXISTS `transaction`;
@@ -45,6 +44,38 @@ ALTER TABLE evse
 
 ALTER TABLE evse
     ALTER COLUMN topology_source DROP DEFAULT;
+
+--
+-- Step 2: Add physical connector model under EVSE
+--
+
+CREATE TABLE evse_connector (
+    evse_connector_pk int(11) unsigned NOT NULL AUTO_INCREMENT,
+    evse_pk int(11) unsigned NOT NULL,
+    connector_id int(11) NOT NULL,
+    connector_type varchar(255) DEFAULT NULL,
+    connector_format varchar(255) DEFAULT NULL,
+    power_type varchar(255) DEFAULT NULL,
+    max_voltage int(11) DEFAULT NULL,
+    max_amperage int(11) DEFAULT NULL,
+    max_electric_power int(11) DEFAULT NULL,
+    created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (evse_connector_pk),
+    UNIQUE KEY evse_connector_pk_UNIQUE (evse_connector_pk),
+    UNIQUE KEY evse_connector_epk_cid_UNIQUE (evse_pk, connector_id),
+    CONSTRAINT FK_evse_connector_evse_pk FOREIGN KEY (evse_pk)
+        REFERENCES evse (evse_pk) ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+INSERT INTO evse_connector (evse_pk, connector_id)
+SELECT evse_pk, 1
+FROM evse
+WHERE evse_id <> 0;
+
+--
+-- Step 3: Refactor existing EVSE references
+--
 
 ALTER TABLE connector_charging_profile
     CHANGE COLUMN connector_pk evse_pk int(11) unsigned NOT NULL,

--- a/src/main/webapp/WEB-INF/views/data-man/00-cp-misc.jsp
+++ b/src/main/webapp/WEB-INF/views/data-man/00-cp-misc.jsp
@@ -33,9 +33,4 @@
 	</tr>
 
 	<tr><td>Additional Note:</td><td><form:textarea path="note"/></td></tr>
-	<tr><td></td>
-		<td id="add_space">
-			<input type="submit" name="${submitButtonName}" value="${submitButtonValue}">
-			<input type="submit" name="backToOverview" value="Back to Overview">
-		</td></tr>
 </table>

--- a/src/main/webapp/WEB-INF/views/data-man/chargepointAdd.jsp
+++ b/src/main/webapp/WEB-INF/views/data-man/chargepointAdd.jsp
@@ -122,10 +122,16 @@
         </table>
 
         <%@ include file="00-address.jsp" %>
-
-        <c:set var="submitButtonName" value="add" />
-        <c:set var="submitButtonValue" value="Add" />
         <%@ include file="00-cp-misc.jsp" %>
+
+        <table class="userInput">
+            <tr><td></td>
+                <td id="add_space">
+                    <input type="submit" name="add" value="Add">
+                    <input type="submit" name="backToOverview" value="Back to Overview">
+                </td>
+            </tr>
+        </table>
 
     </form:form>
 </div></div>

--- a/src/main/webapp/WEB-INF/views/data-man/chargepointDetails.jsp
+++ b/src/main/webapp/WEB-INF/views/data-man/chargepointDetails.jsp
@@ -19,6 +19,18 @@
 
 --%>
 <%@ include file="../00-header.jsp" %>
+<script type="text/javascript">
+    function toggleEvseConnectors(button, targetId) {
+        var row = document.getElementById(targetId);
+        if (row.style.display === 'none') {
+            row.style.display = '';
+            button.value = 'Hide \u25B2';
+        } else {
+            row.style.display = 'none';
+            button.value = 'View \u25BC';
+        }
+    }
+</script>
 <spring:hasBindErrors name="chargePointForm">
     <div class="error">
         Error while trying to update a charge point:
@@ -132,11 +144,98 @@
 
             <form:hidden path="address.addressPk" readonly="true"/>
             <%@ include file="00-address.jsp" %>
-
-            <c:set var="submitButtonName" value="update" />
-            <c:set var="submitButtonValue" value="Update" />
             <%@ include file="00-cp-misc.jsp" %>
 
+            <section><span>Device Model</span></section>
+            <table class="res deviceModel">
+                <thead>
+                <tr>
+                    <th>Topology</th>
+                    <th>EVSE ID</th>
+                    <th>External EVSE ID</th>
+                    <th>Connectors</th>
+                </tr>
+                </thead>
+                <tbody>
+                <c:forEach items="${chargePointForm.deviceModelForm.evses}" var="evse" varStatus="evseStatus">
+                    <tr class="${evseStatus.index % 2 == 0 ? 'evseOdd' : 'evseEven'}">
+                        <td><encode:forHtml value="${evse.topologySource.literal}" /></td>
+                        <td>
+                            <form:hidden path="deviceModelForm.evses[${evseStatus.index}].evsePk"/>
+                            <form:hidden path="deviceModelForm.evses[${evseStatus.index}].evseId"/>
+                            <form:hidden path="deviceModelForm.evses[${evseStatus.index}].topologySource"/>
+                            <encode:forHtml value="${evse.evseId}" />
+                        </td>
+                        <td><form:input path="deviceModelForm.evses[${evseStatus.index}].evseIdExternal"/></td>
+                        <td>
+                            <input type="button"
+                                   value="View &#9660;"
+                                   onclick="toggleEvseConnectors(this, 'evse-connectors-${evseStatus.index}')">
+                        </td>
+                    </tr>
+                    <tr class="evseConnectorsRow" id="evse-connectors-${evseStatus.index}" style="display: none;">
+                        <td colspan="4">
+                            <div class="connectorPanel">
+                                <table class="res evseConnectors">
+                                    <thead>
+                                    <tr>
+                                        <th>Connector ID</th>
+                                        <th>Type</th>
+                                        <th>Format</th>
+                                        <th>Power Type</th>
+                                        <th>Max Voltage</th>
+                                        <th>Max Amperage</th>
+                                        <th>Max Power (in W)</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <c:forEach items="${evse.connectors}" var="connector" varStatus="connectorStatus">
+                                        <tr>
+                                            <td>
+                                                <form:hidden path="deviceModelForm.evses[${evseStatus.index}].connectors[${connectorStatus.index}].evseConnectorPk"/>
+                                                <form:hidden path="deviceModelForm.evses[${evseStatus.index}].connectors[${connectorStatus.index}].connectorId"/>
+                                                <encode:forHtml value="${connector.connectorId}" />
+                                            </td>
+                                            <td>
+                                                <form:select path="deviceModelForm.evses[${evseStatus.index}].connectors[${connectorStatus.index}].connectorType">
+                                                    <form:option value="" label=""/>
+                                                    <form:options itemLabel="text"/>
+                                                </form:select>
+                                            </td>
+                                            <td>
+                                                <form:select path="deviceModelForm.evses[${evseStatus.index}].connectors[${connectorStatus.index}].connectorFormat">
+                                                    <form:option value="" label=""/>
+                                                    <form:options itemLabel="text"/>
+                                                </form:select>
+                                            </td>
+                                            <td>
+                                                <form:select path="deviceModelForm.evses[${evseStatus.index}].connectors[${connectorStatus.index}].powerType">
+                                                    <form:option value="" label=""/>
+                                                    <form:options itemLabel="text"/>
+                                                </form:select>
+                                            </td>
+                                            <td><form:input type="number" min="1" step="1" path="deviceModelForm.evses[${evseStatus.index}].connectors[${connectorStatus.index}].maxVoltage"/></td>
+                                            <td><form:input type="number" min="1" step="1" path="deviceModelForm.evses[${evseStatus.index}].connectors[${connectorStatus.index}].maxAmperage"/></td>
+                                            <td><form:input type="number" min="1" step="1" path="deviceModelForm.evses[${evseStatus.index}].connectors[${connectorStatus.index}].maxElectricPower"/></td>
+                                        </tr>
+                                    </c:forEach>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </td>
+                    </tr>
+                </c:forEach>
+                </tbody>
+            </table>
+
+            <table class="userInput">
+                <tr><td></td>
+                    <td id="add_space">
+                        <input type="submit" name="update" value="Update">
+                        <input type="submit" name="backToOverview" value="Back to Overview">
+                    </td>
+                </tr>
+            </table>
     </form:form>
 </div></div>
 <%@ include file="../00-footer.jsp" %>

--- a/src/main/webapp/static/css/style.css
+++ b/src/main/webapp/static/css/style.css
@@ -63,6 +63,36 @@ table.res td {
 	width: auto;
 	word-wrap: break-word;
 }
+
+.deviceModel .connectorPanel {
+	margin: 10px 16px 16px 16px;
+	max-width: calc(100% - 32px);
+	overflow-x: auto;
+}
+.deviceModel table.evseConnectors {
+	table-layout: auto;
+	width: 100%;
+}
+.deviceModel table.evseConnectors select {
+	width: auto;
+	max-width: 100%;
+}
+.deviceModel table.evseConnectors input[type="number"] {
+	width: 110px;
+	max-width: 100%;
+}
+table.res.deviceModel tr.evseOdd {
+	background: #fcfaf2;
+}
+table.res.deviceModel tr.evseEven {
+	background: #fff;
+}
+table.res.deviceModel tr.evseOdd:hover, table.res.deviceModel tr.evseEven:hover {
+	background: #ebf4f9;
+}
+table.res.deviceModel tr.evseConnectorsRow {
+	background: #f7f7f7;
+}
 /*** Table for charge point details ***/
 table.cpd {
 	border-collapse: collapse;

--- a/src/test/java/de/rwth/idsg/steve/certification/ocpp16/Ocpp16JsonCsmsCertificationIT.java
+++ b/src/test/java/de/rwth/idsg/steve/certification/ocpp16/Ocpp16JsonCsmsCertificationIT.java
@@ -50,6 +50,7 @@ import de.rwth.idsg.steve.web.dto.ocpp.TriggerMessageEnum;
 import de.rwth.idsg.steve.web.dto.ocpp.TriggerMessageParams;
 import de.rwth.idsg.steve.web.dto.ocpp.UnlockConnectorParams;
 import de.rwth.idsg.steve.web.dto.ocpp.UpdateFirmwareParams;
+import jooq.steve.db.enums.EvseTopologySource;
 import lombok.extern.slf4j.Slf4j;
 import ocpp._2022._02.security.CertificateHashData;
 import ocpp._2022._02.security.CertificateHashDataType;
@@ -124,7 +125,7 @@ import static jooq.steve.db.Tables.CHARGE_BOX_LOG_UPLOAD_JOB;
 import static jooq.steve.db.Tables.RESERVATION;
 import static jooq.steve.db.Tables.TRANSACTION;
 import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
-import static jooq.steve.db.tables.Connector.CONNECTOR;
+import static jooq.steve.db.tables.Evse.EVSE;
 import static jooq.steve.db.tables.OcppTag.OCPP_TAG;
 import static ocpp._2022._02.security.SignedUpdateFirmwareResponse.UpdateFirmwareStatusEnumType;
 import static ocpp.cp._2015._10.ReservationStatus.ACCEPTED;
@@ -1587,14 +1588,15 @@ public class Ocpp16JsonCsmsCertificationIT extends AbstractOcpp16JsonCsms {
             assertEquals(REGISTERED_OCPP_TAG, reservation.getIdTag());
             assertEquals(ReservationStatus.ACCEPTED.name(), reservation.getStatus());
 
-            var connectorPk = dslContext.select(CONNECTOR.CONNECTOR_PK)
-                .from(CONNECTOR)
-                .where(CONNECTOR.CHARGE_BOX_ID.equal(REGISTERED_CHARGE_BOX_ID))
-                .and(CONNECTOR.CONNECTOR_ID.equal(params.getConnectorId()))
+            var connectorPk = dslContext.select(EVSE.EVSE_PK)
+                .from(EVSE)
+                .where(EVSE.CHARGE_BOX_ID.equal(REGISTERED_CHARGE_BOX_ID))
+                .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+                .and(EVSE.EVSE_ID.equal(params.getConnectorId()))
                 .fetchOne();
 
             assertNotNull(connectorPk);
-            assertEquals(connectorPk.component1(), reservation.getConnectorPk());
+            assertEquals(connectorPk.component1(), reservation.getEvsePk());
         }
 
         assertNotNull(chargePoint.send(statusNotification(1, ChargePointStatus.RESERVED, ChargePointErrorCode.NO_ERROR), StatusNotificationResponse.class));

--- a/src/test/java/de/rwth/idsg/steve/repository/impl/AbstractRepositoryITBase.java
+++ b/src/test/java/de/rwth/idsg/steve/repository/impl/AbstractRepositoryITBase.java
@@ -32,6 +32,7 @@ import java.sql.SQLException;
 import java.util.UUID;
 
 import static jooq.steve.db.tables.Evse.EVSE;
+import static jooq.steve.db.tables.EvseConnector.EVSE_CONNECTOR;
 import static jooq.steve.db.tables.OcppTag.OCPP_TAG;
 
 /**
@@ -118,6 +119,19 @@ abstract class AbstractRepositoryITBase {
             .set(EVSE.CHARGE_BOX_ID, KNOWN_CHARGE_BOX_ID)
             .set(EVSE.TOPOLOGY_SOURCE, EvseTopologySource.ocpp1)
             .set(EVSE.EVSE_ID, 1)
+            .onDuplicateKeyIgnore()
+            .execute();
+
+        Integer evsePk = dslContext.select(EVSE.EVSE_PK)
+            .from(EVSE)
+            .where(EVSE.CHARGE_BOX_ID.eq(KNOWN_CHARGE_BOX_ID))
+            .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+            .and(EVSE.EVSE_ID.eq(1))
+            .fetchOne(EVSE.EVSE_PK);
+
+        dslContext.insertInto(EVSE_CONNECTOR)
+            .set(EVSE_CONNECTOR.EVSE_PK, evsePk)
+            .set(EVSE_CONNECTOR.CONNECTOR_ID, 1)
             .onDuplicateKeyIgnore()
             .execute();
 

--- a/src/test/java/de/rwth/idsg/steve/repository/impl/AbstractRepositoryITBase.java
+++ b/src/test/java/de/rwth/idsg/steve/repository/impl/AbstractRepositoryITBase.java
@@ -19,6 +19,7 @@
 package de.rwth.idsg.steve.repository.impl;
 
 import de.rwth.idsg.steve.utils.__DatabasePreparer__;
+import jooq.steve.db.enums.EvseTopologySource;
 import org.joda.time.DateTime;
 import org.jooq.DSLContext;
 import org.jooq.exception.DataAccessException;
@@ -30,7 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.sql.SQLException;
 import java.util.UUID;
 
-import static jooq.steve.db.tables.Connector.CONNECTOR;
+import static jooq.steve.db.tables.Evse.EVSE;
 import static jooq.steve.db.tables.OcppTag.OCPP_TAG;
 
 /**
@@ -113,9 +114,10 @@ abstract class AbstractRepositoryITBase {
         var preparer = new __DatabasePreparer__(dslContext);
         preparer.prepare();
 
-        dslContext.insertInto(CONNECTOR)
-            .set(CONNECTOR.CHARGE_BOX_ID, KNOWN_CHARGE_BOX_ID)
-            .set(CONNECTOR.CONNECTOR_ID, 1)
+        dslContext.insertInto(EVSE)
+            .set(EVSE.CHARGE_BOX_ID, KNOWN_CHARGE_BOX_ID)
+            .set(EVSE.TOPOLOGY_SOURCE, EvseTopologySource.ocpp1)
+            .set(EVSE.EVSE_ID, 1)
             .onDuplicateKeyIgnore()
             .execute();
 

--- a/src/test/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImplIT.java
+++ b/src/test/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImplIT.java
@@ -24,6 +24,7 @@ import de.rwth.idsg.steve.repository.dto.InsertConnectorStatusParams;
 import de.rwth.idsg.steve.repository.dto.InsertTransactionParams;
 import de.rwth.idsg.steve.repository.dto.UpdateChargeboxParams;
 import de.rwth.idsg.steve.repository.dto.UpdateTransactionParams;
+import jooq.steve.db.enums.EvseTopologySource;
 import jooq.steve.db.enums.TransactionStopEventActor;
 import jooq.steve.db.tables.records.ReservationRecord;
 import jooq.steve.db.tables.records.TransactionRecord;
@@ -38,8 +39,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 
 import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
-import static jooq.steve.db.tables.Connector.CONNECTOR;
 import static jooq.steve.db.tables.ConnectorStatus.CONNECTOR_STATUS;
+import static jooq.steve.db.tables.Evse.EVSE;
 import static jooq.steve.db.tables.Reservation.RESERVATION;
 import static jooq.steve.db.tables.TransactionStart.TRANSACTION_START;
 import static jooq.steve.db.tables.TransactionStop.TRANSACTION_STOP;
@@ -138,7 +139,7 @@ public class OcppServerRepositoryImplIT extends AbstractRepositoryITBase {
     @Test
     public void insertMeterValuesByTransactionRecord() {
         TransactionRecord transaction = new TransactionRecord();
-        transaction.setConnectorPk(1);
+        transaction.setEvsePk(1);
         transaction.setTransactionPk(1);
         assertNoDatabaseException(() -> repository.insertMeterValues(KNOWN_CHARGE_BOX_ID, List.of(new MeterValue()), transaction));
     }
@@ -166,16 +167,17 @@ public class OcppServerRepositoryImplIT extends AbstractRepositoryITBase {
 
     @Test
     public void insertTransaction_usesChargePointWideReservation() {
-        Integer connectorPkZero = dslContext.insertInto(CONNECTOR)
-            .set(CONNECTOR.CHARGE_BOX_ID, KNOWN_CHARGE_BOX_ID)
-            .set(CONNECTOR.CONNECTOR_ID, 0)
-            .returning(CONNECTOR.CONNECTOR_PK)
+        Integer connectorPkZero = dslContext.insertInto(EVSE)
+            .set(EVSE.CHARGE_BOX_ID, KNOWN_CHARGE_BOX_ID)
+            .set(EVSE.TOPOLOGY_SOURCE, EvseTopologySource.ocpp1)
+            .set(EVSE.EVSE_ID, 0)
+            .returning(EVSE.EVSE_PK)
             .fetchOne()
-            .getConnectorPk();
+            .getEvsePk();
         Assertions.assertNotNull(connectorPkZero);
 
         Integer reservationId = dslContext.insertInto(RESERVATION)
-            .set(RESERVATION.CONNECTOR_PK, connectorPkZero)
+            .set(RESERVATION.EVSE_PK, connectorPkZero)
             .set(RESERVATION.ID_TAG, KNOWN_OCPP_TAG)
             .set(RESERVATION.START_DATETIME, DateTime.now())
             .set(RESERVATION.EXPIRY_DATETIME, DateTime.now().plusHours(1))
@@ -231,16 +233,17 @@ public class OcppServerRepositoryImplIT extends AbstractRepositoryITBase {
     }
 
     private void seedTransactionStart(int transactionId) {
-        Integer connectorPk = dslContext.select(CONNECTOR.CONNECTOR_PK)
-            .from(CONNECTOR)
-            .where(CONNECTOR.CHARGE_BOX_ID.eq(KNOWN_CHARGE_BOX_ID))
-            .and(CONNECTOR.CONNECTOR_ID.eq(1))
-            .fetchOne(CONNECTOR.CONNECTOR_PK);
+        Integer connectorPk = dslContext.select(EVSE.EVSE_PK)
+            .from(EVSE)
+            .where(EVSE.CHARGE_BOX_ID.eq(KNOWN_CHARGE_BOX_ID))
+            .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+            .and(EVSE.EVSE_ID.eq(1))
+            .fetchOne(EVSE.EVSE_PK);
 
         dslContext.insertInto(TRANSACTION_START)
             .set(TRANSACTION_START.TRANSACTION_PK, transactionId)
             .set(TRANSACTION_START.EVENT_TIMESTAMP, DateTime.now())
-            .set(TRANSACTION_START.CONNECTOR_PK, connectorPk)
+            .set(TRANSACTION_START.EVSE_PK, connectorPk)
             .set(TRANSACTION_START.ID_TAG, KNOWN_OCPP_TAG)
             .set(TRANSACTION_START.START_TIMESTAMP, DateTime.now())
             .set(TRANSACTION_START.START_VALUE, "1000")

--- a/src/test/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImplIT.java
+++ b/src/test/java/de/rwth/idsg/steve/repository/impl/OcppServerRepositoryImplIT.java
@@ -41,6 +41,7 @@ import java.util.List;
 import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
 import static jooq.steve.db.tables.ConnectorStatus.CONNECTOR_STATUS;
 import static jooq.steve.db.tables.Evse.EVSE;
+import static jooq.steve.db.tables.EvseConnector.EVSE_CONNECTOR;
 import static jooq.steve.db.tables.Reservation.RESERVATION;
 import static jooq.steve.db.tables.TransactionStart.TRANSACTION_START;
 import static jooq.steve.db.tables.TransactionStop.TRANSACTION_STOP;
@@ -129,6 +130,24 @@ public class OcppServerRepositoryImplIT extends AbstractRepositoryITBase {
             .from(CONNECTOR_STATUS)
             .fetchOne(0, int.class);
         Assertions.assertEquals(1, count);
+    }
+
+    @Test
+    public void insertConnectorStatusCreatesOcpp1PhysicalConnector() {
+        int ocpp1ConnectorId = 2;
+        assertNoDatabaseException(() -> repository.insertConnectorStatus(
+            connectorStatusParams(ocpp1ConnectorId)
+        ));
+
+        Integer physicalConnectorId = dslContext.select(EVSE_CONNECTOR.CONNECTOR_ID)
+            .from(EVSE_CONNECTOR)
+            .join(EVSE).on(EVSE.EVSE_PK.eq(EVSE_CONNECTOR.EVSE_PK))
+            .where(EVSE.CHARGE_BOX_ID.eq(KNOWN_CHARGE_BOX_ID))
+            .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+            .and(EVSE.EVSE_ID.eq(ocpp1ConnectorId))
+            .fetchOne(EVSE_CONNECTOR.CONNECTOR_ID);
+
+        Assertions.assertEquals(1, physicalConnectorId);
     }
 
     @Test
@@ -261,9 +280,13 @@ public class OcppServerRepositoryImplIT extends AbstractRepositoryITBase {
     }
 
     private static InsertConnectorStatusParams connectorStatusParams() {
+        return connectorStatusParams(1);
+    }
+
+    private static InsertConnectorStatusParams connectorStatusParams(int connectorId) {
         return InsertConnectorStatusParams.builder()
             .chargeBoxId(KNOWN_CHARGE_BOX_ID)
-            .connectorId(1)
+            .connectorId(connectorId)
             .timestamp(DateTime.now())
             .status("Available")
             .errorCode("NoError")

--- a/src/test/java/de/rwth/idsg/steve/repository/impl/ReservationRepositoryImplIT.java
+++ b/src/test/java/de/rwth/idsg/steve/repository/impl/ReservationRepositoryImplIT.java
@@ -21,6 +21,7 @@ package de.rwth.idsg.steve.repository.impl;
 import de.rwth.idsg.steve.repository.ReservationRepository;
 import de.rwth.idsg.steve.repository.dto.InsertReservationParams;
 import de.rwth.idsg.steve.web.dto.ReservationQueryForm;
+import jooq.steve.db.enums.EvseTopologySource;
 import org.joda.time.DateTime;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.Assertions;
@@ -28,7 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static jooq.steve.db.tables.Connector.CONNECTOR;
+import static jooq.steve.db.tables.Evse.EVSE;
 import static jooq.steve.db.tables.OcppTag.OCPP_TAG;
 import static jooq.steve.db.tables.Reservation.RESERVATION;
 import static jooq.steve.db.tables.TransactionStart.TRANSACTION_START;
@@ -115,9 +116,10 @@ public class ReservationRepositoryImplIT extends AbstractRepositoryITBase {
 
     @Test
     public void used_chargePointWideReservationOnConnectorZero() {
-        dslContext.insertInto(CONNECTOR)
-            .set(CONNECTOR.CHARGE_BOX_ID, KNOWN_CHARGE_BOX_ID)
-            .set(CONNECTOR.CONNECTOR_ID, 0)
+        dslContext.insertInto(EVSE)
+            .set(EVSE.CHARGE_BOX_ID, KNOWN_CHARGE_BOX_ID)
+            .set(EVSE.TOPOLOGY_SOURCE, EvseTopologySource.ocpp1)
+            .set(EVSE.EVSE_ID, 0)
             .onDuplicateKeyIgnore()
             .execute();
 
@@ -157,14 +159,15 @@ public class ReservationRepositoryImplIT extends AbstractRepositoryITBase {
 
     @Test
     public void auditTimestamps() {
-        Integer connectorPk = dslContext.select(CONNECTOR.CONNECTOR_PK)
-            .from(CONNECTOR)
-            .where(CONNECTOR.CHARGE_BOX_ID.eq(KNOWN_CHARGE_BOX_ID))
-            .and(CONNECTOR.CONNECTOR_ID.eq(1))
-            .fetchOne(CONNECTOR.CONNECTOR_PK);
+        Integer connectorPk = dslContext.select(EVSE.EVSE_PK)
+            .from(EVSE)
+            .where(EVSE.CHARGE_BOX_ID.eq(KNOWN_CHARGE_BOX_ID))
+            .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+            .and(EVSE.EVSE_ID.eq(1))
+            .fetchOne(EVSE.EVSE_PK);
 
         Integer id = dslContext.insertInto(RESERVATION)
-            .set(RESERVATION.CONNECTOR_PK, connectorPk)
+            .set(RESERVATION.EVSE_PK, connectorPk)
             .set(RESERVATION.ID_TAG, KNOWN_OCPP_TAG)
             .set(RESERVATION.STATUS, "WAITING")
             .returning(RESERVATION.RESERVATION_PK)
@@ -195,15 +198,16 @@ public class ReservationRepositoryImplIT extends AbstractRepositoryITBase {
         Integer id = repository.insert(insertReservationParams(reservationConnectorId));
         repository.accepted(id);
 
-        Integer connectorPk = dslContext.select(CONNECTOR.CONNECTOR_PK)
-            .from(CONNECTOR)
-            .where(CONNECTOR.CHARGE_BOX_ID.eq(KNOWN_CHARGE_BOX_ID))
-            .and(CONNECTOR.CONNECTOR_ID.eq(1))
-            .fetchOne(CONNECTOR.CONNECTOR_PK);
+        Integer connectorPk = dslContext.select(EVSE.EVSE_PK)
+            .from(EVSE)
+            .where(EVSE.CHARGE_BOX_ID.eq(KNOWN_CHARGE_BOX_ID))
+            .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+            .and(EVSE.EVSE_ID.eq(1))
+            .fetchOne(EVSE.EVSE_PK);
         Assertions.assertNotNull(connectorPk);
 
         Integer transactionPk = dslContext.insertInto(TRANSACTION_START)
-            .set(TRANSACTION_START.CONNECTOR_PK, connectorPk)
+            .set(TRANSACTION_START.EVSE_PK, connectorPk)
             .set(TRANSACTION_START.ID_TAG, idTagFromTransaction)
             .set(TRANSACTION_START.EVENT_TIMESTAMP, DateTime.now())
             .set(TRANSACTION_START.START_TIMESTAMP, DateTime.now().minusMinutes(1))

--- a/src/test/java/de/rwth/idsg/steve/repository/impl/TransactionRepositoryImplIT.java
+++ b/src/test/java/de/rwth/idsg/steve/repository/impl/TransactionRepositoryImplIT.java
@@ -20,6 +20,7 @@ package de.rwth.idsg.steve.repository.impl;
 
 import de.rwth.idsg.steve.repository.TransactionRepository;
 import de.rwth.idsg.steve.web.dto.TransactionQueryForm;
+import jooq.steve.db.enums.EvseTopologySource;
 import org.joda.time.DateTime;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.Assertions;
@@ -29,8 +30,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.StringWriter;
 
-import static jooq.steve.db.tables.Connector.CONNECTOR;
 import static jooq.steve.db.tables.ConnectorMeterValue.CONNECTOR_METER_VALUE;
+import static jooq.steve.db.tables.Evse.EVSE;
 import static jooq.steve.db.tables.TransactionStart.TRANSACTION_START;
 
 /**
@@ -69,15 +70,16 @@ public class TransactionRepositoryImplIT extends AbstractRepositoryITBase {
 
     @Test
     public void getDetails() {
-        Integer connectorPk = dslContext.select(CONNECTOR.CONNECTOR_PK)
-            .from(CONNECTOR)
-            .where(CONNECTOR.CHARGE_BOX_ID.eq(KNOWN_CHARGE_BOX_ID))
-            .and(CONNECTOR.CONNECTOR_ID.eq(1))
-            .fetchOne(CONNECTOR.CONNECTOR_PK);
+        Integer connectorPk = dslContext.select(EVSE.EVSE_PK)
+            .from(EVSE)
+            .where(EVSE.CHARGE_BOX_ID.eq(KNOWN_CHARGE_BOX_ID))
+            .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+            .and(EVSE.EVSE_ID.eq(1))
+            .fetchOne(EVSE.EVSE_PK);
 
         Integer txId = dslContext.insertInto(TRANSACTION_START)
             .set(TRANSACTION_START.EVENT_TIMESTAMP, DateTime.now())
-            .set(TRANSACTION_START.CONNECTOR_PK, connectorPk)
+            .set(TRANSACTION_START.EVSE_PK, connectorPk)
             .set(TRANSACTION_START.ID_TAG, KNOWN_OCPP_TAG)
             .set(TRANSACTION_START.START_TIMESTAMP, DateTime.now().minusMinutes(5))
             .set(TRANSACTION_START.START_VALUE, "100")
@@ -92,11 +94,12 @@ public class TransactionRepositoryImplIT extends AbstractRepositoryITBase {
 
     @Test
     public void getDetailsForZombieTransactionDoesNotIncludeNextTransactionStartValue() {
-        Integer connectorPk = dslContext.select(CONNECTOR.CONNECTOR_PK)
-            .from(CONNECTOR)
-            .where(CONNECTOR.CHARGE_BOX_ID.eq(KNOWN_CHARGE_BOX_ID))
-            .and(CONNECTOR.CONNECTOR_ID.eq(1))
-            .fetchOne(CONNECTOR.CONNECTOR_PK);
+        Integer connectorPk = dslContext.select(EVSE.EVSE_PK)
+            .from(EVSE)
+            .where(EVSE.CHARGE_BOX_ID.eq(KNOWN_CHARGE_BOX_ID))
+            .and(EVSE.TOPOLOGY_SOURCE.eq(EvseTopologySource.ocpp1))
+            .and(EVSE.EVSE_ID.eq(1))
+            .fetchOne(EVSE.EVSE_PK);
 
         DateTime firstStart = DateTime.now().minusMinutes(20);
         DateTime nextStart = firstStart.plusMinutes(10);
@@ -105,14 +108,14 @@ public class TransactionRepositoryImplIT extends AbstractRepositoryITBase {
         insertTransactionStart(connectorPk, nextStart, "200");
 
         dslContext.insertInto(CONNECTOR_METER_VALUE)
-            .set(CONNECTOR_METER_VALUE.CONNECTOR_PK, connectorPk)
+            .set(CONNECTOR_METER_VALUE.EVSE_PK, connectorPk)
             .set(CONNECTOR_METER_VALUE.VALUE_TIMESTAMP, firstStart.plusMinutes(5))
             .set(CONNECTOR_METER_VALUE.VALUE, "150")
             .set(CONNECTOR_METER_VALUE.UNIT, "Wh")
             .execute();
 
         dslContext.insertInto(CONNECTOR_METER_VALUE)
-            .set(CONNECTOR_METER_VALUE.CONNECTOR_PK, connectorPk)
+            .set(CONNECTOR_METER_VALUE.EVSE_PK, connectorPk)
             .set(CONNECTOR_METER_VALUE.VALUE_TIMESTAMP, nextStart)
             .set(CONNECTOR_METER_VALUE.VALUE, "200")
             .set(CONNECTOR_METER_VALUE.UNIT, "Wh")
@@ -134,7 +137,7 @@ public class TransactionRepositoryImplIT extends AbstractRepositoryITBase {
     private Integer insertTransactionStart(Integer connectorPk, DateTime startTimestamp, String startValue) {
         return dslContext.insertInto(TRANSACTION_START)
             .set(TRANSACTION_START.EVENT_TIMESTAMP, startTimestamp)
-            .set(TRANSACTION_START.CONNECTOR_PK, connectorPk)
+            .set(TRANSACTION_START.EVSE_PK, connectorPk)
             .set(TRANSACTION_START.ID_TAG, KNOWN_OCPP_TAG)
             .set(TRANSACTION_START.START_TIMESTAMP, startTimestamp)
             .set(TRANSACTION_START.START_VALUE, startValue)


### PR DESCRIPTION
- `connector` is promoted and renamed to `evse`.
- `evse_connector` is introduced as the physical socket layer.
- old `connector_pk` history references become `evse_pk`, which matches the “OCPP 1 connector becomes EVSE” transition.
- OCPP 1 runtime paths correctly namespace EVSE lookup with `topology_source = ocpp1`.
- OCPP 1 runtime creation now creates one physical connector under each non-zero EVSE, with `evse_connector.connector_id = 1`.
- EVSE `0` is correctly left without a physical connector.
- import/export includes `EVSE_CONNECTOR`.
- tests seed `EVSE_CONNECTOR` and cover the OCPP 1 connector-to-EVSE mapping.
- the business logic and flows map database `evse_id`/`evse_pk` for ocpp1 stations back to `connectorId`/`connectorPk`. as a result, the service and web (api and mvc) layers remain untouched.