### PR TITLE
fix CpoName rendering on charge point detail page

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/repository/dto/ChargePoint.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/dto/ChargePoint.java
@@ -18,12 +18,15 @@
  */
 package de.rwth.idsg.steve.repository.dto;
 
+import de.rwth.idsg.steve.ocpp.ws.JsonObjectMapper;
+import de.rwth.idsg.steve.web.dto.ocpp.ConfigurationKeyEnum;
 import jooq.steve.db.tables.records.AddressRecord;
 import jooq.steve.db.tables.records.ChargeBoxRecord;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.joda.time.DateTime;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  *
@@ -45,6 +48,27 @@ public final class ChargePoint {
     public static final class Details {
         private final ChargeBoxRecord chargeBox;
         private final AddressRecord address;
+
+        public String getCpoName() {
+            return getConfigValueSafely(chargeBox, ConfigurationKeyEnum.CpoName.name());
+        }
+
+        private static String getConfigValueSafely(ChargeBoxRecord chargeBox, String key) {
+            var value = chargeBox.getOcppConfiguration();
+            if (value == null) {
+                return null;
+            }
+
+            var mapper = JsonObjectMapper.INSTANCE.getMapper();
+            var node = mapper.readTree(value.data());
+            if (!node.isObject()) {
+                return null;
+            }
+
+            var ocppConfiguration = (ObjectNode) node;
+            var configNode = ocppConfiguration.get(key);
+            return configNode == null ? null : configNode.asString();
+        }
     }
 
 }

--- a/src/main/java/de/rwth/idsg/steve/repository/dto/ChargePoint.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/dto/ChargePoint.java
@@ -18,7 +18,7 @@
  */
 package de.rwth.idsg.steve.repository.dto;
 
-import de.rwth.idsg.steve.ocpp.ws.JsonObjectMapper;
+import de.rwth.idsg.steve.utils.JsonUtils;
 import de.rwth.idsg.steve.web.dto.ocpp.ConfigurationKeyEnum;
 import jooq.steve.db.tables.records.AddressRecord;
 import jooq.steve.db.tables.records.ChargeBoxRecord;
@@ -26,7 +26,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.joda.time.DateTime;
-import tools.jackson.databind.node.ObjectNode;
 
 /**
  *
@@ -50,24 +49,7 @@ public final class ChargePoint {
         private final AddressRecord address;
 
         public String getCpoName() {
-            return getConfigValueSafely(chargeBox, ConfigurationKeyEnum.CpoName.name());
-        }
-
-        private static String getConfigValueSafely(ChargeBoxRecord chargeBox, String key) {
-            var value = chargeBox.getOcppConfiguration();
-            if (value == null) {
-                return null;
-            }
-
-            var mapper = JsonObjectMapper.INSTANCE.getMapper();
-            var node = mapper.readTree(value.data());
-            if (!node.isObject()) {
-                return null;
-            }
-
-            var ocppConfiguration = (ObjectNode) node;
-            var configNode = ocppConfiguration.get(key);
-            return configNode == null ? null : configNode.asString();
+            return JsonUtils.getPropertyValueAsString(chargeBox.getOcppConfiguration(), ConfigurationKeyEnum.CpoName.name());
         }
     }
 

--- a/src/main/java/de/rwth/idsg/steve/repository/dto/ChargePointRegistration.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/dto/ChargePointRegistration.java
@@ -19,6 +19,7 @@
 package de.rwth.idsg.steve.repository.dto;
 
 import de.rwth.idsg.steve.ocpp.OcppSecurityProfile;
+import de.rwth.idsg.steve.utils.JsonUtils;
 import de.rwth.idsg.steve.web.dto.ocpp.ConfigurationKeyEnum;
 import org.jetbrains.annotations.NotNull;
 import tools.jackson.databind.node.ObjectNode;
@@ -34,7 +35,6 @@ public record ChargePointRegistration(
 ) {
 
     public String cpoName() {
-        var node = ocppConfiguration.get(ConfigurationKeyEnum.CpoName.name());
-        return node == null ? null : node.asString();
+        return JsonUtils.getPropertyValueAsString(ocppConfiguration, ConfigurationKeyEnum.CpoName.name());
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
@@ -21,7 +21,6 @@ package de.rwth.idsg.steve.repository.impl;
 import de.rwth.idsg.steve.SteveException;
 import de.rwth.idsg.steve.ocpp.OcppProtocol;
 import de.rwth.idsg.steve.ocpp.OcppSecurityProfile;
-import de.rwth.idsg.steve.ocpp.ws.JsonObjectMapper;
 import de.rwth.idsg.steve.repository.AddressRepository;
 import de.rwth.idsg.steve.repository.ChargePointRepository;
 import de.rwth.idsg.steve.repository.dto.ChargePoint;
@@ -29,6 +28,7 @@ import de.rwth.idsg.steve.repository.dto.ChargePointRegistration;
 import de.rwth.idsg.steve.repository.dto.ChargePointSelect;
 import de.rwth.idsg.steve.repository.dto.ConnectorStatus;
 import de.rwth.idsg.steve.utils.DateTimeUtils;
+import de.rwth.idsg.steve.utils.JsonUtils;
 import de.rwth.idsg.steve.web.dto.ChargePointForm;
 import de.rwth.idsg.steve.web.dto.ChargePointQueryForm;
 import de.rwth.idsg.steve.web.dto.ConnectorStatusForm;
@@ -53,7 +53,6 @@ import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.CollectionUtils;
-import tools.jackson.databind.node.ObjectNode;
 
 import java.util.List;
 import java.util.Map;
@@ -97,7 +96,7 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
                             rec.value3(),
                             OcppSecurityProfile.fromValue(rec.value4()),
                             rec.value5(),
-                            toObjectNode(rec.value6()),
+                            JsonUtils.toObjectNode(rec.value6()),
                             rec.value7()
                         ));
 
@@ -438,17 +437,4 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
            .execute();
     }
 
-    private static ObjectNode toObjectNode(JSON value) {
-        var mapper = JsonObjectMapper.INSTANCE.getMapper();
-
-        if (value == null) {
-            return mapper.createObjectNode();
-        }
-
-        var node = mapper.readTree(value.data());
-        if (!node.isObject()) {
-            throw new SteveException("Existing OCPP configuration is not a JSON object"); // should not happen
-        }
-        return (ObjectNode) node;
-    }
 }

--- a/src/main/java/de/rwth/idsg/steve/utils/JsonUtils.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/JsonUtils.java
@@ -1,0 +1,55 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.utils;
+
+import de.rwth.idsg.steve.SteveException;
+import de.rwth.idsg.steve.ocpp.ws.JsonObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.jooq.JSON;
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 13.05.2026
+ */
+public class JsonUtils {
+
+    public static String getPropertyValueAsString(JSON jsonFromDB, String key) {
+        return getPropertyValueAsString(toObjectNode(jsonFromDB), key);
+    }
+
+    public static String getPropertyValueAsString(ObjectNode jsonNode, String key) {
+        var node = jsonNode.get(key);
+        return node == null ? null : node.asString();
+    }
+
+    public static ObjectNode toObjectNode(JSON jsonFromDB) {
+        var mapper = JsonObjectMapper.INSTANCE.getMapper();
+
+        if (jsonFromDB == null || StringUtils.isEmpty(jsonFromDB.data())) {
+            return mapper.createObjectNode();
+        }
+
+        var node = mapper.readTree(jsonFromDB.data());
+        if (!node.isObject()) {
+            throw new SteveException("Existing OCPP configuration is not a JSON object"); // should not happen
+        }
+        return (ObjectNode) node;
+    }
+}

--- a/src/main/webapp/WEB-INF/views/data-man/chargepointDetails.jsp
+++ b/src/main/webapp/WEB-INF/views/data-man/chargepointDetails.jsp
@@ -99,7 +99,7 @@
                     <tr><td>Diagnostics Status:</td><td><encode:forHtml value="${cp.chargeBox.diagnosticsStatus}" /></td></tr>
                     <tr><td>Diagnostics Timestamp:</td><td><encode:forHtml value="${cp.chargeBox.diagnosticsTimestamp}" /></td></tr>
                     <tr><td>Last Heartbeat Timestamp:</td><td><encode:forHtml value="${cp.chargeBox.lastHeartbeatTimestamp}" /></td></tr>
-                    <tr><td>CPO Name:</td><td><encode:forHtml value="${cp.chargeBox.cpoName}" /></td></tr>
+                    <tr><td>CPO Name:</td><td><encode:forHtml value="${cp.cpoName}" /></td></tr>
                     <tr>
                         <td>Insert connector status after start/stop transaction:
                         </td>


### PR DESCRIPTION
after https://github.com/steve-community/steve/pull/2039, CpoName is not a standalone column anymore. therefore, ChargeBoxRecord.getCpoName() does not exist. we need to get it out of ChargeBoxRecord.getOcppConfiguration()