### PR TITLE
refactor: split ChargePointForm into Create and Update parts

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/repository/ChargePointRepository.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/ChargePointRepository.java
@@ -24,7 +24,8 @@ import de.rwth.idsg.steve.repository.dto.ChargePoint;
 import de.rwth.idsg.steve.repository.dto.ChargePointRegistration;
 import de.rwth.idsg.steve.repository.dto.ChargePointSelect;
 import de.rwth.idsg.steve.repository.dto.ConnectorStatus;
-import de.rwth.idsg.steve.web.dto.ChargePointForm;
+import de.rwth.idsg.steve.web.dto.ChargePointFormForCreate;
+import de.rwth.idsg.steve.web.dto.ChargePointFormForUpdate;
 import de.rwth.idsg.steve.web.dto.ChargePointQueryForm;
 import de.rwth.idsg.steve.web.dto.ConnectorStatusForm;
 import org.jetbrains.annotations.Nullable;
@@ -56,7 +57,7 @@ public interface ChargePointRepository {
     List<Integer> getNonZeroConnectorIds(String chargeBoxId);
 
     void addChargePointList(List<String> chargeBoxIdList);
-    int addChargePoint(ChargePointForm form);
-    void updateChargePoint(ChargePointForm form);
+    int addChargePoint(ChargePointFormForCreate form);
+    void updateChargePoint(ChargePointFormForUpdate form);
     void deleteChargePoint(int chargeBoxPk);
 }

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImpl.java
@@ -29,7 +29,8 @@ import de.rwth.idsg.steve.repository.dto.ChargePointSelect;
 import de.rwth.idsg.steve.repository.dto.ConnectorStatus;
 import de.rwth.idsg.steve.utils.DateTimeUtils;
 import de.rwth.idsg.steve.utils.JsonUtils;
-import de.rwth.idsg.steve.web.dto.ChargePointForm;
+import de.rwth.idsg.steve.web.dto.ChargePointFormForCreate;
+import de.rwth.idsg.steve.web.dto.ChargePointFormForUpdate;
 import de.rwth.idsg.steve.web.dto.ChargePointQueryForm;
 import de.rwth.idsg.steve.web.dto.ConnectorStatusForm;
 import jooq.steve.db.enums.EvseTopologySource;
@@ -361,7 +362,7 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
     }
 
     @Override
-    public int addChargePoint(ChargePointForm form) {
+    public int addChargePoint(ChargePointFormForCreate form) {
         return ctx.transactionResult(configuration -> {
             DSLContext ctx = DSL.using(configuration);
             try {
@@ -376,7 +377,7 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
     }
 
     @Override
-    public void updateChargePoint(ChargePointForm form) {
+    public void updateChargePoint(ChargePointFormForUpdate form) {
         ctx.transaction(configuration -> {
             DSLContext ctx = DSL.using(configuration);
             try {
@@ -415,7 +416,7 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
                   .where(CHARGE_BOX.CHARGE_BOX_PK.eq(chargeBoxPk));
     }
 
-    private int addChargePointInternal(DSLContext ctx, ChargePointForm form, Integer addressPk) {
+    private int addChargePointInternal(DSLContext ctx, ChargePointFormForCreate form, Integer addressPk) {
         var query = ctx.insertInto(CHARGE_BOX)
                        .set(CHARGE_BOX.CHARGE_BOX_ID, form.getChargeBoxId())
                        .set(CHARGE_BOX.DESCRIPTION, form.getDescription())
@@ -435,7 +436,7 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
                     .getChargeBoxPk();
     }
 
-    private static void updateChargePointInternal(DSLContext ctx, ChargePointForm form, Integer addressPk) {
+    private static void updateChargePointInternal(DSLContext ctx, ChargePointFormForUpdate form, Integer addressPk) {
        var query = ctx.update(CHARGE_BOX)
                       .set(CHARGE_BOX.DESCRIPTION, form.getDescription())
                       .set(CHARGE_BOX.INSERT_CONNECTOR_STATUS_AFTER_TRANSACTION_MSG, form.getInsertConnectorStatusAfterTransactionMsg())
@@ -453,7 +454,7 @@ public class ChargePointRepositoryImpl implements ChargePointRepository {
              .execute();
     }
 
-    private static void updateDeviceModel(DSLContext ctx, ChargePointForm form) {
+    private static void updateDeviceModel(DSLContext ctx, ChargePointFormForUpdate form) {
         var evses = form.getDeviceModelForm().getEvses();
         if (CollectionUtils.isEmpty(evses)) {
             return;

--- a/src/main/java/de/rwth/idsg/steve/service/ChargePointService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/ChargePointService.java
@@ -38,7 +38,8 @@ import de.rwth.idsg.steve.service.notification.OcppStationSecurityBasicAuthChang
 import de.rwth.idsg.steve.service.notification.OcppStationSecurityProfileChanged;
 import de.rwth.idsg.steve.utils.ConnectorStatusCountFilter;
 import de.rwth.idsg.steve.utils.DateTimeUtils;
-import de.rwth.idsg.steve.web.dto.ChargePointForm;
+import de.rwth.idsg.steve.web.dto.ChargePointFormForCreate;
+import de.rwth.idsg.steve.web.dto.ChargePointFormForUpdate;
 import de.rwth.idsg.steve.web.dto.ChargePointQueryForm;
 import de.rwth.idsg.steve.web.dto.ConnectorStatusForm;
 import de.rwth.idsg.steve.web.dto.OcppJsonStatus;
@@ -130,12 +131,12 @@ public class ChargePointService {
         chargePointRepository.addChargePointList(chargeBoxIdList);
     }
 
-    public int addChargePoint(ChargePointForm form) {
+    public int addChargePoint(ChargePointFormForCreate form) {
         encodePasswordIfNeeded(form);
         return chargePointRepository.addChargePoint(form);
     }
 
-    public void updateChargePoint(ChargePointForm form) {
+    public void updateChargePoint(ChargePointFormForUpdate form) {
         var chargeBoxId = form.getChargeBoxId();
         var newRawPassword = form.getAuthPassword();
         var newSecurityProfile = form.getSecurityProfile();
@@ -182,7 +183,7 @@ public class ChargePointService {
         }
     }
 
-    private void encodePasswordIfNeeded(ChargePointForm form) {
+    private void encodePasswordIfNeeded(ChargePointFormForCreate form) {
         String encodedPwd = StringUtils.isEmpty(form.getAuthPassword())
             ? null
             : passwordEncoder.encode(form.getAuthPassword());

--- a/src/main/java/de/rwth/idsg/steve/utils/mapper/ChargePointDetailsMapper.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/mapper/ChargePointDetailsMapper.java
@@ -25,7 +25,7 @@ import de.rwth.idsg.steve.ocpp.model.PowerType;
 import de.rwth.idsg.steve.repository.dto.ChargePoint;
 import de.rwth.idsg.steve.web.dto.ChargePointDeviceModelForm;
 import de.rwth.idsg.steve.web.dto.ChargePointDeviceModelForm.EvseConnectorForm;
-import de.rwth.idsg.steve.web.dto.ChargePointForm;
+import de.rwth.idsg.steve.web.dto.ChargePointFormForUpdate;
 import jooq.steve.db.tables.records.ChargeBoxRecord;
 import jooq.steve.db.tables.records.EvseConnectorRecord;
 import jooq.steve.db.tables.records.EvseRecord;
@@ -45,10 +45,10 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ChargePointDetailsMapper {
 
-    public static ChargePointForm mapToForm(ChargePoint.Details cp) {
+    public static ChargePointFormForUpdate mapToForm(ChargePoint.Details cp) {
         ChargeBoxRecord chargeBox = cp.getChargeBox();
 
-        ChargePointForm form = new ChargePointForm();
+        ChargePointFormForUpdate form = new ChargePointFormForUpdate();
         form.setChargeBoxPk(chargeBox.getChargeBoxPk());
         form.setChargeBoxId(chargeBox.getChargeBoxId());
         form.setNote(chargeBox.getNote());

--- a/src/main/java/de/rwth/idsg/steve/web/controller/ChargePointsController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/controller/ChargePointsController.java
@@ -23,7 +23,8 @@ import de.rwth.idsg.steve.service.ChargePointService;
 import de.rwth.idsg.steve.utils.ControllerHelper;
 import de.rwth.idsg.steve.utils.mapper.ChargePointDetailsMapper;
 import de.rwth.idsg.steve.web.dto.ChargePointBatchInsertForm;
-import de.rwth.idsg.steve.web.dto.ChargePointForm;
+import de.rwth.idsg.steve.web.dto.ChargePointFormForCreate;
+import de.rwth.idsg.steve.web.dto.ChargePointFormForUpdate;
 import de.rwth.idsg.steve.web.dto.ChargePointQueryForm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -98,7 +99,7 @@ public class ChargePointsController {
     @GetMapping(DETAILS_PATH)
     public String getDetails(@PathVariable("chargeBoxPk") int chargeBoxPk, Model model) {
         ChargePoint.Details cp = chargePointService.getDetails(chargeBoxPk);
-        ChargePointForm form = ChargePointDetailsMapper.mapToForm(cp);
+        ChargePointFormForUpdate form = ChargePointDetailsMapper.mapToForm(cp);
 
         model.addAttribute("chargePointForm", form);
         model.addAttribute("cp", cp);
@@ -109,13 +110,13 @@ public class ChargePointsController {
 
     @GetMapping(ADD_PATH)
     public String addGet(Model model) {
-        model.addAttribute("chargePointForm", new ChargePointForm());
+        model.addAttribute("chargePointForm", new ChargePointFormForCreate());
         setCommonAttributesForSingleAdd(model);
         return "data-man/chargepointAdd";
     }
 
     @PostMapping(params = "add", value = ADD_SINGLE_PATH)
-    public String addSinglePost(@Valid @ModelAttribute("chargePointForm") ChargePointForm chargePointForm,
+    public String addSinglePost(@Valid @ModelAttribute("chargePointForm") ChargePointFormForCreate chargePointForm,
                                 BindingResult result, Model model) {
         if (result.hasErrors()) {
             setCommonAttributesForSingleAdd(model);
@@ -132,7 +133,7 @@ public class ChargePointsController {
                                BindingResult result, Model model) {
         if (result.hasErrors()) {
             addCountryCodes(model);
-            model.addAttribute("chargePointForm", new ChargePointForm());
+            model.addAttribute("chargePointForm", new ChargePointFormForCreate());
             return "data-man/chargepointAdd";
         }
 
@@ -141,7 +142,7 @@ public class ChargePointsController {
     }
 
     @PostMapping(params = "update", value = UPDATE_PATH)
-    public String update(@Valid @ModelAttribute("chargePointForm") ChargePointForm chargePointForm,
+    public String update(@Valid @ModelAttribute("chargePointForm") ChargePointFormForUpdate chargePointForm,
                          BindingResult result, Model model) {
         if (result.hasErrors()) {
             setCommonAttributesForSingleAdd(model);
@@ -203,7 +204,7 @@ public class ChargePointsController {
         model.addAttribute("batchChargePointForm", new ChargePointBatchInsertForm());
     }
 
-    private void add(ChargePointForm form) {
+    private void add(ChargePointFormForCreate form) {
         chargePointService.addChargePoint(form);
         chargePointService.removeUnknown(Collections.singletonList(form.getChargeBoxId()));
     }

--- a/src/main/java/de/rwth/idsg/steve/web/dto/ChargePointFormForCreate.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ChargePointFormForCreate.java
@@ -43,7 +43,7 @@ import static de.rwth.idsg.steve.ocpp.OcppSecurityProfile.Profile_0;
 @Setter
 @ToString
 @SecurityProfileValid
-public class ChargePointForm {
+public class ChargePointFormForCreate {
 
     // Internal database id
     private Integer chargeBoxPk;
@@ -85,7 +85,4 @@ public class ChargePointForm {
 
     @Schema(accessMode = Schema.AccessMode.READ_ONLY)
     private boolean hasAuthPassword;
-
-    @Valid
-    private ChargePointDeviceModelForm deviceModelForm = new ChargePointDeviceModelForm();
 }

--- a/src/main/java/de/rwth/idsg/steve/web/dto/ChargePointFormForUpdate.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ChargePointFormForUpdate.java
@@ -1,0 +1,38 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.web.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import jakarta.validation.Valid;
+
+/**
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 20.05.2026
+ */
+@Getter
+@Setter
+@ToString(callSuper = true)
+public class ChargePointFormForUpdate extends ChargePointFormForCreate {
+
+    @Valid
+    private ChargePointDeviceModelForm deviceModelForm = new ChargePointDeviceModelForm();
+}

--- a/src/main/java/de/rwth/idsg/steve/web/validation/SecurityProfileValidator.java
+++ b/src/main/java/de/rwth/idsg/steve/web/validation/SecurityProfileValidator.java
@@ -20,7 +20,7 @@ package de.rwth.idsg.steve.web.validation;
 
 import de.rwth.idsg.steve.ocpp.OcppSecurityProfile;
 import de.rwth.idsg.steve.service.ChargePointService;
-import de.rwth.idsg.steve.web.dto.ChargePointForm;
+import de.rwth.idsg.steve.web.dto.ChargePointFormForCreate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -30,12 +30,12 @@ import jakarta.validation.ConstraintValidatorContext;
 
 @Component
 @RequiredArgsConstructor
-public class SecurityProfileValidator implements ConstraintValidator<SecurityProfileValid, ChargePointForm> {
+public class SecurityProfileValidator implements ConstraintValidator<SecurityProfileValid, ChargePointFormForCreate> {
 
     private final ChargePointService chargePointService;
 
     @Override
-    public boolean isValid(ChargePointForm form, ConstraintValidatorContext context) {
+    public boolean isValid(ChargePointFormForCreate form, ConstraintValidatorContext context) {
         OcppSecurityProfile securityProfile = form.getSecurityProfile();
         String newAuthPassword = form.getAuthPassword();
 

--- a/src/test/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImplIT.java
+++ b/src/test/java/de/rwth/idsg/steve/repository/impl/ChargePointRepositoryImplIT.java
@@ -23,7 +23,8 @@ import de.rwth.idsg.steve.ocpp.OcppSecurityProfile;
 import de.rwth.idsg.steve.ocpp.ws.JsonObjectMapper;
 import de.rwth.idsg.steve.repository.ChargePointRepository;
 import de.rwth.idsg.steve.web.dto.Address;
-import de.rwth.idsg.steve.web.dto.ChargePointForm;
+import de.rwth.idsg.steve.web.dto.ChargePointFormForCreate;
+import de.rwth.idsg.steve.web.dto.ChargePointFormForUpdate;
 import de.rwth.idsg.steve.web.dto.ChargePointQueryForm;
 import de.rwth.idsg.steve.web.dto.ConnectorStatusForm;
 import ocpp.cs._2015._10.RegistrationStatus;
@@ -168,7 +169,7 @@ public class ChargePointRepositoryImplIT extends AbstractRepositoryITBase {
 
     @Test
     public void updateChargePoint() {
-        var form = chargePointForm(KNOWN_CHARGE_BOX_ID);
+        var form = chargePointFormForUpdate(KNOWN_CHARGE_BOX_ID);
         Integer chargeBoxPk = dslContext.select(CHARGE_BOX.CHARGE_BOX_PK)
             .from(CHARGE_BOX)
             .where(CHARGE_BOX.CHARGE_BOX_ID.eq(KNOWN_CHARGE_BOX_ID))
@@ -226,8 +227,12 @@ public class ChargePointRepositoryImplIT extends AbstractRepositoryITBase {
         assertAuditTimestampsAfterUpdate(before.value1(), before.value2(), after.value1(), after.value2());
     }
 
-    private static ChargePointForm chargePointForm(String chargeBoxId) {
-        var form = new ChargePointForm();
+    private static ChargePointFormForCreate chargePointForm(String chargeBoxId) {
+        return chargePointFormForUpdate(chargeBoxId);
+    }
+
+    private static ChargePointFormForUpdate chargePointFormForUpdate(String chargeBoxId) {
+        var form = new ChargePointFormForUpdate();
         form.setChargeBoxId(chargeBoxId);
         form.setRegistrationStatus(RegistrationStatus.ACCEPTED);
         form.setInsertConnectorStatusAfterTransactionMsg(true);

--- a/src/test/java/de/rwth/idsg/steve/web/validation/SecurityProfileValidatorTest.java
+++ b/src/test/java/de/rwth/idsg/steve/web/validation/SecurityProfileValidatorTest.java
@@ -22,7 +22,7 @@ import de.rwth.idsg.steve.ocpp.OcppSecurityProfile;
 import de.rwth.idsg.steve.ocpp.ws.JsonObjectMapper;
 import de.rwth.idsg.steve.repository.dto.ChargePointRegistration;
 import de.rwth.idsg.steve.service.ChargePointService;
-import de.rwth.idsg.steve.web.dto.ChargePointForm;
+import de.rwth.idsg.steve.web.dto.ChargePointFormForCreate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -81,7 +81,7 @@ public class SecurityProfileValidatorTest {
                                     boolean isValid) {
         OcppSecurityProfile securityProfile = OcppSecurityProfile.fromValue(securityProfileNumber);
 
-        ChargePointForm form = new ChargePointForm();
+        ChargePointFormForCreate form = new ChargePointFormForCreate();
         form.setSecurityProfile(securityProfile);
         form.setAuthPassword(authPassword);
 


### PR DESCRIPTION
ChargePointDeviceModelForm is only applicable for update flows. enforce it with separate/dedicated forms/DTOs.