### PR TITLE
pass down Task to OcppCallbacks

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/ocpp/CommunicationTask.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/CommunicationTask.java
@@ -135,7 +135,7 @@ public abstract class CommunicationTask<S extends ChargePointSelection, RESPONSE
     public void success(String chargeBoxId, RESPONSE response) {
         for (OcppCallback<RESPONSE> c : callbackList) {
             try {
-                c.success(chargeBoxId, response);
+                c.success(this, chargeBoxId, response);
             } catch (Exception e) {
                 log.error("Exception occurred in OcppCallback", e);
             }
@@ -145,7 +145,7 @@ public abstract class CommunicationTask<S extends ChargePointSelection, RESPONSE
     public void failed(String chargeBoxId, Exception exception) {
         for (OcppCallback<RESPONSE> c : callbackList) {
             try {
-                c.failed(chargeBoxId, exception);
+                c.failed(this, chargeBoxId, exception);
             } catch (Exception e) {
                 log.error("Exception occurred in OcppCallback", e);
             }
@@ -159,7 +159,7 @@ public abstract class CommunicationTask<S extends ChargePointSelection, RESPONSE
     public void success(String chargeBoxId, OcppJsonError error) {
         for (OcppCallback<RESPONSE> c : callbackList) {
             try {
-                c.success(chargeBoxId, error);
+                c.success(this, chargeBoxId, error);
             } catch (Exception e) {
                 log.error("Exception occurred in OcppCallback", e);
             }
@@ -193,12 +193,17 @@ public abstract class CommunicationTask<S extends ChargePointSelection, RESPONSE
         public abstract void success(String chargeBoxId, RES response);
 
         @Override
-        public void success(String chargeBoxId, OcppJsonError error) {
+        public void success(CommunicationTask<?, RES> task, String chargeBoxId, RES response) {
+            success(chargeBoxId, response);
+        }
+
+        @Override
+        public void success(CommunicationTask<?, RES> task, String chargeBoxId, OcppJsonError error) {
             addNewResponse(chargeBoxId, error.toString());
         }
 
         @Override
-        public void failed(String chargeBoxId, Exception e) {
+        public void failed(CommunicationTask<?, RES> task, String chargeBoxId, Exception e) {
             addNewError(chargeBoxId, e.getMessage());
         }
     }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/OcppCallback.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/OcppCallback.java
@@ -29,19 +29,19 @@ import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonError;
  */
 public interface OcppCallback<T> {
 
-    void success(String chargeBoxId, T response);
+    void success(CommunicationTask<?, T> task, String chargeBoxId, T response);
 
     /**
      * Relevant to WebSocket/JSON transport: Even though we have an error, this object is still a valid response from
      * charge point and the implementation should treat it as such. {@link CommunicationTask#addNewError(String, String)}
      * should be used when the request could not be delivered and there is a Java exception.
      */
-    void success(String chargeBoxId, OcppJsonError error);
+    void success(CommunicationTask<?, T> task, String chargeBoxId, OcppJsonError error);
 
     // -------------------------------------------------------------------------
     // Technical errors ((e.g. communication problems)
     // -------------------------------------------------------------------------
 
-    void failed(String chargeBoxId, Exception e);
+    void failed(CommunicationTask<?, T> task, String chargeBoxId, Exception e);
 
 }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/task/ReserveNowTask.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/task/ReserveNowTask.java
@@ -18,6 +18,7 @@
  */
 package de.rwth.idsg.steve.ocpp.task;
 
+import de.rwth.idsg.steve.ocpp.CommunicationTask;
 import de.rwth.idsg.steve.ocpp.Ocpp15AndAboveTask;
 import de.rwth.idsg.steve.ocpp.OcppCallback;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonError;
@@ -47,9 +48,9 @@ public class ReserveNowTask extends Ocpp15AndAboveTask<ReserveNowParams, Reserva
 
     @Override
     public OcppCallback<ReservationStatus> defaultCallback() {
-        return new DefaultOcppCallback<ReservationStatus>() {
+        return new OcppCallback<>() {
             @Override
-            public void success(String chargeBoxId, ReservationStatus response) {
+            public void success(CommunicationTask<?, ReservationStatus> task, String chargeBoxId, ReservationStatus response) {
                 addNewResponse(chargeBoxId, response.value());
 
                 if (ReservationStatus.ACCEPTED == response) {
@@ -60,13 +61,13 @@ public class ReserveNowTask extends Ocpp15AndAboveTask<ReserveNowParams, Reserva
             }
 
             @Override
-            public void success(String chargeBoxId, OcppJsonError error) {
+            public void success(CommunicationTask<?, ReservationStatus> task, String chargeBoxId, OcppJsonError error) {
                 addNewError(chargeBoxId, error.toString());
                 delete();
             }
 
             @Override
-            public void failed(String chargeBoxId, Exception e) {
+            public void failed(CommunicationTask<?, ReservationStatus> task, String chargeBoxId, Exception e) {
                 addNewError(chargeBoxId, e.getMessage());
                 delete();
             }

--- a/src/main/java/de/rwth/idsg/steve/service/ChargePointServiceClient.java
+++ b/src/main/java/de/rwth/idsg/steve/service/ChargePointServiceClient.java
@@ -20,6 +20,7 @@ package de.rwth.idsg.steve.service;
 
 import de.rwth.idsg.steve.SteveException;
 import de.rwth.idsg.steve.ocpp.ChargePointServiceInvokerImpl;
+import de.rwth.idsg.steve.ocpp.CommunicationTask;
 import de.rwth.idsg.steve.ocpp.OcppCallback;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.task.CancelReservationTask;
@@ -226,7 +227,7 @@ public class ChargePointServiceClient {
 
             task.addCallback(new OcppCallback<>() {
                 @Override
-                public void success(String chargeBoxId, ConfigurationStatus response) {
+                public void success(CommunicationTask<?, ConfigurationStatus> task, String chargeBoxId, ConfigurationStatus response) {
                     if (response == ACCEPTED) {
                         var params = new GetConfigurationParams();
                         params.setChargePointSelectList(ocpp15AndAboveStations);
@@ -235,12 +236,12 @@ public class ChargePointServiceClient {
                 }
 
                 @Override
-                public void success(String chargeBoxId, OcppJsonError error) {
+                public void success(CommunicationTask<?, ConfigurationStatus> task, String chargeBoxId, OcppJsonError error) {
 
                 }
 
                 @Override
-                public void failed(String chargeBoxId, Exception e) {
+                public void failed(CommunicationTask<?, ConfigurationStatus> task, String chargeBoxId, Exception e) {
 
                 }
             });

--- a/src/main/java/de/rwth/idsg/steve/web/dto/RestCallback.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/RestCallback.java
@@ -18,6 +18,7 @@
  */
 package de.rwth.idsg.steve.web.dto;
 
+import de.rwth.idsg.steve.ocpp.CommunicationTask;
 import de.rwth.idsg.steve.ocpp.OcppCallback;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonError;
 import lombok.Getter;
@@ -49,19 +50,19 @@ public class RestCallback<T> implements OcppCallback<T> {
     private boolean finished = false;
 
     @Override
-    public void success(String chargeBoxId, T response) {
+    public void success(CommunicationTask<?, T> task, String chargeBoxId, T response) {
         successResponsesByChargeBoxId.put(chargeBoxId, response);
         countDownLatch.countDown();
     }
 
     @Override
-    public void success(String chargeBoxId, OcppJsonError error) {
+    public void success(CommunicationTask<?, T> task, String chargeBoxId, OcppJsonError error) {
         errorResponsesByChargeBoxId.put(chargeBoxId, error);
         countDownLatch.countDown();
     }
 
     @Override
-    public void failed(String chargeBoxId, Exception e) {
+    public void failed(CommunicationTask<?, T> task, String chargeBoxId, Exception e) {
         exceptionsByChargeBoxId.put(chargeBoxId, e);
         countDownLatch.countDown();
     }


### PR DESCRIPTION
reason: sometimes some callbacks need more context and task details.