### PR TITLE
refine stop meter value selection with monotonic streaks

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/service/TransactionService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/TransactionService.java
@@ -44,6 +44,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import static de.rwth.idsg.steve.utils.TransactionStopServiceHelper.floatingStringToIntString;
+import static de.rwth.idsg.steve.utils.TransactionStopServiceHelper.kWhStringToWhDouble;
 import static de.rwth.idsg.steve.utils.TransactionStopServiceHelper.kWhStringToWhString;
 
 /**
@@ -154,7 +155,7 @@ public class TransactionService {
         // 1. intermediate meter values have priority (most accurate data)
         // -------------------------------------------------------------------------
 
-        TransactionDetails.MeterValues last = findLastMeterValue(intermediateValues);
+        TransactionDetails.MeterValues last = findLastMeterValue(intermediateValues, thisTx);
         if (last != null) {
             return TerminationValues.builder()
                                     .stopValue(floatingStringToIntString(last.getValue()))
@@ -194,12 +195,17 @@ public class TransactionService {
     }
 
     @Nullable
-    private static TransactionDetails.MeterValues findLastMeterValue(List<TransactionDetails.MeterValues> values) {
-        TransactionDetails.MeterValues v =
-                values.stream()
-                      .filter(TransactionStopServiceHelper::isEnergyValue)
-                      .max(Comparator.comparing(TransactionDetails.MeterValues::getValueTimestamp))
-                      .orElse(null);
+    static TransactionDetails.MeterValues findLastMeterValue(List<TransactionDetails.MeterValues> values,
+                                                             Transaction thisTx) {
+        var treatedValues = values.stream()
+            .filter(TransactionStopServiceHelper::isEnergyValue)
+            .sorted(Comparator.comparing(TransactionDetails.MeterValues::getValueTimestamp))
+            .toList();
+
+        TransactionDetails.MeterValues v = findLastMeterValueFromMonotonicStreak(
+            treatedValues,
+            Double.parseDouble(thisTx.getStartValue())
+        );
 
         // if the list of values is empty, we fall to this case, as well.
         if (v == null) {
@@ -218,9 +224,43 @@ public class TransactionService {
                                                  .unit(v.getUnit())
                                                  .phase(v.getPhase())
                                                  .build();
-        } else {
-            return v;
         }
+
+        return v;
+    }
+
+    @Nullable
+    private static TransactionDetails.MeterValues findLastMeterValueFromMonotonicStreak(List<TransactionDetails.MeterValues> values,
+                                                                                        double startValueWh) {
+        TransactionDetails.MeterValues lastMatchingValue = null;
+        Double previousValueWh = null;
+        int currentStreakLength = 0;
+        boolean firstStreak = true;
+
+        for (TransactionDetails.MeterValues value : values) {
+            double valueWh = toWh(value);
+
+            if (previousValueWh != null && valueWh < previousValueWh) {
+                firstStreak = false;
+                currentStreakLength = 1;
+            } else {
+                currentStreakLength++;
+            }
+
+            if (valueWh >= startValueWh && (firstStreak || currentStreakLength > 1)) {
+                lastMatchingValue = value;
+            }
+
+            previousValueWh = valueWh;
+        }
+
+        return lastMatchingValue;
+    }
+
+    private static double toWh(TransactionDetails.MeterValues meterValue) {
+        return UnitOfMeasure.K_WH.value().equals(meterValue.getUnit())
+            ? kWhStringToWhDouble(meterValue.getValue())
+            : Double.parseDouble(meterValue.getValue());
     }
 
     @Builder

--- a/src/main/java/de/rwth/idsg/steve/service/TransactionService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/TransactionService.java
@@ -221,7 +221,7 @@ public class TransactionService {
                                                  .format(v.getFormat())
                                                  .measurand(v.getMeasurand())
                                                  .location(v.getLocation())
-                                                 .unit(v.getUnit())
+                                                 .unit(UnitOfMeasure.WH.value())
                                                  .phase(v.getPhase())
                                                  .build();
         }

--- a/src/main/java/de/rwth/idsg/steve/utils/TransactionStopServiceHelper.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/TransactionStopServiceHelper.java
@@ -49,9 +49,12 @@ public class TransactionStopServiceHelper {
         return Integer.toString((int) Math.ceil(Double.parseDouble(s)));
     }
 
+    public static double kWhStringToWhDouble(String s) {
+        return Double.parseDouble(s) * 1000;
+    }
+
     public static String kWhStringToWhString(String s) {
-        double kWhValue = Double.parseDouble(s);
-        return Double.toString(kWhValue * 1000);
+        return Double.toString(kWhStringToWhDouble(s));
     }
 
     public static boolean isEnergyValue(TransactionDetails.MeterValues v) {

--- a/src/test/java/de/rwth/idsg/steve/service/TransactionServiceTest.java
+++ b/src/test/java/de/rwth/idsg/steve/service/TransactionServiceTest.java
@@ -1,0 +1,131 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.service;
+
+import de.rwth.idsg.steve.repository.dto.Transaction;
+import de.rwth.idsg.steve.repository.dto.TransactionDetails;
+import ocpp.cs._2012._06.UnitOfMeasure;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class TransactionServiceTest {
+
+    private static final int TRANSACTION_PK = 42;
+    private static final String START_VALUE = "1000";
+    private static final DateTime START_TIMESTAMP = DateTime.parse("2026-06-30T10:00:00Z");
+
+    @Test
+    public void findLast_usesPreviousStreakWhenLatestReadingBreaksMonotonicity() {
+        // given
+        DateTime t1 = START_TIMESTAMP.plusMinutes(1);
+        DateTime t2 = START_TIMESTAMP.plusMinutes(2);
+        DateTime t3 = START_TIMESTAMP.plusMinutes(3);
+        DateTime t4 = START_TIMESTAMP.plusMinutes(4);
+        DateTime t5 = START_TIMESTAMP.plusMinutes(5);
+
+        // when
+        var last = TransactionService.findLastMeterValue(
+            List.of(
+                meterValue("1050", t1),
+                meterValue("1100", t2),
+                meterValue("1150", t3),
+                meterValue("1200", t4),
+                meterValue("1050", t5)
+            ),
+            transactionDetails()
+        );
+
+        // then
+        Assertions.assertNotNull(last);
+        Assertions.assertEquals("1200", last.getValue());
+        Assertions.assertEquals(t4, last.getValueTimestamp());
+    }
+
+    @Test
+    public void findLast_usesLatestReadingFromNewStreakAfterMonotonicityBreak() {
+        // given
+        DateTime t1 = START_TIMESTAMP.plusMinutes(1);
+        DateTime t2 = START_TIMESTAMP.plusMinutes(2);
+        DateTime t3 = START_TIMESTAMP.plusMinutes(3);
+        DateTime t4 = START_TIMESTAMP.plusMinutes(4);
+
+        // when
+        var last = TransactionService.findLastMeterValue(
+            List.of(
+                meterValue("1100", t1),
+                meterValue("1200", t2),
+                meterValue("900", t3),
+                meterValue("1300", t4)
+            ),
+            transactionDetails()
+        );
+
+        // then
+        Assertions.assertNotNull(last);
+        Assertions.assertEquals("1300", last.getValue());
+        Assertions.assertEquals(t4, last.getValueTimestamp());
+    }
+
+    @Test
+    public void findLast_comparesKWhAndWhValuesWithinSameStreak() {
+        // given
+        DateTime t1 = START_TIMESTAMP.plusMinutes(1);
+        DateTime t2 = START_TIMESTAMP.plusMinutes(2);
+        DateTime t3 = START_TIMESTAMP.plusMinutes(3);
+
+        // when
+        var last = TransactionService.findLastMeterValue(
+            List.of(
+                meterValue("1.1", UnitOfMeasure.K_WH.value(), t1),
+                meterValue("1200", UnitOfMeasure.WH.value(), t2),
+                meterValue("1.15", UnitOfMeasure.K_WH.value(), t3)
+            ),
+            transactionDetails()
+        );
+
+        // then
+        Assertions.assertNotNull(last);
+        Assertions.assertEquals("1200", last.getValue());
+        Assertions.assertEquals(t2, last.getValueTimestamp());
+    }
+
+    private static Transaction transactionDetails() {
+        return Transaction.builder()
+            .id(TRANSACTION_PK)
+            .chargeBoxId("charge-box")
+            .startValue(START_VALUE)
+            .startTimestamp(START_TIMESTAMP)
+            .build();
+    }
+
+    private static TransactionDetails.MeterValues meterValue(String value, DateTime timestamp) {
+        return meterValue(value, UnitOfMeasure.WH.value(), timestamp);
+    }
+
+    private static TransactionDetails.MeterValues meterValue(String value, String unit, DateTime timestamp) {
+        return TransactionDetails.MeterValues.builder()
+            .value(value)
+            .valueTimestamp(timestamp)
+            .unit(unit)
+            .build();
+    }
+}


### PR DESCRIPTION
select the last energy meter value from a monotonic non-decreasing streak within the transaction instead of blindly taking the latest value.