### PR TITLE
Fix elapsed connection duration formatting

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/utils/DateTimeUtils.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/DateTimeUtils.java
@@ -22,11 +22,8 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.joda.time.Period;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.PeriodFormatter;
-import org.joda.time.format.PeriodFormatterBuilder;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -40,14 +37,6 @@ public final class DateTimeUtils {
 
     private static final DateTimeFormatter HUMAN_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd 'at' HH:mm");
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormat.forPattern("HH:mm");
-
-    private static final PeriodFormatter PERIOD_FORMATTER = new PeriodFormatterBuilder()
-            .printZeroNever()
-            .appendDays().appendSuffix(" day", " days").appendSeparator(" ")
-            .appendHours().appendSuffix(" hour", " hours").appendSeparator(" ")
-            .appendMinutes().appendSuffix(" minute", " minutes").appendSeparator(" ")
-            .appendSeconds().appendSuffix(" second", " seconds")
-            .toFormatter();
 
     /**
      * Print the date/time nicer, if it's from today, yesterday or tomorrow.
@@ -80,7 +69,24 @@ public final class DateTimeUtils {
     }
 
     public static String timeElapsed(DateTime from, DateTime to) {
-        return PERIOD_FORMATTER.print(new Period(from, to));
+        if (from == null || to == null) {
+            return "";
+        }
+
+        long totalSeconds = Math.max(0, TimeUnit.MILLISECONDS.toSeconds(to.getMillis() - from.getMillis()));
+        long days = TimeUnit.SECONDS.toDays(totalSeconds);
+        long hours = TimeUnit.SECONDS.toHours(totalSeconds) % 24;
+        long minutes = TimeUnit.SECONDS.toMinutes(totalSeconds) % 60;
+        long seconds = totalSeconds % 60;
+
+        StringBuilder sb = new StringBuilder();
+
+        appendTimePart(sb, days, "day");
+        appendTimePart(sb, hours, "hour");
+        appendTimePart(sb, minutes, "minute");
+        appendTimePart(sb, seconds, "second");
+
+        return sb.isEmpty() ? "0 seconds" : sb.toString();
     }
 
     public static long getOffsetFromUtcInSeconds() {
@@ -101,5 +107,23 @@ public final class DateTimeUtils {
 
     public static OffsetDateTime toOffsetDateTime(DateTime dt, ZoneId zoneId) {
         return OffsetDateTime.ofInstant(dt.toDate().toInstant(), zoneId);
+    }
+
+    private static void appendTimePart(StringBuilder sb, long value, String unit) {
+        if (value == 0) {
+            return;
+        }
+
+        if (!sb.isEmpty()) {
+            sb.append(' ');
+        }
+
+        sb.append(value)
+            .append(' ')
+            .append(unit);
+
+        if (value != 1) {
+            sb.append('s');
+        }
     }
 }

--- a/src/test/java/de/rwth/idsg/steve/utils/DateTimeUtilsTest.java
+++ b/src/test/java/de/rwth/idsg/steve/utils/DateTimeUtilsTest.java
@@ -29,6 +29,36 @@ import java.time.ZoneOffset;
 public class DateTimeUtilsTest {
 
     @Test
+    public void testTimeElapsed_convertsWeeksToDays() {
+        DateTime from = DateTime.parse("2026-06-23T07:23:00.000+02:00");
+        DateTime to = DateTime.parse("2026-06-30T15:24:03.000+02:00");
+
+        String result = DateTimeUtils.timeElapsed(from, to);
+
+        Assertions.assertEquals("7 days 8 hours 1 minute 3 seconds", result);
+    }
+
+    @Test
+    public void testTimeElapsed_convertsWeeksAndDaysToDays() {
+        DateTime from = DateTime.parse("2026-06-01T00:00:00.000Z");
+        DateTime to = DateTime.parse("2026-06-13T02:03:04.000Z");
+
+        String result = DateTimeUtils.timeElapsed(from, to);
+
+        Assertions.assertEquals("12 days 2 hours 3 minutes 4 seconds", result);
+    }
+
+    @Test
+    public void testTimeElapsed_convertsMonthsToDays() {
+        DateTime from = DateTime.parse("2026-01-01T00:00:00.000Z");
+        DateTime to = DateTime.parse("2026-02-01T04:00:00.000Z");
+
+        String result = DateTimeUtils.timeElapsed(from, to);
+
+        Assertions.assertEquals("31 days 4 hours", result);
+    }
+
+    @Test
     public void testToDateTime_nullInput() {
         DateTime result = DateTimeUtils.toDateTime(null);
         Assertions.assertNull(result);


### PR DESCRIPTION
The formatter only printed days, hours, minutes, and seconds. This caused values like 1 week plus 8 hours to display as only "8 hours". Format elapsed WebSocket connection time from total seconds. Convert all larger time units into days so the most general displayed unit is always days, e.g. 1 week becomes 7 days and 1 week plus 5 days becomes 12 days. Add regression coverage for week, week-plus-days, and month-length durations.