### PR TITLE
Add disconnect action for OCPP JSON sessions

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStore.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStore.java
@@ -46,6 +46,8 @@ public interface SessionContextStore {
 
     Boolean registerIncomingCallId(String chargeBoxId, WebSocketSession session, @NotNull String messageId);
 
+    boolean closeSession(String chargeBoxId, String sessionId);
+
     void closeSessions(String chargeBoxId);
 
     int getSize(String chargeBoxId);

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreImpl.java
@@ -177,7 +177,7 @@ public class SessionContextStoreImpl implements SessionContextStore {
                 WebSocketSession session = sessionContext.getSession();
                 if (session.getId().equals(sessionId)) {
                     try {
-                        log.info("Closing session '{}' for chargeBoxId '{}'", chargeBoxId, sessionId);
+                        log.info("Closing session '{}' for chargeBoxId '{}'", sessionId, chargeBoxId);
                         session.close();
                         return true;
                     } catch (IOException e) {

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreImpl.java
@@ -163,6 +163,38 @@ public class SessionContextStoreImpl implements SessionContextStore {
     }
 
     @Override
+    public boolean closeSession(String chargeBoxId, String sessionId) {
+        Lock l = locks.get(chargeBoxId);
+        l.lock();
+        try {
+            Deque<SessionContext> endpointDeque = lookupTable.get(chargeBoxId);
+            if (endpointDeque == null) {
+                log.warn("Could not find chargeBoxId '{}' while closing session '{}'", chargeBoxId, sessionId);
+                return false;
+            }
+
+            for (SessionContext sessionContext : endpointDeque) {
+                WebSocketSession session = sessionContext.getSession();
+                if (session.getId().equals(sessionId)) {
+                    try {
+                        log.info("Closing session '{}' for chargeBoxId '{}'", chargeBoxId, sessionId);
+                        session.close();
+                        return true;
+                    } catch (IOException e) {
+                        log.error("Error while closing session '{}' for chargeBoxId '{}'", sessionId, chargeBoxId, e);
+                        return false;
+                    }
+                }
+            }
+
+            log.warn("Could not find session '{}' for chargeBoxId '{}'", sessionId, chargeBoxId);
+            return false;
+        } finally {
+            l.unlock();
+        }
+    }
+
+    @Override
     public void closeSessions(String chargeBoxId) {
         Lock l = locks.get(chargeBoxId);
         l.lock();

--- a/src/main/java/de/rwth/idsg/steve/service/ChargePointService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/ChargePointService.java
@@ -363,6 +363,10 @@ public class ChargePointService {
         return returnList;
     }
 
+    public boolean closeOcppJsonSession(OcppVersion version, String chargeBoxId, String sessionId) {
+        return sessionContextStoreHolder.getOrCreate(version).closeSession(chargeBoxId, sessionId);
+    }
+
     public List<ChargePointSelect> getChargePoints(OcppVersion version) {
         return getChargePoints(version, Collections.singletonList(RegistrationStatus.ACCEPTED), Collections.emptyList());
     }
@@ -425,6 +429,7 @@ public class ChargePointService {
 
             for (var ctx : sessionContexts) {
                 DateTime openSince = ctx.getOpenSince();
+                String sessionId = ctx.getSession().getId();
 
                 Integer chargeBoxPk = primaryKeyLookup.get(chargeBoxId);
                 if (chargeBoxPk == null) {
@@ -432,6 +437,7 @@ public class ChargePointService {
                 }
 
                 OcppJsonStatus status = OcppJsonStatus.builder()
+                    .sessionId(sessionId)
                     .chargeBoxPk(chargeBoxPk)
                     .chargeBoxId(chargeBoxId)
                     .connectedSinceDT(openSince)

--- a/src/main/java/de/rwth/idsg/steve/web/controller/HomeController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/controller/HomeController.java
@@ -18,6 +18,7 @@
  */
 package de.rwth.idsg.steve.web.controller;
 
+import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.repository.dto.ConnectorStatus;
 import de.rwth.idsg.steve.service.ChargePointService;
 import de.rwth.idsg.steve.utils.ConnectorStatusCountFilter;
@@ -26,9 +27,11 @@ import de.rwth.idsg.steve.web.dto.ConnectorStatusForm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -39,7 +42,7 @@ import java.util.List;
  */
 @Controller
 @RequiredArgsConstructor
-@RequestMapping(value = "/manager", method = RequestMethod.GET)
+@RequestMapping("/manager")
 public class HomeController {
 
     private final ChargePointService chargePointService;
@@ -53,24 +56,25 @@ public class HomeController {
     private static final String HOME_PREFIX = "/home";
 
     private static final String OCPP_JSON_STATUS = HOME_PREFIX + "/ocppJsonStatus";
+    private static final String OCPP_JSON_STATUS_DISCONNECT = OCPP_JSON_STATUS + "/disconnect";
     private static final String CONNECTOR_STATUS_PATH = HOME_PREFIX + "/connectorStatus";
     private static final String CONNECTOR_STATUS_QUERY_PATH = HOME_PREFIX + "/connectorStatus/query";
     // -------------------------------------------------------------------------
     // HTTP methods
     // -------------------------------------------------------------------------
 
-    @RequestMapping(value = {"", HOME_PREFIX})
+    @GetMapping(value = {"", HOME_PREFIX})
     public String getHome(Model model) {
         model.addAttribute("stats", chargePointService.getStats());
         return "home";
     }
 
-    @RequestMapping(value = CONNECTOR_STATUS_PATH)
+    @GetMapping(value = CONNECTOR_STATUS_PATH)
     public String getConnectorStatus(Model model) {
         return getConnectorStatusQuery(new ConnectorStatusForm(), model);
     }
 
-    @RequestMapping(value = CONNECTOR_STATUS_QUERY_PATH)
+    @GetMapping(value = CONNECTOR_STATUS_QUERY_PATH)
     public String getConnectorStatusQuery(@ModelAttribute(PARAMS) ConnectorStatusForm params, Model model) {
         model.addAttribute("cpList", chargePointService.getChargeBoxIds());
         model.addAttribute("statusValues", ConnectorStatusCountFilter.ALL_STATUS_VALUES);
@@ -82,9 +86,17 @@ public class HomeController {
         return "connectorStatus";
     }
 
-    @RequestMapping(value = OCPP_JSON_STATUS)
+    @GetMapping(value = OCPP_JSON_STATUS)
     public String getOcppJsonStatus(Model model) {
         model.addAttribute("ocppJsonStatusList", chargePointService.getOcppJsonStatus());
         return "ocppJsonStatus";
+    }
+
+    @PostMapping(value = OCPP_JSON_STATUS_DISCONNECT)
+    public String disconnectOcppJsonSession(@RequestParam OcppVersion version,
+                                            @RequestParam String chargeBoxId,
+                                            @RequestParam String sessionId) {
+        chargePointService.closeOcppJsonSession(version, chargeBoxId, sessionId);
+        return "redirect:/manager" + OCPP_JSON_STATUS;
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/web/dto/OcppJsonStatus.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/OcppJsonStatus.java
@@ -32,9 +32,12 @@ import org.joda.time.DateTime;
 @Builder
 @ToString
 public final class OcppJsonStatus {
+    private final String sessionId;
     private final Integer chargeBoxPk;
-    private final String chargeBoxId, connectedSince;
-    private final String connectionDuration;
+    private final String chargeBoxId;
     private final OcppVersion version;
+
     private final DateTime connectedSinceDT;
+    private final String connectedSince;
+    private final String connectionDuration;
 }

--- a/src/main/webapp/WEB-INF/views/ocppJsonStatus.jsp
+++ b/src/main/webapp/WEB-INF/views/ocppJsonStatus.jsp
@@ -60,9 +60,9 @@ Connection Status for JSON Charge Points
                 <td data-sort-value="${s.connectedSinceDT.millis}">${s.connectionDuration}</td>
                 <td>
                     <form:form action="${ctxPath}/manager/home/ocppJsonStatus/disconnect" method="post">
-                        <input type="hidden" name="version" value="${s.version}"/>
-                        <input type="hidden" name="chargeBoxId" value="${s.chargeBoxId}"/>
-                        <input type="hidden" name="sessionId" value="${s.sessionId}"/>
+                        <input type="hidden" name="version" value="<encode:forHtmlAttribute value='${s.version}' />"/>
+                        <input type="hidden" name="chargeBoxId" value="<encode:forHtmlAttribute value='${s.chargeBoxId}' />"/>
+                        <input type="hidden" name="sessionId" value="<encode:forHtmlAttribute value='${s.sessionId}' />"/>
                         <input type="submit" class="redSubmit" value="Disconnect" title="Close this connection/session"/>
                     </form:form>
                 </td>

--- a/src/main/webapp/WEB-INF/views/ocppJsonStatus.jsp
+++ b/src/main/webapp/WEB-INF/views/ocppJsonStatus.jsp
@@ -32,13 +32,14 @@ Connection Status for JSON Charge Points
                 This indicates that charge point has opened more than one actual connection.</span>
         </a>
 </span></section>
-    <table class="res">
+    <table class="res action">
         <thead>
             <tr>
                 <th data-sort="string">ChargeBox ID</th>
                 <th data-sort="string">OCPP Version</th>
                 <th data-sort="date">Connected Since</th>
-                <th data-sort="string">Connection Duration</th>
+                <th data-sort="date">Connection Duration</th>
+                <th></th>
             </tr>
         </thead>
         <tbody>
@@ -56,7 +57,15 @@ Connection Status for JSON Charge Points
                 </td>
                 <td>${s.version.value}</td>
                 <td data-sort-value="${s.connectedSinceDT.millis}">${s.connectedSince}</td>
-                <td>${s.connectionDuration}</td>
+                <td data-sort-value="${s.connectedSinceDT.millis}">${s.connectionDuration}</td>
+                <td>
+                    <form:form action="${ctxPath}/manager/home/ocppJsonStatus/disconnect" method="post">
+                        <input type="hidden" name="version" value="${s.version}"/>
+                        <input type="hidden" name="chargeBoxId" value="${s.chargeBoxId}"/>
+                        <input type="hidden" name="sessionId" value="${s.sessionId}"/>
+                        <input type="submit" class="redSubmit" value="Disconnect" title="Close this connection/session"/>
+                    </form:form>
+                </td>
             </tr>
         </c:forEach>
         </tbody>

--- a/src/test/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreTest.java
+++ b/src/test/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreTest.java
@@ -27,6 +27,8 @@ import org.springframework.web.socket.adapter.jetty.JettyWebSocketSession;
 
 import java.util.UUID;
 
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class SessionContextStoreTest {
@@ -102,6 +104,58 @@ public class SessionContextStoreTest {
             Assertions.assertEquals(0, sizeAfterRemove);
             Assertions.assertEquals(0, store.getSize("foo"));
         }
+    }
+
+    @Test
+    public void testCloseSession() throws Exception {
+        var store = new SessionContextStoreImpl(
+            WsSessionSelectStrategyEnum.ALWAYS_LAST,
+            new NoOpTaskScheduler(),
+            new FutureResponseContextStoreImpl()
+        );
+
+        var session1 = getMockSession();
+        var session2 = getMockSession();
+
+        store.add("foo", session1);
+        store.add("foo", session2);
+
+        boolean closed = store.closeSession("foo", session1.getId());
+
+        Assertions.assertTrue(closed);
+        verify(session1).close();
+        verify(session2, never()).close();
+    }
+
+    @Test
+    public void testCloseSession_doesNotScanOtherChargeBoxIds() throws Exception {
+        var store = new SessionContextStoreImpl(
+            WsSessionSelectStrategyEnum.ALWAYS_LAST,
+            new NoOpTaskScheduler(),
+            new FutureResponseContextStoreImpl()
+        );
+
+        var session = getMockSession();
+
+        store.add("foo", session);
+
+        boolean closed = store.closeSession("bar", session.getId());
+
+        Assertions.assertFalse(closed);
+        verify(session, never()).close();
+    }
+
+    @Test
+    public void testCloseSession_unknownSession() {
+        var store = new SessionContextStoreImpl(
+            WsSessionSelectStrategyEnum.ALWAYS_LAST,
+            new NoOpTaskScheduler(),
+            new FutureResponseContextStoreImpl()
+        );
+
+        boolean closed = store.closeSession("foo", "unknown-session");
+
+        Assertions.assertFalse(closed);
     }
 
     private static JettyWebSocketSession getMockSession() {


### PR DESCRIPTION
Expose a per-row disconnect action on the OCPP JSON status page. Each row now carries the session id for its underlying WebSocket connection and posts the OCPP version, chargeBoxId, and sessionId to a disconnect endpoint.

<img width="1012" height="176" alt="Screenshot 2026-06-30 at 21 14 55" src="https://github.com/user-attachments/assets/59245651-8f25-438c-8cb3-56de76cd8255" />
