### PR TITLE
Improve CertificateSigningServiceLocal

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/config/SteveProperties.java
+++ b/src/main/java/de/rwth/idsg/steve/config/SteveProperties.java
@@ -111,6 +111,7 @@ public class SteveProperties {
                     public static class IssuerConfig {
                         private String caCertificatePem;
                         private String caKeyPem;
+                        private String caKeyPassword;
 
                         /**
                          * Optional PEM bundle for issuer chain in order:

--- a/src/main/java/de/rwth/idsg/steve/service/CertificateSigningServiceLocal.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CertificateSigningServiceLocal.java
@@ -66,6 +66,7 @@ import java.util.List;
 
 import static de.rwth.idsg.steve.utils.CertificateUtils.certificatesToPEM;
 import static de.rwth.idsg.steve.utils.CertificateUtils.isSameKeyFamily;
+import static de.rwth.idsg.steve.utils.CertificateUtils.parsePrivateKeyViaBouncyCastle;
 import static de.rwth.idsg.steve.utils.CertificateUtils.resolveSignatureAlgorithm;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static jooq.steve.db.enums.CertificateSignatureAlgorithm.ECDSA;
@@ -283,7 +284,7 @@ public class CertificateSigningServiceLocal implements CertificateSigningService
         }
 
         var caCertificate = resolveResource(resourceLoader, issuerConfig.getCaCertificatePem(), CertificateUtils::parseCertificate);
-        var caPrivateKey = resolveResource(resourceLoader, issuerConfig.getCaKeyPem(), CertificateUtils::parsePrivateKeyViaBouncyCastle);
+        var caPrivateKey = resolveResource(resourceLoader, issuerConfig.getCaKeyPem(), pem -> parsePrivateKeyViaBouncyCastle(pem, issuerConfig.getCaKeyPassword()));
         var issuerCertificateChain = loadIssuerCertificateChain(resourceLoader, caCertificate, issuerConfig.getCaChainPem());
         var certificateSignatureAlgorithm = resolveSignatureAlgorithm(caPrivateKey);
 
@@ -337,17 +338,23 @@ public class CertificateSigningServiceLocal implements CertificateSigningService
     }
 
     private List<X509Certificate> loadIssuerCertificateChain(ResourceLoader resourceLoader,
-                                                            X509Certificate caCertificate,
-                                                            String caChainPem) throws Exception {
+                                                             X509Certificate caCertificate,
+                                                             String caChainPem) throws Exception {
         return StringUtils.isBlank(caChainPem)
             ? List.of(caCertificate)
             : resolveResource(resourceLoader, caChainPem, CertificateUtils::parseCertificates);
     }
 
     private static <T> T resolveResource(ResourceLoader resourceLoader, String location, ThrowingFunction<String, T> converter) throws Exception {
-        var resource = ResourceUtils.isUrl(location)
-            ? resourceLoader.getResource(location)
-            : resourceLoader.getResource("file:" + location);
+        var resource = resourceLoader.getResource(location);
+
+        if (!resource.exists() && !ResourceUtils.isUrl(location)) {
+            resource = resourceLoader.getResource("classpath:" + location);
+        }
+
+        if (!resource.exists() && !ResourceUtils.isUrl(location)) {
+            resource = resourceLoader.getResource("file:" + location);
+        }
 
         if (!resource.exists()) {
             throw new IllegalArgumentException("Signing certificate PEM resource does not exist: " + location);

--- a/src/main/java/de/rwth/idsg/steve/utils/CertificateUtils.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/CertificateUtils.java
@@ -30,11 +30,15 @@ import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.Certificate;
 import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMEncryptedKeyPair;
 import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8DecryptorProviderBuilder;
+import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
 
 import java.io.ByteArrayInputStream;
 import java.io.StringReader;
@@ -118,6 +122,12 @@ public class CertificateUtils {
     }
 
     public static PrivateKey parsePrivateKeyViaBouncyCastle(String privateKeyPem) throws Exception {
+        return parsePrivateKeyViaBouncyCastle(privateKeyPem, null);
+    }
+
+    public static PrivateKey parsePrivateKeyViaBouncyCastle(String privateKeyPem, String password) throws Exception {
+        char[] passwordAsChar = (password == null) ? null : password.toCharArray();
+
         try (var reader = new StringReader(privateKeyPem);
              var pemParser = new PEMParser(reader)) {
             var parsedObj = pemParser.readObject();
@@ -133,8 +143,22 @@ public class CertificateUtils {
             if (parsedObj instanceof PEMKeyPair keyPair) {
                 return converter.getKeyPair(keyPair).getPrivate();
             }
+            if (parsedObj instanceof PKCS8EncryptedPrivateKeyInfo pkcs8) {
+                var decryptor = new JceOpenSSLPKCS8DecryptorProviderBuilder()
+                    .setProvider(PROVIDER_NAME)
+                    .build(passwordAsChar);
 
-            throw new IllegalArgumentException("Unsupported private key PEM format");
+                return converter.getPrivateKey(pkcs8.decryptPrivateKeyInfo(decryptor));
+            }
+            if (parsedObj instanceof PEMEncryptedKeyPair encryptedKeyPair) {
+                var decryptor = new JcePEMDecryptorProviderBuilder()
+                    .setProvider(PROVIDER_NAME)
+                    .build(passwordAsChar);
+
+                return converter.getKeyPair(encryptedKeyPair.decryptKeyPair(decryptor)).getPrivate();
+            }
+
+            throw new IllegalArgumentException("Unsupported private key PEM format: " + parsedObj.getClass().getName());
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,8 +74,10 @@ steve:
           rsa:
             ca-certificate-pem:
             ca-key-pem:
+            ca-key-password:
             ca-chain-pem:
           ecdsa:
             ca-certificate-pem:
             ca-key-pem:
+            ca-key-password:
             ca-chain-pem:


### PR DESCRIPTION
- add support for private keys with password
- do not force `file` prefix on unprefixed files. we usually try to load them from `classpath`. try in that order.