### PR TITLE
Powerfill donates OCTT workarounds

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/config/SteveProperties.java
+++ b/src/main/java/de/rwth/idsg/steve/config/SteveProperties.java
@@ -68,6 +68,7 @@ public class SteveProperties {
         boolean autoRegisterUnknownStations;
         String chargeBoxIdValidationRegex;
         Protocols enabledProtocols;
+        boolean octtQuirksEnabled;
         Security security = new Security();
 
         @Data

--- a/src/main/java/de/rwth/idsg/steve/service/CertificateSigningServiceLocal.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CertificateSigningServiceLocal.java
@@ -85,6 +85,7 @@ public class CertificateSigningServiceLocal implements CertificateSigningService
     private final ChargePointService chargePointService;
     private final ChargePointServiceClient chargePointServiceClient;
     private final CertificateValidator certificateValidator;
+    private final boolean octtQuirksEnabled;
 
     private final EnumMap<CertificateSignatureAlgorithm, CertificateIssuerMaterial> issuers = new EnumMap<>(CertificateSignatureAlgorithm.class);
     private final int certificateValidityYears;
@@ -101,6 +102,7 @@ public class CertificateSigningServiceLocal implements CertificateSigningService
         this.chargePointService = chargePointService;
         this.chargePointServiceClient = chargePointServiceClient;
         this.certificateValidator = certificateValidator;
+        this.octtQuirksEnabled = steveProperties.getOcpp().isOcttQuirksEnabled();
 
         var csrSigningProps = steveProperties.getOcpp().getSecurity().getCsrSigning().getProviderLocal();
         if (!csrSigningProps.isValid()) {
@@ -286,7 +288,7 @@ public class CertificateSigningServiceLocal implements CertificateSigningService
         var caCertificate = resolveResource(resourceLoader, issuerConfig.getCaCertificatePem(), CertificateUtils::parseCertificate);
         var caPrivateKey = resolveResource(resourceLoader, issuerConfig.getCaKeyPem(), pem -> parsePrivateKeyViaBouncyCastle(pem, issuerConfig.getCaKeyPassword()));
         var issuerCertificateChain = loadIssuerCertificateChain(resourceLoader, caCertificate, issuerConfig.getCaChainPem());
-        var certificateSignatureAlgorithm = resolveSignatureAlgorithm(caPrivateKey);
+        var certificateSignatureAlgorithm = resolveSignatureAlgorithm(caPrivateKey, octtQuirksEnabled);
 
         var issuer = new CertificateIssuerMaterial(
             name,
@@ -297,7 +299,7 @@ public class CertificateSigningServiceLocal implements CertificateSigningService
         );
 
         issuer.validateFamily();
-        issuer.validateCaCertificate();
+        issuer.validateCaCertificate(octtQuirksEnabled);
         issuer.validateCertificateChain();
 
         issuers.put(name, issuer);

--- a/src/main/java/de/rwth/idsg/steve/service/CertificateValidator.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CertificateValidator.java
@@ -53,9 +53,11 @@ import java.security.cert.X509Certificate;
 public class CertificateValidator {
 
     private final String clientCertHeaderFromProxy;
+    private final boolean octtQuirksEnabled;
 
     public CertificateValidator(SteveProperties steveProperties) {
         clientCertHeaderFromProxy = steveProperties.getOcpp().getSecurity().getClientCertHeaderFromProxy();
+        octtQuirksEnabled = steveProperties.getOcpp().isOcttQuirksEnabled();
     }
 
     /**
@@ -126,6 +128,14 @@ public class CertificateValidator {
     }
 
     public void verifyOcppFields(ChargePointRegistration chargePointRegistration, X500Name subject) {
+        if (octtQuirksEnabled) {
+            // there was no way to get the CpoName from station-emulating OCTT.
+            // it does not send the key in the GetConfiguration. so, when the time came to compare
+            // the values in CSR with something we know in advance... we don't know the reference info.
+            // therefore, we are deciding to disable validating O (organizationName) and CN (commonName) of certs.
+            return;
+        }
+
         String chargeBoxId = chargePointRegistration.chargeBoxId();
 
         // A00.FR.404 :

--- a/src/main/java/de/rwth/idsg/steve/service/ChargePointConfigUpdater.java
+++ b/src/main/java/de/rwth/idsg/steve/service/ChargePointConfigUpdater.java
@@ -19,6 +19,7 @@
 package de.rwth.idsg.steve.service;
 
 import de.rwth.idsg.steve.SteveException;
+import de.rwth.idsg.steve.config.SteveProperties;
 import de.rwth.idsg.steve.ocpp.OcppTransport;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.repository.dto.ChargePointSelect;
@@ -49,6 +50,7 @@ import static de.rwth.idsg.steve.web.dto.ocpp.ConfigurationKeyEnum.SecurityProfi
 @RequiredArgsConstructor
 public class ChargePointConfigUpdater {
 
+    private final SteveProperties steveProperties;
     private final ChargePointService chargePointService;
 
     // use this when we need to wait for the response to process it
@@ -58,6 +60,12 @@ public class ChargePointConfigUpdater {
 
     @EventListener
     public void getAllOcppConfigs(OcppStationWebSocketConnected notification) {
+        if (steveProperties.getOcpp().isOcttQuirksEnabled()) {
+            // disable sending this after a successful WS connection, even though it is not illegal
+            // according to OCPP. it throws OCTT off, because it does not expect it.
+            return;
+        }
+
         try {
             // GetConfiguration was not there in Ocpp 1.2
             if (notification.getOcppVersion() == OcppVersion.V_12) {

--- a/src/main/java/de/rwth/idsg/steve/service/ChargePointServiceClient.java
+++ b/src/main/java/de/rwth/idsg/steve/service/ChargePointServiceClient.java
@@ -19,6 +19,7 @@
 package de.rwth.idsg.steve.service;
 
 import de.rwth.idsg.steve.SteveException;
+import de.rwth.idsg.steve.config.SteveProperties;
 import de.rwth.idsg.steve.ocpp.ChargePointServiceInvokerImpl;
 import de.rwth.idsg.steve.ocpp.CommunicationTask;
 import de.rwth.idsg.steve.ocpp.OcppCallback;
@@ -142,6 +143,7 @@ public class ChargePointServiceClient {
     private final CertificateRepository certificateRepository;
     private final EventRepository eventRepository;
 
+    private final SteveProperties steveProperties;
     private final TaskExecutor taskExecutor;
     private final TaskStore taskStore;
     private final ChargePointServiceInvokerImpl invoker;
@@ -218,7 +220,10 @@ public class ChargePointServiceClient {
 
         // after successfully changing config at station, get all configs from station
         // for us to have the final snapshots of them (i.e. to update database).
-        {
+        //
+        // however, do this only when NOT working with OCTT, because this message throws OCTT off.
+        if (!steveProperties.getOcpp().isOcttQuirksEnabled()) {
+
             // GetConfiguration was not there in Ocpp 1.2
             var ocpp15AndAboveStations = params.getChargePointSelectList()
                 .stream()

--- a/src/main/java/de/rwth/idsg/steve/utils/CertificateIssuerMaterial.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/CertificateIssuerMaterial.java
@@ -59,7 +59,7 @@ public record CertificateIssuerMaterial(
         }
     }
 
-    public void validateCaCertificate() throws Exception {
+    public void validateCaCertificate(boolean octtQuirksEnabled) throws Exception {
         if (caCertificate.getBasicConstraints() < 0) {
             throw new IllegalArgumentException("Configured CA certificate for issuer '" + name + "' is not a CA certificate (basicConstraints CA=true required)");
         }
@@ -69,7 +69,7 @@ public record CertificateIssuerMaterial(
             throw new IllegalArgumentException("Configured CA certificate for issuer '" + name + "' must allow keyCertSign in keyUsage");
         }
 
-        String checkAlgorithm = resolveSignatureAlgorithm(caPrivateKey);
+        String checkAlgorithm = resolveSignatureAlgorithm(caPrivateKey, octtQuirksEnabled);
         byte[] dummyProbeData = "certificate-key-pair-check".getBytes(StandardCharsets.UTF_8);
 
         Signature signer = Signature.getInstance(checkAlgorithm, PROVIDER_NAME);

--- a/src/main/java/de/rwth/idsg/steve/utils/CertificateUtils.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/CertificateUtils.java
@@ -272,7 +272,11 @@ public class CertificateUtils {
         String normalized = pem;
         // Nginx/proxy headers can be URL-encoded; PEM files typically are not.
         if (pem.contains("%")) {
-            normalized = percentDecode(pem);
+            try {
+                normalized = percentDecode(pem);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Could not parse PEM", e);
+            }
         }
 
         return normalized

--- a/src/main/java/de/rwth/idsg/steve/utils/CertificateUtils.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/CertificateUtils.java
@@ -161,10 +161,14 @@ public class CertificateUtils {
         }
     }
 
-    public static String resolveSignatureAlgorithm(PrivateKey privateKey) {
+    public static String resolveSignatureAlgorithm(PrivateKey privateKey, boolean octtQuirksEnabled) {
         String keyAlgorithm = privateKey.getAlgorithm();
         if ("RSA".equalsIgnoreCase(keyAlgorithm)) {
-            return "SHA256withRSAandMGF1";
+            // The spec (OCPP 1.6 security whitepaper edition 3) prescribes to use "RSA-PSS" for the RSA world.
+            // This corresponds to SHA256withRSAandMGF1 in Bouncy Castle.
+            // However, this was incompatible with OCTT.
+            // Therefore, we downgrade to the legacy SHA256withRSA. Sad but true.
+            return octtQuirksEnabled ? "SHA256withRSA" : "SHA256withRSAandMGF1";
         }
         if ("EC".equalsIgnoreCase(keyAlgorithm) || "ECDSA".equalsIgnoreCase(keyAlgorithm)) {
             return "SHA256withECDSA";

--- a/src/main/java/de/rwth/idsg/steve/utils/CertificateUtils.java
+++ b/src/main/java/de/rwth/idsg/steve/utils/CertificateUtils.java
@@ -22,7 +22,6 @@ import jooq.steve.db.enums.CertificateSignatureAlgorithm;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -41,9 +40,9 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -263,14 +262,44 @@ public class CertificateUtils {
         }
     }
 
-    private static String normalizePemInput(String pem) {
+    public static String normalizePemInput(String pem) {
         if (pem == null) return null;
 
         String normalized = pem;
         // Nginx/proxy headers can be URL-encoded; PEM files typically are not.
         if (pem.contains("%")) {
-            normalized = URLDecoder.decode(pem, StandardCharsets.UTF_8);
+            normalized = percentDecode(pem);
         }
-        return normalized.replace("\t", "\n");
+
+        return normalized
+            .replace("\t", "\n")
+            .replace("\r\n", "\n")
+            .replace('\r', '\n');
+    }
+
+    private static String percentDecode(String input) {
+        var decoded = new StringBuilder(input.length());
+        var bytes = new ByteArrayOutputStream();
+
+        for (int i = 0; i < input.length(); i++) {
+            char ch = input.charAt(i);
+            if (ch != '%') {
+                decoded.append(ch);
+                continue;
+            }
+
+            bytes.reset();
+            while (i < input.length() && input.charAt(i) == '%') {
+                if (i + 2 >= input.length()) {
+                    throw new IllegalArgumentException("Incomplete percent-encoded sequence in PEM input");
+                }
+                bytes.write(Integer.parseInt(input.substring(i + 1, i + 3), 16));
+                i += 3;
+            }
+            i--;
+            decoded.append(bytes.toString(StandardCharsets.UTF_8));
+        }
+
+        return decoded.toString();
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/CertificateSignedParams.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/CertificateSignedParams.java
@@ -18,6 +18,7 @@
  */
 package de.rwth.idsg.steve.web.dto.ocpp;
 
+import de.rwth.idsg.steve.utils.CertificateUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -37,4 +38,8 @@ public class CertificateSignedParams extends MultipleChargePointSelect {
     @Size(max = 10_000, message = "Certificate chain must not exceed {max} characters")
     @Schema(description = "PEM-encoded certificate chain (signed certificate + CA certificate)")
     private String certificateChain;
+
+    public void setCertificateChain(String certificateChain) {
+        this.certificateChain = CertificateUtils.normalizePemInput(certificateChain);
+    }
 }

--- a/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/InstallCertificateParams.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/InstallCertificateParams.java
@@ -18,6 +18,7 @@
  */
 package de.rwth.idsg.steve.web.dto.ocpp;
 
+import de.rwth.idsg.steve.utils.CertificateUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -40,4 +41,8 @@ public class InstallCertificateParams extends MultipleChargePointSelect {
     @Size(max = 5_500, message = "Certificate must not exceed {max} characters")
     @Schema(description = "PEM-encoded X.509 certificate")
     private String certificate;
+
+    public void setCertificate(String certificate) {
+        this.certificate = CertificateUtils.normalizePemInput(certificate);
+    }
 }

--- a/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/SignedUpdateFirmwareParams.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ocpp/SignedUpdateFirmwareParams.java
@@ -18,6 +18,7 @@
  */
 package de.rwth.idsg.steve.web.dto.ocpp;
 
+import de.rwth.idsg.steve.utils.CertificateUtils;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -45,4 +46,8 @@ public class SignedUpdateFirmwareParams extends UpdateFirmwareParams {
     @Future(message = "Install Date/Time must be in future")
     @Schema(description = "When charge point should install the downloaded firmware")
     private DateTime installDateTime;
+
+    public void setSigningCertificate(String signingCertificate) {
+        this.signingCertificate = CertificateUtils.normalizePemInput(signingCertificate);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,7 @@ steve:
     ws-session-select-strategy: ${ws.session.select.strategy}
     auto-register-unknown-stations: ${auto.register.unknown.stations}
     charge-box-id-validation-regex: ${charge-box-id.validation.regex}
+    octt-quirks-enabled: false
 
     # Which transport (SOAP and JSON-over-WebSocket) of which OCPP version (1.2, 1.5 and 1.6) should we enable?
     # This configuration affects the endpoints we expose for station communication, but also the corresponding web page

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,9 @@ steve:
     ws-session-select-strategy: ${ws.session.select.strategy}
     auto-register-unknown-stations: ${auto.register.unknown.stations}
     charge-box-id-validation-regex: ${charge-box-id.validation.regex}
+
+    # Enables compatibility workarounds for OCTT-based OCA certification testing.
+    # These workarounds alter otherwise OCPP-compliant behavior to accommodate OCTT-specific expectations.
     octt-quirks-enabled: false
 
     # Which transport (SOAP and JSON-over-WebSocket) of which OCPP version (1.2, 1.5 and 1.6) should we enable?

--- a/src/test/java/de/rwth/idsg/steve/certification/ocpp16/Ocpp16JsonCsmsCertificationIT.java
+++ b/src/test/java/de/rwth/idsg/steve/certification/ocpp16/Ocpp16JsonCsmsCertificationIT.java
@@ -150,7 +150,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Slf4j
 @ActiveProfiles(profiles = "test")
-@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(
+    properties = "steve.ocpp.octt-quirks-enabled=true",
+    webEnvironment = WebEnvironment.DEFINED_PORT
+)
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Ocpp16JsonCsmsCertificationIT extends AbstractOcpp16JsonCsms {
 
@@ -660,12 +663,10 @@ public class Ocpp16JsonCsmsCertificationIT extends AbstractOcpp16JsonCsms {
             .withValue("60");
         var changeConfigRes = new ChangeConfigurationResponse().withStatus(ConfigurationStatus.ACCEPTED);
         var changeConfigExchange = chargePoint.planRequest(changeConfigReq, changeConfigRes);
-        var getConfExchange = planGetConf(chargePoint);
 
         var operationFuture = supplyAsyncUnchecked(() -> operationsService.changeConfiguration(params));
         changeConfigExchange.await();
         assertEquals(ConfigurationStatus.ACCEPTED, successResponse(operationFuture.join()));
-        getConfExchange.await();
 
         chargePoint.close();
     }
@@ -2284,12 +2285,10 @@ public class Ocpp16JsonCsmsCertificationIT extends AbstractOcpp16JsonCsms {
             new ChangeConfigurationRequest().withKey(AuthorizationKey.name()).withValue(valueHex),
             new ChangeConfigurationResponse().withStatus(ConfigurationStatus.ACCEPTED)
         );
-        var getConfExchange = planGetConf(chargePoint);
 
         var future = supplyAsyncUnchecked(() -> operationsService.changeConfiguration(params));
         changeConfigExchange.await();
         assertEquals(ConfigurationStatus.ACCEPTED, successResponse(future.join()));
-        getConfExchange.await();
 
         var record = dslContext
             .selectFrom(CHARGE_BOX)

--- a/src/test/java/de/rwth/idsg/steve/certification/ocpp16/Ocpp16JsonCsmsCertification_TLS_IT.java
+++ b/src/test/java/de/rwth/idsg/steve/certification/ocpp16/Ocpp16JsonCsmsCertification_TLS_IT.java
@@ -88,7 +88,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @Slf4j
 @ActiveProfiles(profiles = {"test", "test-tls"})
-@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(
+    properties = "steve.ocpp.octt-quirks-enabled=true",
+    webEnvironment = WebEnvironment.DEFINED_PORT
+)
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Ocpp16JsonCsmsCertification_TLS_IT extends AbstractOcpp16JsonCsms {
 
@@ -242,12 +245,10 @@ public class Ocpp16JsonCsmsCertification_TLS_IT extends AbstractOcpp16JsonCsms {
                 new ChangeConfigurationRequest().withKey(SecurityProfile.name()).withValue("3"),
                 new ChangeConfigurationResponse().withStatus(ConfigurationStatus.ACCEPTED)
             );
-            var getConfExchange = planGetConf(chargePoint);
 
             var changeConfigFuture = supplyAsyncUnchecked(() -> operationsService.changeConfiguration(changeConfig));
             changeConfigExchange.await();
             assertEquals(ConfigurationStatus.ACCEPTED, successResponse(changeConfigFuture.join()));
-            getConfExchange.await();
 
             var chargeBox = dslContext.selectFrom(CHARGE_BOX)
                 .where(CHARGE_BOX.CHARGE_BOX_ID.eq(REGISTERED_CHARGE_BOX_ID))

--- a/src/test/java/de/rwth/idsg/steve/utils/CertificateUtilsTest.java
+++ b/src/test/java/de/rwth/idsg/steve/utils/CertificateUtilsTest.java
@@ -1,0 +1,148 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.utils;
+
+import de.rwth.idsg.steve.web.dto.ocpp.CertificateSignedParams;
+import de.rwth.idsg.steve.web.dto.ocpp.InstallCertificateParams;
+import de.rwth.idsg.steve.web.dto.ocpp.SignedUpdateFirmwareParams;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+public class CertificateUtilsTest {
+
+    private static final String NORMALIZED_CERT =
+        "-----BEGIN CERTIFICATE-----\nline-1\nline-2\n-----END CERTIFICATE-----";
+
+    @ParameterizedTest
+    @MethodSource("pemSeparators")
+    void normalizesPemSeparatorsToLf(String separator) {
+        String cert = "-----BEGIN CERTIFICATE-----"
+            + separator + "line-1"
+            + separator + "line-2"
+            + separator + "-----END CERTIFICATE-----";
+
+        String output = CertificateUtils.normalizePemInput(cert);
+
+        Assertions.assertEquals(NORMALIZED_CERT, output);
+    }
+
+    private static Stream<Arguments> pemSeparators() {
+        return Stream.of(
+            Arguments.of("\r\n"),
+            Arguments.of("\r"),
+            Arguments.of("\n"),
+            Arguments.of("\t")
+        );
+    }
+
+    @Test
+    void normalizesMixedLineEndingsToLf() {
+        String cert = "-----BEGIN CERTIFICATE-----\r\nline-1\rline-2\nline-3\t-----END CERTIFICATE-----";
+
+        String output = CertificateUtils.normalizePemInput(cert);
+
+        Assertions.assertEquals(
+            "-----BEGIN CERTIFICATE-----\nline-1\nline-2\nline-3\n-----END CERTIFICATE-----",
+            output
+        );
+    }
+
+    @Test
+    void decodesUrlEncodedPemBeforeNormalizingLineEndings() {
+        String cert = "-----BEGIN%20CERTIFICATE-----%0D%0Aline-1%0Dline-2%0A-----END%20CERTIFICATE-----";
+
+        String output = CertificateUtils.normalizePemInput(cert);
+
+        Assertions.assertEquals(NORMALIZED_CERT, output);
+    }
+
+    @Test
+    void preservesRawPlusSignsWhenPercentDecodingLineEndings() {
+        String cert = "-----BEGIN%20CERTIFICATE-----%0Aabc+def%0A-----END%20CERTIFICATE-----";
+
+        String output = CertificateUtils.normalizePemInput(cert);
+
+        Assertions.assertEquals("-----BEGIN CERTIFICATE-----\nabc+def\n-----END CERTIFICATE-----", output);
+    }
+
+    @Test
+    void decodesPercentEncodedPlusSigns() {
+        String cert = "-----BEGIN%20CERTIFICATE-----%0Aabc%2Bdef%0A-----END%20CERTIFICATE-----";
+
+        String output = CertificateUtils.normalizePemInput(cert);
+
+        Assertions.assertEquals("-----BEGIN CERTIFICATE-----\nabc+def\n-----END CERTIFICATE-----", output);
+    }
+
+    @Test
+    void doesNotRewriteLiteralEscapeSequences() {
+        String cert = "line-1\\r\\nline-2";
+
+        String output = CertificateUtils.normalizePemInput(cert);
+
+        Assertions.assertEquals("line-1\\r\\nline-2", output);
+    }
+
+    @Test
+    void returnsNullForNullInput() {
+        Assertions.assertNull(CertificateUtils.normalizePemInput(null));
+    }
+
+    @Test
+    void isIdempotentAfterNormalization() {
+        String cert = "-----BEGIN CERTIFICATE-----\r\nline-1\rline-2\t-----END CERTIFICATE-----";
+
+        String once = CertificateUtils.normalizePemInput(cert);
+        String twice = CertificateUtils.normalizePemInput(once);
+
+        Assertions.assertEquals(once, twice);
+    }
+
+    @Test
+    void installCertificateParamsNormalizeCertificate() {
+        var params = new InstallCertificateParams();
+
+        params.setCertificate("-----BEGIN CERTIFICATE-----\r\nline-1\rline-2\t-----END CERTIFICATE-----");
+
+        Assertions.assertEquals(NORMALIZED_CERT, params.getCertificate());
+    }
+
+    @Test
+    void signedUpdateFirmwareParamsNormalizeSigningCertificate() {
+        var params = new SignedUpdateFirmwareParams();
+
+        params.setSigningCertificate("-----BEGIN CERTIFICATE-----\r\nline-1\rline-2\t-----END CERTIFICATE-----");
+
+        Assertions.assertEquals(NORMALIZED_CERT, params.getSigningCertificate());
+    }
+
+    @Test
+    void certificateSignedParamsNormalizeCertificateChain() {
+        var params = new CertificateSignedParams();
+
+        params.setCertificateChain("-----BEGIN CERTIFICATE-----\r\nline-1\rline-2\t-----END CERTIFICATE-----");
+
+        Assertions.assertEquals(NORMALIZED_CERT, params.getCertificateChain());
+    }
+}


### PR DESCRIPTION
## Context

This PR contributes changes from the [OCA certification of Powerfill’s OCPP 1.6 CSMS](https://powerfill.io/blog/powerfill-oca-certified-ocpp-1-6-core-smart-charging-advanced-security).

These changes do not correct OCPP violations in SteVe. The previous behavior was standards-compliant. During certification, however, several OCTT scenarios did not accept or support that behavior. The resulting accommodations are isolated behind an explicit compatibility setting so that SteVe’s default OCPP behavior remains unchanged.

## Changes

- Add the opt-in `steve.ocpp.octt-quirks-enabled` flag.
- Normalize certificate and certificate-chain inputs to LF line endings. Since this is a general-enough normalization, it is not behind the compatibility flag.

When OCTT compatibility is enabled, SteVe additionally:

- uses `SHA256withRSA` instead of the OCPP-prescribed RSA-PSS algorithm for RSA certificate signatures;
- skips certificate subject validation because OCTT does not provide the reference information required;
- suppresses automatic `GetConfiguration` requests after a WebSocket connection and after `ChangeConfiguration`, because OCTT does not expect these otherwise valid sequences of events.

## Compatibility and standards behavior

`octt-quirks-enabled` defaults to `false`.

The compatibility mode intentionally alters or relaxes specific standards-aligned behavior solely to support OCTT-compatibility. It should not be enabled in regular production deployments.

These changes originate from the Powerfill certification effort. They do not imply that standalone SteVe builds or deployments are themselves OCA-certified.

