### PR TITLE
fix: validate tag in StopTransaction

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/repository/OcppTagRepository.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/OcppTagRepository.java
@@ -24,9 +24,9 @@ import de.rwth.idsg.steve.web.dto.OcppTagQueryForm;
 import jooq.steve.db.tables.records.OcppTagActivityRecord;
 import org.jooq.Result;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -47,7 +47,7 @@ public interface OcppTagRepository {
     List<String> getActiveIdTags();
 
     List<String> getParentIdTags();
-    Map<String, String> getParentIdTags(Set<String> idTags);
+    Map<String, String> getParentIdTags(Collection<String> idTags);
 
     void addOcppTagList(List<String> idTagList);
     int addOcppTag(OcppTagForm form);

--- a/src/main/java/de/rwth/idsg/steve/repository/OcppTagRepository.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/OcppTagRepository.java
@@ -25,6 +25,8 @@ import jooq.steve.db.tables.records.OcppTagActivityRecord;
 import org.jooq.Result;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -45,7 +47,7 @@ public interface OcppTagRepository {
     List<String> getActiveIdTags();
 
     List<String> getParentIdTags();
-    String getParentIdtag(String idTag);
+    Map<String, String> getParentIdTags(Set<String> idTags);
 
     void addOcppTagList(List<String> idTagList);
     int addOcppTag(OcppTagForm form);

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImpl.java
@@ -45,10 +45,11 @@ import org.springframework.util.CollectionUtils;
 
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static de.rwth.idsg.steve.utils.CustomDSL.includes;
@@ -223,12 +224,18 @@ public class OcppTagRepositoryImpl implements OcppTagRepository {
     }
 
     @Override
-    public Map<String, String> getParentIdTags(Set<String> idTags) {
+    public Map<String, String> getParentIdTags(Collection<String> idTags) {
+        if (CollectionUtils.isEmpty(idTags)) {
+            return Collections.emptyMap();
+        }
+
+        var notNullIdTags = idTags.stream().filter(Objects::nonNull).collect(Collectors.toSet());
+
         return ctx.select(
                 OCPP_TAG.ID_TAG,
                 OCPP_TAG.PARENT_ID_TAG)
             .from(OCPP_TAG)
-            .where(OCPP_TAG.ID_TAG.in(idTags))
+            .where(OCPP_TAG.ID_TAG.in(notNullIdTags))
             .fetchMap(OCPP_TAG.ID_TAG, OCPP_TAG.PARENT_ID_TAG);
     }
 

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImpl.java
@@ -47,6 +47,8 @@ import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static de.rwth.idsg.steve.utils.CustomDSL.includes;
@@ -221,12 +223,13 @@ public class OcppTagRepositoryImpl implements OcppTagRepository {
     }
 
     @Override
-    public String getParentIdtag(String idTag) {
-        return ctx.select(OCPP_TAG.PARENT_ID_TAG)
-                  .from(OCPP_TAG)
-                  .where(OCPP_TAG.ID_TAG.eq(idTag))
-                  .fetchOne()
-                  .value1();
+    public Map<String, String> getParentIdTags(Set<String> idTags) {
+        return ctx.select(
+                OCPP_TAG.ID_TAG,
+                OCPP_TAG.PARENT_ID_TAG)
+            .from(OCPP_TAG)
+            .where(OCPP_TAG.ID_TAG.in(idTags))
+            .fetchMap(OCPP_TAG.ID_TAG, OCPP_TAG.PARENT_ID_TAG);
     }
 
     @Override

--- a/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_Service.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_Service.java
@@ -278,7 +278,7 @@ public class CentralSystemService16_Service {
                                        .build();
 
         var transaction = ocppServerRepository.getTransaction(chargeBoxIdentity, null, transactionId);
-        var results = serviceValidator.validateStop(transaction, parameters);
+        var results = serviceValidator.validateStop(transaction, parameters, ocppTagService::haveTheSameParentIdTag);
 
         if (results.hasHardErrors()) {
             ocppServerRepository.updateTransactionAsFailed(params, results.getHardErrors());

--- a/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_Service.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_Service.java
@@ -278,7 +278,7 @@ public class CentralSystemService16_Service {
                                        .build();
 
         var transaction = ocppServerRepository.getTransaction(chargeBoxIdentity, null, transactionId);
-        var results = serviceValidator.validateStop(transaction, parameters, ocppTagService::haveTheSameParentIdTag);
+        var results = serviceValidator.validateStop(transaction, parameters, ocppTagService::areIdTagsRelatedByParent);
 
         if (results.hasHardErrors()) {
             ocppServerRepository.updateTransactionAsFailed(params, results.getHardErrors());

--- a/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_ServiceValidator.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_ServiceValidator.java
@@ -39,6 +39,8 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -106,7 +108,9 @@ public class CentralSystemService16_ServiceValidator {
         return logErrors(results);
     }
 
-    public ValidationResults validateStop(TransactionRecord thisTx, @NotNull StopTransactionRequest stopParams) {
+    public ValidationResults validateStop(TransactionRecord thisTx,
+                                          @NotNull StopTransactionRequest stopParams,
+                                          @NotNull BiFunction<String, String, Boolean> parentMatcher) {
         var results = new ValidationResults(stopParams);
 
         if (thisTx == null) {
@@ -132,6 +136,12 @@ public class CentralSystemService16_ServiceValidator {
 
         if (Integer.parseInt(thisTx.getStartValue()) > stopParams.getMeterStop()) {
             results.addHard("meterStart is greater than meterStop");
+        }
+
+        if (stopParams.isSetIdTag()
+            && !Objects.equals(thisTx.getIdTag(), stopParams.getIdTag())
+            && !parentMatcher.apply(stopParams.getIdTag(), thisTx.getIdTag())) {
+            results.addHard("stop.idTag does not match the transaction's idTag or share its parentIdTag");
         }
 
         this.validateMeterValuesInternal(stopParams.getTransactionData(), thisTx.getStartTimestamp(), stopParams.getTimestamp(), results);

--- a/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_ServiceValidator.java
+++ b/src/main/java/de/rwth/idsg/steve/service/CentralSystemService16_ServiceValidator.java
@@ -18,6 +18,7 @@
  */
 package de.rwth.idsg.steve.service;
 
+import com.google.common.base.Strings;
 import jooq.steve.db.enums.TransactionStopEventActor;
 import jooq.steve.db.tables.records.TransactionRecord;
 import lombok.RequiredArgsConstructor;
@@ -110,7 +111,7 @@ public class CentralSystemService16_ServiceValidator {
 
     public ValidationResults validateStop(TransactionRecord thisTx,
                                           @NotNull StopTransactionRequest stopParams,
-                                          @NotNull BiFunction<String, String, Boolean> parentMatcher) {
+                                          @NotNull BiFunction<String, String, Boolean> parentRelationMatcher) {
         var results = new ValidationResults(stopParams);
 
         if (thisTx == null) {
@@ -138,10 +139,10 @@ public class CentralSystemService16_ServiceValidator {
             results.addHard("meterStart is greater than meterStop");
         }
 
-        if (stopParams.isSetIdTag()
+        if (!Strings.isNullOrEmpty(stopParams.getIdTag())
             && !Objects.equals(thisTx.getIdTag(), stopParams.getIdTag())
-            && !parentMatcher.apply(stopParams.getIdTag(), thisTx.getIdTag())) {
-            results.addHard("stop.idTag does not match the transaction's idTag or share its parentIdTag");
+            && !parentRelationMatcher.apply(stopParams.getIdTag(), thisTx.getIdTag())) {
+            results.addHard("stop.idTag is neither the transaction's idTag nor related to it through parentIdTag");
         }
 
         this.validateMeterValuesInternal(stopParams.getTransactionData(), thisTx.getStartTimestamp(), stopParams.getTimestamp(), results);

--- a/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
@@ -30,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 import ocpp.cp._2015._10.AuthorizationData;
 import ocpp.cs._2015._10.AuthorizationStatus;
 import ocpp.cs._2015._10.IdTagInfo;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.joda.time.DateTime;
 import org.springframework.stereotype.Service;
@@ -89,12 +90,28 @@ public class OcppTagService {
         return map.get(idTag);
     }
 
-    public boolean haveTheSameParentIdTag(String idTag1, String idTag2) {
+    /**
+     * Checks whether two distinct idTags are related through {@code parentIdTag}. Exact idTag equality is handled by
+     * the caller before invoking this method.
+     * <pre>
+     * Relationship                           Example                          Result
+     * ------------------------------------------------------------------------------
+     * Same non-null parent                   C1.parent=P, C2.parent=P         true
+     * First tag is the second tag's parent   P.parent=null, C.parent=P        true
+     * Second tag is the first tag's parent   C.parent=P, P.parent=null        true
+     * Different parents                      C1.parent=P1, C2.parent=P2       false
+     * Both tags are parentless               P1.parent=null, P2.parent=null   false
+     * Either tag is unknown                  No database record               false
+     * </pre>
+     */
+    public boolean areIdTagsRelatedByParent(@NotNull String idTag1, @NotNull String idTag2) {
         var parents = ocppTagRepository.getParentIdTags(Set.of(idTag1, idTag2));
         var parent1 = parents.get(idTag1);
         var parent2 = parents.get(idTag2);
 
-        return parent1 != null && parent1.equals(parent2);
+        return (parent1 != null && parent1.equals(parent2))
+            || idTag1.equals(parent2)
+            || idTag2.equals(parent1);
     }
 
     public List<AuthorizationData> getAuthDataOfAllTags() {

--- a/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
+++ b/src/main/java/de/rwth/idsg/steve/service/OcppTagService.java
@@ -36,6 +36,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static de.rwth.idsg.steve.utils.OcppTagActivityRecordUtils.isBlocked;
@@ -84,7 +85,16 @@ public class OcppTagService {
     }
 
     public String getParentIdtag(String idTag) {
-        return ocppTagRepository.getParentIdtag(idTag);
+        var map = ocppTagRepository.getParentIdTags(Set.of(idTag));
+        return map.get(idTag);
+    }
+
+    public boolean haveTheSameParentIdTag(String idTag1, String idTag2) {
+        var parents = ocppTagRepository.getParentIdTags(Set.of(idTag1, idTag2));
+        var parent1 = parents.get(idTag1);
+        var parent2 = parents.get(idTag2);
+
+        return parent1 != null && parent1.equals(parent2);
     }
 
     public List<AuthorizationData> getAuthDataOfAllTags() {

--- a/src/test/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImplIT.java
+++ b/src/test/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImplIT.java
@@ -138,41 +138,52 @@ public class OcppTagRepositoryImplIT extends AbstractRepositoryITBase {
     }
 
     @Test
-    public void haveTheSameParentIdTag_sharedParent_returnsTrue() {
+    public void areIdTagsRelatedByParent_sharedParent_returnsTrue() {
         String parentIdTag = insertTag("parent", null);
         String firstIdTag = insertTag("child", parentIdTag);
         String secondIdTag = insertTag("child", parentIdTag);
 
-        Assertions.assertTrue(ocppTagService.haveTheSameParentIdTag(firstIdTag, secondIdTag));
+        Assertions.assertTrue(ocppTagService.areIdTagsRelatedByParent(firstIdTag, secondIdTag));
     }
 
     @Test
-    public void haveTheSameParentIdTag_differentParents_returnsFalse() {
+    public void areIdTagsRelatedByParent_parentAndChild_returnsTrueInBothDirections() {
+        String parentIdTag = insertTag("parent", null);
+        String childIdTag = insertTag("child", parentIdTag);
+
+        Assertions.assertAll(
+            () -> Assertions.assertTrue(ocppTagService.areIdTagsRelatedByParent(parentIdTag, childIdTag)),
+            () -> Assertions.assertTrue(ocppTagService.areIdTagsRelatedByParent(childIdTag, parentIdTag))
+        );
+    }
+
+    @Test
+    public void areIdTagsRelatedByParent_differentParents_returnsFalse() {
         String firstParentIdTag = insertTag("parent", null);
         String secondParentIdTag = insertTag("parent", null);
         String firstIdTag = insertTag("child", firstParentIdTag);
         String secondIdTag = insertTag("child", secondParentIdTag);
 
-        Assertions.assertFalse(ocppTagService.haveTheSameParentIdTag(firstIdTag, secondIdTag));
+        Assertions.assertFalse(ocppTagService.areIdTagsRelatedByParent(firstIdTag, secondIdTag));
     }
 
     @Test
-    public void haveTheSameParentIdTag_withoutParents_returnsFalse() {
+    public void areIdTagsRelatedByParent_withoutParents_returnsFalse() {
         String firstIdTag = insertTag("parentless", null);
         String secondIdTag = insertTag("parentless", null);
 
-        Assertions.assertFalse(ocppTagService.haveTheSameParentIdTag(firstIdTag, secondIdTag));
+        Assertions.assertFalse(ocppTagService.areIdTagsRelatedByParent(firstIdTag, secondIdTag));
     }
 
     @Test
-    public void haveTheSameParentIdTag_unknownTag_returnsFalse() {
+    public void areIdTagsRelatedByParent_unknownTag_returnsFalse() {
         String parentIdTag = insertTag("parent", null);
         String knownIdTag = insertTag("child", parentIdTag);
         String unknownIdTag = uniqueId("unknown");
 
         Assertions.assertAll(
-            () -> Assertions.assertFalse(ocppTagService.haveTheSameParentIdTag(knownIdTag, unknownIdTag)),
-            () -> Assertions.assertFalse(ocppTagService.haveTheSameParentIdTag(unknownIdTag, knownIdTag))
+            () -> Assertions.assertFalse(ocppTagService.areIdTagsRelatedByParent(knownIdTag, unknownIdTag)),
+            () -> Assertions.assertFalse(ocppTagService.areIdTagsRelatedByParent(unknownIdTag, knownIdTag))
         );
     }
 

--- a/src/test/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImplIT.java
+++ b/src/test/java/de/rwth/idsg/steve/repository/impl/OcppTagRepositoryImplIT.java
@@ -19,6 +19,7 @@
 package de.rwth.idsg.steve.repository.impl;
 
 import de.rwth.idsg.steve.repository.OcppTagRepository;
+import de.rwth.idsg.steve.service.OcppTagService;
 import de.rwth.idsg.steve.web.dto.OcppTagForm;
 import de.rwth.idsg.steve.web.dto.OcppTagQueryForm;
 import jooq.steve.db.tables.records.OcppTagRecord;
@@ -27,6 +28,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Set;
 
 import static jooq.steve.db.tables.OcppTag.OCPP_TAG;
 
@@ -39,6 +42,8 @@ public class OcppTagRepositoryImplIT extends AbstractRepositoryITBase {
     private DSLContext dslContext;
     @Autowired
     private OcppTagRepository repository;
+    @Autowired
+    private OcppTagService ocppTagService;
 
     @BeforeEach
     public void setup() {
@@ -109,13 +114,66 @@ public class OcppTagRepositoryImplIT extends AbstractRepositoryITBase {
 
     @Test
     public void getParentIdTags() {
-        var tags = assertNoDatabaseException(repository::getParentIdTags);
+        var tags = assertNoDatabaseException(() -> repository.getParentIdTags());
         Assertions.assertNotNull(tags);
     }
 
     @Test
-    public void getParentIdtag() {
-        assertNoDatabaseException(() -> repository.getParentIdtag(KNOWN_OCPP_TAG));
+    public void getParentIdTagsByIdTags() {
+        String parentIdTag = insertTag("parent", null);
+        String childIdTag = insertTag("child", parentIdTag);
+        String parentlessIdTag = insertTag("parentless", null);
+        String unknownIdTag = uniqueId("unknown");
+
+        var result = assertNoDatabaseException(
+            () -> repository.getParentIdTags(Set.of(childIdTag, parentlessIdTag, unknownIdTag))
+        );
+
+        Assertions.assertAll(
+            () -> Assertions.assertEquals(parentIdTag, result.get(childIdTag)),
+            () -> Assertions.assertTrue(result.containsKey(parentlessIdTag)),
+            () -> Assertions.assertNull(result.get(parentlessIdTag)),
+            () -> Assertions.assertFalse(result.containsKey(unknownIdTag))
+        );
+    }
+
+    @Test
+    public void haveTheSameParentIdTag_sharedParent_returnsTrue() {
+        String parentIdTag = insertTag("parent", null);
+        String firstIdTag = insertTag("child", parentIdTag);
+        String secondIdTag = insertTag("child", parentIdTag);
+
+        Assertions.assertTrue(ocppTagService.haveTheSameParentIdTag(firstIdTag, secondIdTag));
+    }
+
+    @Test
+    public void haveTheSameParentIdTag_differentParents_returnsFalse() {
+        String firstParentIdTag = insertTag("parent", null);
+        String secondParentIdTag = insertTag("parent", null);
+        String firstIdTag = insertTag("child", firstParentIdTag);
+        String secondIdTag = insertTag("child", secondParentIdTag);
+
+        Assertions.assertFalse(ocppTagService.haveTheSameParentIdTag(firstIdTag, secondIdTag));
+    }
+
+    @Test
+    public void haveTheSameParentIdTag_withoutParents_returnsFalse() {
+        String firstIdTag = insertTag("parentless", null);
+        String secondIdTag = insertTag("parentless", null);
+
+        Assertions.assertFalse(ocppTagService.haveTheSameParentIdTag(firstIdTag, secondIdTag));
+    }
+
+    @Test
+    public void haveTheSameParentIdTag_unknownTag_returnsFalse() {
+        String parentIdTag = insertTag("parent", null);
+        String knownIdTag = insertTag("child", parentIdTag);
+        String unknownIdTag = uniqueId("unknown");
+
+        Assertions.assertAll(
+            () -> Assertions.assertFalse(ocppTagService.haveTheSameParentIdTag(knownIdTag, unknownIdTag)),
+            () -> Assertions.assertFalse(ocppTagService.haveTheSameParentIdTag(unknownIdTag, knownIdTag))
+        );
     }
 
     @Test
@@ -203,5 +261,14 @@ public class OcppTagRepositoryImplIT extends AbstractRepositoryITBase {
             .where(OCPP_TAG.OCPP_TAG_PK.eq(pk))
             .fetchOne();
         assertAuditTimestampsAfterUpdate(before.value1(), before.value2(), after.value1(), after.value2());
+    }
+
+    private String insertTag(String prefix, String parentIdTag) {
+        String idTag = uniqueId(prefix);
+        dslContext.insertInto(OCPP_TAG)
+            .set(OCPP_TAG.ID_TAG, idTag)
+            .set(OCPP_TAG.PARENT_ID_TAG, parentIdTag)
+            .execute();
+        return idTag;
     }
 }

--- a/src/test/java/de/rwth/idsg/steve/service/CentralSystemService16ServiceValidatorTest.java
+++ b/src/test/java/de/rwth/idsg/steve/service/CentralSystemService16ServiceValidatorTest.java
@@ -348,7 +348,7 @@ public class CentralSystemService16ServiceValidatorTest {
 
         assertHardErrors(
             result,
-            "stop.idTag does not match the transaction's idTag or share its parentIdTag"
+            "stop.idTag is neither the transaction's idTag nor related to it through parentIdTag"
         );
     }
 

--- a/src/test/java/de/rwth/idsg/steve/service/CentralSystemService16ServiceValidatorTest.java
+++ b/src/test/java/de/rwth/idsg/steve/service/CentralSystemService16ServiceValidatorTest.java
@@ -41,6 +41,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiFunction;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -50,6 +51,7 @@ public class CentralSystemService16ServiceValidatorTest {
 
     private static final Instant NOW = Instant.parse("2026-02-17T12:00:00Z");
     private static final Clock FIXED_CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+    private static final BiFunction<String, String, Boolean> DIFFERENT_PARENTS = (first, second) -> false;
 
     private final CentralSystemService16_ServiceValidator validator = new CentralSystemService16_ServiceValidator(FIXED_CLOCK);
 
@@ -256,7 +258,7 @@ public class CentralSystemService16ServiceValidatorTest {
     @Test
     public void validateStop_transactionMissing_returnsHardError() {
         var params = stopParams(new DateTime(NOW.toEpochMilli()), "200");
-        var result = validator.validateStop(null, params);
+        var result = validator.validateStop(null, params, DIFFERENT_PARENTS);
 
         assertHardErrors(result, "The transaction is not found in database");
     }
@@ -271,7 +273,7 @@ public class CentralSystemService16ServiceValidatorTest {
             TransactionStopEventActor.station
         );
         var params = stopParams(DateTime.parse("2026-02-17T10:30:00Z"), "200");
-        var result = validator.validateStop(tx, params);
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertHardErrors(result, "The transaction was already stopped by the station");
     }
@@ -286,7 +288,7 @@ public class CentralSystemService16ServiceValidatorTest {
             TransactionStopEventActor.manual
         );
         var params = stopParams(DateTime.parse("2026-02-17T10:30:00Z"), "200");
-        var result = validator.validateStop(tx, params);
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertValid(result);
     }
@@ -295,7 +297,7 @@ public class CentralSystemService16ServiceValidatorTest {
     public void validateStop_startAfterStop_returnsHardError() {
         var tx = tx("100", DateTime.parse("2026-02-17T12:01:00Z"), null, null, null);
         var params = stopParams(DateTime.parse("2026-02-17T12:00:00Z"), "200");
-        var result = validator.validateStop(tx, params);
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertHardErrors(result, "start.timestamp is after stop.timestamp");
     }
@@ -304,7 +306,7 @@ public class CentralSystemService16ServiceValidatorTest {
     public void validateStop_futureStopTimestamp_returnsHardError() {
         var tx = tx("100", DateTime.parse("2026-02-17T09:00:00Z"), null, null, null);
         var params = stopParams(DateTime.parse("2026-02-17T12:05:01Z"), "200");
-        var result = validator.validateStop(tx, params);
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertHardErrors(result, "stop.timestamp is in the future");
     }
@@ -313,7 +315,7 @@ public class CentralSystemService16ServiceValidatorTest {
     public void validateStop_futureStopTimestampAtBoundary_isAllowed() {
         var tx = tx("100", DateTime.parse("2026-02-17T09:00:00Z"), null, null, null);
         var params = stopParams(DateTime.parse("2026-02-17T12:05:00Z"), "200");
-        var result = validator.validateStop(tx, params);
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertValid(result);
     }
@@ -322,7 +324,7 @@ public class CentralSystemService16ServiceValidatorTest {
     public void validateStop_stopMeterLowerThanStart_returnsHardError() {
         var tx = tx("300", DateTime.parse("2026-02-17T09:00:00Z"), null, null, null);
         var params = stopParams(DateTime.parse("2026-02-17T10:00:00Z"), "200");
-        var result = validator.validateStop(tx, params);
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertHardErrors(result, "meterStart is greater than meterStop");
     }
@@ -331,7 +333,43 @@ public class CentralSystemService16ServiceValidatorTest {
     public void validateStop_validStationStop_returnsValidResult() {
         var tx = tx("100", DateTime.parse("2026-02-17T09:00:00Z"), null, null, null);
         var params = stopParams(DateTime.parse("2026-02-17T10:00:00Z"), "200");
-        var result = validator.validateStop(tx, params);
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
+
+        assertValid(result);
+    }
+
+    @Test
+    public void validateStop_differentIdTagsWithoutMatchingParents_returnsHardError() {
+        var tx = tx("100", DateTime.parse("2026-02-17T09:00:00Z"), null, null, null);
+        var params = stopParams(DateTime.parse("2026-02-17T10:00:00Z"), "200")
+            .withIdTag("tag-2");
+
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
+
+        assertHardErrors(
+            result,
+            "stop.idTag does not match the transaction's idTag or share its parentIdTag"
+        );
+    }
+
+    @Test
+    public void validateStop_differentIdTagsWithMatchingParents_isAllowed() {
+        var tx = tx("100", DateTime.parse("2026-02-17T09:00:00Z"), null, null, null);
+        var params = stopParams(DateTime.parse("2026-02-17T10:00:00Z"), "200")
+            .withIdTag("tag-2");
+
+        var result = validator.validateStop(tx, params, (first, second) -> true);
+
+        assertValid(result);
+    }
+
+    @Test
+    public void validateStop_withoutIdTag_isAllowed() {
+        var tx = tx("100", DateTime.parse("2026-02-17T09:00:00Z"), null, null, null);
+        var params = stopParams(DateTime.parse("2026-02-17T10:00:00Z"), "200")
+            .withIdTag(null);
+
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertValid(result);
     }
@@ -341,7 +379,7 @@ public class CentralSystemService16ServiceValidatorTest {
         var tx = tx("100", DateTime.parse("2026-02-17T09:00:00Z"), null, null, null);
         var params = stopParams(DateTime.parse("2026-02-17T10:00:00Z"), "200")
             .withTransactionData(List.of(meterValue("2026-02-17T12:05:01Z")));
-        var result = validator.validateStop(tx, params);
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertSoftErrors(
             result,
@@ -356,7 +394,7 @@ public class CentralSystemService16ServiceValidatorTest {
         var tx = tx("100", DateTime.parse("2026-02-17T09:00:00Z"), null, null, null);
         var params = stopParams(DateTime.parse("2026-02-17T10:00:00Z"), "200")
             .withTransactionData(List.of(meterValue("2026-02-17T10:10:00Z")));
-        var result = validator.validateStop(tx, params);
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertSoftErrors(result, "at least one MeterValue.timestamp is after stop.timestamp");
     }
@@ -367,7 +405,7 @@ public class CentralSystemService16ServiceValidatorTest {
         var tx = tx("100", DateTime.parse("2026-02-17T09:00:00Z"), null, null, null);
         var params = stopParams(DateTime.parse("2026-02-17T10:00:00Z"), "200")
             .withTransactionData(List.of(meterValue("2026-02-17T08:54:59Z")));
-        var result = validator.validateStop(tx, params);
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertSoftErrors(result, "at least one MeterValue.timestamp is before start.timestamp");
     }
@@ -378,7 +416,7 @@ public class CentralSystemService16ServiceValidatorTest {
         var tx = tx("100", DateTime.parse("2026-02-17T09:00:00Z"), null, null, null);
         var params = stopParams(DateTime.parse("2026-02-17T10:00:00Z"), "200")
             .withTransactionData(List.of(meterValue("2026-02-17T08:55:01Z")));
-        var result = validator.validateStop(tx, params);
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertValid(result);
     }
@@ -388,7 +426,7 @@ public class CentralSystemService16ServiceValidatorTest {
         var tx = tx("100", DateTime.parse("2026-02-17T09:00:00Z"), null, null, null);
         var params = stopParams(DateTime.parse("2026-02-17T10:00:00Z"), "200")
             .withTransactionData(List.of(meterValue("2026-02-17T09:00:00Z")));
-        var result = validator.validateStop(tx, params);
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertValid(result);
     }
@@ -404,7 +442,7 @@ public class CentralSystemService16ServiceValidatorTest {
 
         var params = stopParams(DateTime.parse("2026-02-17T10:00:00Z"), "200")
             .withTransactionData(List.of(meterValue("2026-02-17T10:00:01Z")));
-        var result = validator.validateStop(tx, params);
+        var result = validator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertValid(result);
     }
@@ -418,7 +456,8 @@ public class CentralSystemService16ServiceValidatorTest {
         var messageClock = Clock.fixed(Instant.parse("2026-03-25T08:10:00Z"), ZoneOffset.UTC);
         var localValidator = new CentralSystemService16_ServiceValidator(messageClock);
 
-        var tx = tx("100", DateTime.parse("2026-03-25T06:22:44.000Z"), null, null, null);
+        var tx = tx("100", DateTime.parse("2026-03-25T06:22:44.000Z"), null, null, null)
+            .setIdTag("XYZ");
 
         StopTransactionRequest params = new StopTransactionRequest()
             .withIdTag("XYZ")
@@ -441,7 +480,7 @@ public class CentralSystemService16ServiceValidatorTest {
                     .withSampledValue(sampledValue("203", ReadingContext.TRANSACTION_END, ValueFormat.SIGNED_DATA))
             ));
 
-        var result = localValidator.validateStop(tx, params);
+        var result = localValidator.validateStop(tx, params, DIFFERENT_PARENTS);
 
         assertValid(result);
     }
@@ -583,6 +622,7 @@ public class CentralSystemService16ServiceValidatorTest {
                                         String stopValue, DateTime stopTimestamp,
                                         TransactionStopEventActor stopActor) {
         return new TransactionRecord()
+            .setIdTag("tag-1")
             .setStartValue(startValue)
             .setStartTimestamp(startTimestamp)
             .setStopValue(stopValue)


### PR DESCRIPTION
check transaction ownership (of user) when processing StopTransaction. it is a HARD error, if
- idTag is set in StopTransaction, and
- it does not match the idTag from StartTransaction, and
- idTags from start and stop are related through parentIdTag

---

This is a fix for https://github.com/steve-community/steve/security/advisories/GHSA-67fq-r6rm-rqpm. However...

In OCPP, 1.6 `StopTransaction` is a station-originated **_report of a transaction that has already ended, and not a CSMS command that grants permission to end it._**

`idTag` is even optional because valid terminations include cable disconnection, reset, remote stop, power loss, and other non-card events. If an attacker can impersonate or compromise a charge point, **_they can omit idTag entirely and report a stop_**. Comparing tags would therefore not repair that trust-boundary failure; charge-point authentication/security-profile configuration is the relevant control.

The official OCA conformance test places the ownership check on the charge point: it must not issue StopTransaction.req for an unrelated valid tag, while a tag sharing the starting tag’s parentIdTag is permitted. See the [OCA OCPP 1.6 conformance test cases, sections 2.3.1–2.3.2](https://openchargealliance.org/wp-content/uploads/2025/09/CompliancyTestTool-TestCaseDocument.pdf).