### PR TITLE
refactor websocket, make IncomingPipeline and Deserializer beans

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/config/WebSocketConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/WebSocketConfiguration.java
@@ -18,8 +18,8 @@
  */
 package de.rwth.idsg.steve.config;
 
-import de.rwth.idsg.steve.ocpp.ws.AbstractWebSocketEndpoint;
 import de.rwth.idsg.steve.ocpp.ws.OcppWebSocketHandshakeHandler;
+import de.rwth.idsg.steve.ocpp.ws.WebSocketEndpoint;
 import de.rwth.idsg.steve.service.CertificateValidator;
 import de.rwth.idsg.steve.service.ChargePointService;
 import de.rwth.idsg.steve.web.validation.ChargeBoxIdValidator;
@@ -35,7 +35,6 @@ import org.springframework.web.socket.server.jetty.JettyRequestUpgradeStrategy;
 import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
 
 import java.time.Duration;
-import java.util.List;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -50,8 +49,8 @@ public class WebSocketConfiguration implements WebSocketConfigurer {
     private final SteveProperties steveProperties;
     private final ChargePointService chargePointService;
     private final ChargeBoxIdValidator chargeBoxIdValidator;
-    private final List<AbstractWebSocketEndpoint> endpoints;
     private final CertificateValidator certificateValidator;
+    private final WebSocketEndpoint webSocketEndpoint;
 
     public static final String PATH_INFIX = "/websocket/CentralSystemService/";
     public static final Duration PING_INTERVAL = Duration.ofMinutes(15);
@@ -63,13 +62,13 @@ public class WebSocketConfiguration implements WebSocketConfigurer {
         OcppWebSocketHandshakeHandler handshakeHandler = new OcppWebSocketHandshakeHandler(
             chargeBoxIdValidator,
             handshakeHandler(),
-            endpoints,
+            webSocketEndpoint,
             chargePointService,
             certificateValidator,
             steveProperties.getOcpp().getSecurity().getProtocolHeaderFromProxy()
         );
 
-        registry.addHandler(handshakeHandler.getDummyWebSocketHandler(), PATH_INFIX + "*")
+        registry.addHandler(webSocketEndpoint, PATH_INFIX + "*")
                 .setHandshakeHandler(handshakeHandler)
                 .setAllowedOrigins("*");
     }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/ChargePointServiceJsonInvoker.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/ChargePointServiceJsonInvoker.java
@@ -97,7 +97,11 @@ public class ChargePointServiceJsonInvoker {
 
         FutureResponseContext frc = new FutureResponseContext(task, pair.getResponseClass());
 
-        CommunicationContext context = new CommunicationContext(sessionStore.getSession(chargeBoxId), chargeBoxId);
+        CommunicationContext context = new CommunicationContext(
+            sessionStore.getSession(chargeBoxId),
+            chargeBoxId,
+            cps.getOcppProtocol()
+        );
         context.setOutgoingMessage(call);
         context.setFutureResponseContext(frc);
 

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/OcppWebSocketHandshakeHandler.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/OcppWebSocketHandshakeHandler.java
@@ -33,9 +33,9 @@ import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.web.authentication.www.BasicAuthenticationConverter;
 import org.springframework.util.CollectionUtils;
+import org.springframework.web.socket.SubProtocolCapable;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.WebSocketHttpHeaders;
-import org.springframework.web.socket.handler.TextWebSocketHandler;
 import org.springframework.web.socket.server.HandshakeFailureException;
 import org.springframework.web.socket.server.HandshakeHandler;
 import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
@@ -56,21 +56,12 @@ public class OcppWebSocketHandshakeHandler implements HandshakeHandler {
 
     private final ChargeBoxIdValidator chargeBoxIdValidator;
     private final DefaultHandshakeHandler delegate;
-    private final List<AbstractWebSocketEndpoint> endpoints;
+    private final SubProtocolCapable subProtocolCapable;
     private final ChargePointService chargePointService;
     private final CertificateValidator certificateValidator;
     private final String protocolHeaderFromProxy;
 
     private final BasicAuthenticationConverter converter = new BasicAuthenticationConverter();
-
-    /**
-     * We need some WebSocketHandler just for Spring to register it for the path. We will not use it for the actual
-     * operations. This instance will be passed to doHandshake(..) below. We will find the proper WebSocketEndpoint
-     * based on the selectedProtocol and replace the dummy one with the proper one in the subsequent call chain.
-     */
-    public WebSocketHandler getDummyWebSocketHandler() {
-        return new TextWebSocketHandler();
-    }
 
     @Override
     public boolean doHandshake(ServerHttpRequest request, ServerHttpResponse response,
@@ -173,31 +164,33 @@ public class OcppWebSocketHandshakeHandler implements HandshakeHandler {
             return false;
         }
 
-        AbstractWebSocketEndpoint endpoint = selectEndpoint(requestedProtocols);
+        String version = selectVersion(requestedProtocols);
 
-        if (endpoint == null) {
+        if (version == null) {
             log.error("ChargeBoxId '{}': None of the requested protocols '{}' is supported", chargeBoxId, requestedProtocols);
             response.setStatusCode(HttpStatus.NOT_FOUND);
             return false;
         }
 
-        attributes.put(AbstractWebSocketEndpoint.CHARGEBOX_ID_KEY, chargeBoxId);
-        log.debug("ChargeBoxId '{}' will be using {}", chargeBoxId, endpoint.getClass().getSimpleName());
-        return delegate.doHandshake(request, response, endpoint, attributes);
+        attributes.put(WebSocketEndpoint.CHARGEBOX_ID_KEY, chargeBoxId);
+
+        log.debug("ChargeBoxId '{}' will be using {}", chargeBoxId, version);
+        return delegate.doHandshake(request, response, wsHandler, attributes);
     }
 
     /**
-     * Selects the endpoint for the first supported protocol in the station's preference order. Since requested
-     * protocols are evaluated before endpoints (because we iterate over requestedProtocols in the outer loop),
-     * the station's preference order dominates the endpoint collection's order (i.e. the order of endpoints
+     * Selects the OCPP version for the first supported protocol in the station's preference order. Since requested
+     * protocols are evaluated before versions (because we iterate over requestedProtocols in the outer loop),
+     * the station's preference order dominates the version collection's order (i.e. the order of versions
      * does not matter).
      *
-     * @return the selected endpoint, or {@code null} if none of the requested protocols is supported
+     * @return the selected OCPP version, or {@code null} if none of the requested protocols is supported
      */
-    private AbstractWebSocketEndpoint selectEndpoint(List<String> requestedProtocols ) {
+    private String selectVersion(List<String> requestedProtocols) {
+        List<String> supportedProtocols = subProtocolCapable.getSubProtocols();
         for (String requestedProtocol : requestedProtocols) {
-            for (AbstractWebSocketEndpoint item : endpoints) {
-                if (item.getVersion().getValue().equals(requestedProtocol)) {
+            for (String item : supportedProtocols) {
+                if (item.equals(requestedProtocol)) {
                     return item;
                 }
             }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketEndpoint.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketEndpoint.java
@@ -22,16 +22,15 @@ import com.google.common.base.Strings;
 import de.rwth.idsg.steve.ocpp.OcppTransport;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
-import de.rwth.idsg.steve.ocpp.ws.pipeline.Deserializer;
 import de.rwth.idsg.steve.ocpp.ws.pipeline.IncomingPipeline;
 import de.rwth.idsg.steve.ocpp.ws.pipeline.OcppCallHandler;
 import de.rwth.idsg.steve.repository.OcppServerRepository;
 import de.rwth.idsg.steve.service.notification.OcppStationWebSocketConnected;
 import de.rwth.idsg.steve.service.notification.OcppStationWebSocketDisconnected;
+import lombok.RequiredArgsConstructor;
 import org.joda.time.DateTime;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.PongMessage;
@@ -40,52 +39,29 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 17.03.2015
  */
-public abstract class AbstractWebSocketEndpoint extends ConcurrentWebSocketHandler implements SubProtocolCapable, OcppCallHandler {
+@Component
+@RequiredArgsConstructor
+public class WebSocketEndpoint extends ConcurrentWebSocketHandler implements SubProtocolCapable {
 
     public static final String CHARGEBOX_ID_KEY = "CHARGEBOX_ID_KEY";
 
+    private final List<OcppCallHandler> versionHandlers;
     private final OcppServerRepository ocppServerRepository;
-    private final IncomingPipeline pipeline;
-    private final SessionContextStore sessionContextStore;
-
-    private final Logger log = LoggerFactory.getLogger(getClass());
-    private final List<Consumer<String>> connectedCallbackList = new ArrayList<>();
-    private final List<Consumer<String>> disconnectedCallbackList = new ArrayList<>();
-
-    public AbstractWebSocketEndpoint(OcppServerRepository ocppServerRepository,
-                                     FutureResponseContextStore futureResponseContextStore,
-                                     ApplicationEventPublisher applicationEventPublisher,
-                                     SessionContextStoreHolder sessionContextStoreHolder,
-                                     AbstractTypeStore typeStore) {
-        this.ocppServerRepository = ocppServerRepository;
-        this.sessionContextStore = sessionContextStoreHolder.getOrCreate(getVersion());
-        this.pipeline = new IncomingPipeline(new Deserializer(futureResponseContextStore, sessionContextStore, typeStore), this);
-
-        connectedCallbackList.add((chargeBoxId) -> applicationEventPublisher.publishEvent(new OcppStationWebSocketConnected(chargeBoxId, getVersion())));
-        disconnectedCallbackList.add((chargeBoxId) -> applicationEventPublisher.publishEvent(new OcppStationWebSocketDisconnected(chargeBoxId, getVersion())));
-
-        log.info("Initialized");
-    }
-
-    public abstract OcppVersion getVersion();
-
-    @Override
-    public Logger getLogger() {
-        return log;
-    }
+    private final SessionContextStoreHolder sessionContextStoreHolder;
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final IncomingPipeline incomingPipeline;
 
     @Override
     public List<String> getSubProtocols() {
-        return Collections.singletonList(getVersion().getValue());
+        return versionHandlers.stream()
+            .map(it -> it.getVersion().getValue())
+            .toList();
     }
 
     @Override
@@ -105,8 +81,10 @@ public abstract class AbstractWebSocketEndpoint extends ConcurrentWebSocketHandl
     }
 
     private void handleTextMessage(WebSocketSession session, TextMessage webSocketMessage) throws Exception {
+        var chargeBoxId = getChargeBoxId(session);
+        var version = getVersion(session);
+
         String incomingString = webSocketMessage.getPayload();
-        String chargeBoxId = getChargeBoxId(session);
 
         // https://github.com/steve-community/steve/issues/66
         if (Strings.isNullOrEmpty(incomingString)) {
@@ -116,10 +94,14 @@ public abstract class AbstractWebSocketEndpoint extends ConcurrentWebSocketHandl
 
         WebSocketLogger.receivedText(chargeBoxId, session, incomingString);
 
-        CommunicationContext context = new CommunicationContext(session, chargeBoxId);
+        CommunicationContext context = new CommunicationContext(
+            session,
+            chargeBoxId,
+            version.toProtocol(OcppTransport.JSON)
+        );
         context.setIncomingString(incomingString);
 
-        pipeline.accept(context);
+        incomingPipeline.accept(context);
     }
 
     private void handlePongMessage(WebSocketSession session) {
@@ -129,31 +111,37 @@ public abstract class AbstractWebSocketEndpoint extends ConcurrentWebSocketHandl
 
     @Override
     public void onOpen(WebSocketSession session) throws Exception {
-        String chargeBoxId = getChargeBoxId(session);
+        var chargeBoxId = getChargeBoxId(session);
+        var version = getVersion(session);
+
         WebSocketLogger.connected(chargeBoxId, session);
 
+        var sessionContextStore = sessionContextStoreHolder.getOrCreate(version);
         boolean stationConnected = sessionContextStore.add(chargeBoxId, session);
 
-        ocppServerRepository.updateOcppProtocol(chargeBoxId, getVersion().toProtocol(OcppTransport.JSON));
+        ocppServerRepository.updateOcppProtocol(chargeBoxId, version.toProtocol(OcppTransport.JSON));
 
         // Take into account that there might be multiple connections to a charging station.
         // Send notification only for the change 0 -> 1.
         if (stationConnected) {
-            connectedCallbackList.forEach(consumer -> consumer.accept(chargeBoxId));
+            applicationEventPublisher.publishEvent(new OcppStationWebSocketConnected(chargeBoxId, version));
         }
     }
 
     @Override
     public void onClose(WebSocketSession session, CloseStatus closeStatus) throws Exception {
-        String chargeBoxId = getChargeBoxId(session);
+        var chargeBoxId = getChargeBoxId(session);
+        var version = getVersion(session);
+
         WebSocketLogger.closed(chargeBoxId, session, closeStatus);
 
+        var sessionContextStore = sessionContextStoreHolder.getOrCreate(version);
         boolean stationDisconnected = sessionContextStore.remove(chargeBoxId, session);
 
         // Take into account that there might be multiple connections to a charging station.
         // Send notification only for the change 1 -> 0.
         if (stationDisconnected) {
-            disconnectedCallbackList.forEach(consumer -> consumer.accept(chargeBoxId));
+            applicationEventPublisher.publishEvent(new OcppStationWebSocketDisconnected(chargeBoxId, version));
         }
     }
 
@@ -175,4 +163,7 @@ public abstract class AbstractWebSocketEndpoint extends ConcurrentWebSocketHandl
         return (String) session.getAttributes().get(CHARGEBOX_ID_KEY);
     }
 
+    private OcppVersion getVersion(WebSocketSession session) {
+        return OcppVersion.fromValue(session.getAcceptedProtocol());
+    }
 }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/CommunicationContext.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/CommunicationContext.java
@@ -18,6 +18,7 @@
  */
 package de.rwth.idsg.steve.ocpp.ws.data;
 
+import de.rwth.idsg.steve.ocpp.OcppProtocol;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -36,6 +37,7 @@ public class CommunicationContext {
 
     @NotNull private final WebSocketSession session;
     @NotNull private final String chargeBoxId;
+    @NotNull private final OcppProtocol protocol;
 
     @Setter private String incomingString;
     @Setter private String outgoingString;

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/ocpp12/Ocpp12Handler.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/ocpp12/Ocpp12Handler.java
@@ -24,10 +24,9 @@ import de.rwth.idsg.steve.ocpp.OcppEnabledCondition;
 import de.rwth.idsg.steve.ocpp.OcppProtocol;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.soap.CentralSystemService12_SoapServer;
-import de.rwth.idsg.steve.ocpp.ws.AbstractWebSocketEndpoint;
-import de.rwth.idsg.steve.ocpp.ws.FutureResponseContextStore;
-import de.rwth.idsg.steve.ocpp.ws.SessionContextStoreHolder;
-import de.rwth.idsg.steve.repository.OcppServerRepository;
+import de.rwth.idsg.steve.ocpp.ws.TypeStore;
+import de.rwth.idsg.steve.ocpp.ws.pipeline.OcppCallHandler;
+import lombok.extern.slf4j.Slf4j;
 import ocpp.cs._2010._08.AuthorizeRequest;
 import ocpp.cs._2010._08.BootNotificationRequest;
 import ocpp.cs._2010._08.DiagnosticsStatusNotificationRequest;
@@ -37,32 +36,40 @@ import ocpp.cs._2010._08.MeterValuesRequest;
 import ocpp.cs._2010._08.StartTransactionRequest;
 import ocpp.cs._2010._08.StatusNotificationRequest;
 import ocpp.cs._2010._08.StopTransactionRequest;
-import org.springframework.context.ApplicationEventPublisher;
+import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
+
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 12.03.2015
  */
+@Slf4j
 @Component
 @Conditional(OcppEnabledCondition.V12.Json.class)
-public class Ocpp12WebSocketEndpoint extends AbstractWebSocketEndpoint {
+public class Ocpp12Handler implements OcppCallHandler {
 
     private final CentralSystemService12_SoapServer server;
 
-    public Ocpp12WebSocketEndpoint(OcppServerRepository ocppServerRepository,
-                                   FutureResponseContextStore futureResponseContextStore,
-                                   ApplicationEventPublisher applicationEventPublisher,
-                                   CentralSystemService12_SoapServer server,
-                                   SessionContextStoreHolder sessionContextStoreHolder) {
-        super(ocppServerRepository, futureResponseContextStore, applicationEventPublisher, sessionContextStoreHolder, Ocpp12TypeStore.INSTANCE);
+    public Ocpp12Handler(CentralSystemService12_SoapServer server) {
         this.server = server;
+        log.info("Initialized");
     }
 
     @Override
     public OcppVersion getVersion() {
         return OcppVersion.V_12;
+    }
+
+    @Override
+    public TypeStore getTypeStore() {
+        return Ocpp12TypeStore.INSTANCE;
+    }
+
+    @Override
+    public Logger getLogger() {
+        return log;
     }
 
     @Override
@@ -81,5 +88,4 @@ public class Ocpp12WebSocketEndpoint extends AbstractWebSocketEndpoint {
                 throw new IllegalArgumentException("Unexpected RequestType, dispatch method not found");
         };
     }
-
 }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/ocpp15/Ocpp15Handler.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/ocpp15/Ocpp15Handler.java
@@ -24,10 +24,9 @@ import de.rwth.idsg.steve.ocpp.OcppEnabledCondition;
 import de.rwth.idsg.steve.ocpp.OcppProtocol;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.soap.CentralSystemService15_SoapServer;
-import de.rwth.idsg.steve.ocpp.ws.AbstractWebSocketEndpoint;
-import de.rwth.idsg.steve.ocpp.ws.FutureResponseContextStore;
-import de.rwth.idsg.steve.ocpp.ws.SessionContextStoreHolder;
-import de.rwth.idsg.steve.repository.OcppServerRepository;
+import de.rwth.idsg.steve.ocpp.ws.TypeStore;
+import de.rwth.idsg.steve.ocpp.ws.pipeline.OcppCallHandler;
+import lombok.extern.slf4j.Slf4j;
 import ocpp.cs._2012._06.AuthorizeRequest;
 import ocpp.cs._2012._06.BootNotificationRequest;
 import ocpp.cs._2012._06.DataTransferRequest;
@@ -38,7 +37,7 @@ import ocpp.cs._2012._06.MeterValuesRequest;
 import ocpp.cs._2012._06.StartTransactionRequest;
 import ocpp.cs._2012._06.StatusNotificationRequest;
 import ocpp.cs._2012._06.StopTransactionRequest;
-import org.springframework.context.ApplicationEventPublisher;
+import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -46,24 +45,31 @@ import org.springframework.stereotype.Component;
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 12.03.2015
  */
+@Slf4j
 @Component
 @Conditional(OcppEnabledCondition.V15.Json.class)
-public class Ocpp15WebSocketEndpoint extends AbstractWebSocketEndpoint {
+public class Ocpp15Handler implements OcppCallHandler {
 
     private final CentralSystemService15_SoapServer server;
 
-    public Ocpp15WebSocketEndpoint(OcppServerRepository ocppServerRepository,
-                                   FutureResponseContextStore futureResponseContextStore,
-                                   ApplicationEventPublisher applicationEventPublisher,
-                                   CentralSystemService15_SoapServer server,
-                                   SessionContextStoreHolder sessionContextStoreHolder) {
-        super(ocppServerRepository, futureResponseContextStore, applicationEventPublisher, sessionContextStoreHolder, Ocpp15TypeStore.INSTANCE);
+    public Ocpp15Handler(CentralSystemService15_SoapServer server) {
         this.server = server;
+        log.info("Initialized");
     }
 
     @Override
     public OcppVersion getVersion() {
         return OcppVersion.V_15;
+    }
+
+    @Override
+    public TypeStore getTypeStore() {
+        return Ocpp15TypeStore.INSTANCE;
+    }
+
+    @Override
+    public Logger getLogger() {
+        return log;
     }
 
     @Override

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/ocpp16/Ocpp16Handler.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/ocpp16/Ocpp16Handler.java
@@ -24,10 +24,9 @@ import de.rwth.idsg.steve.ocpp.OcppEnabledCondition;
 import de.rwth.idsg.steve.ocpp.OcppProtocol;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.soap.CentralSystemService16_SoapServer;
-import de.rwth.idsg.steve.ocpp.ws.AbstractWebSocketEndpoint;
-import de.rwth.idsg.steve.ocpp.ws.FutureResponseContextStore;
-import de.rwth.idsg.steve.ocpp.ws.SessionContextStoreHolder;
-import de.rwth.idsg.steve.repository.OcppServerRepository;
+import de.rwth.idsg.steve.ocpp.ws.TypeStore;
+import de.rwth.idsg.steve.ocpp.ws.pipeline.OcppCallHandler;
+import lombok.extern.slf4j.Slf4j;
 import ocpp._2022._02.security.LogStatusNotification;
 import ocpp._2022._02.security.SecurityEventNotification;
 import ocpp._2022._02.security.SignCertificate;
@@ -42,7 +41,7 @@ import ocpp.cs._2015._10.MeterValuesRequest;
 import ocpp.cs._2015._10.StartTransactionRequest;
 import ocpp.cs._2015._10.StatusNotificationRequest;
 import ocpp.cs._2015._10.StopTransactionRequest;
-import org.springframework.context.ApplicationEventPublisher;
+import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -50,24 +49,31 @@ import org.springframework.stereotype.Component;
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 13.03.2018
  */
+@Slf4j
 @Component
 @Conditional(OcppEnabledCondition.V16.Json.class)
-public class Ocpp16WebSocketEndpoint extends AbstractWebSocketEndpoint {
+public class Ocpp16Handler implements OcppCallHandler {
 
     private final CentralSystemService16_SoapServer server;
 
-    public Ocpp16WebSocketEndpoint(OcppServerRepository ocppServerRepository,
-                                   FutureResponseContextStore futureResponseContextStore,
-                                   ApplicationEventPublisher applicationEventPublisher,
-                                   CentralSystemService16_SoapServer server,
-                                   SessionContextStoreHolder sessionContextStoreHolder) {
-        super(ocppServerRepository, futureResponseContextStore, applicationEventPublisher, sessionContextStoreHolder, Ocpp16TypeStore.INSTANCE);
+    public Ocpp16Handler(CentralSystemService16_SoapServer server) {
         this.server = server;
+        log.info("Initialized");
     }
 
     @Override
     public OcppVersion getVersion() {
         return OcppVersion.V_16;
+    }
+
+    @Override
+    public TypeStore getTypeStore() {
+        return Ocpp16TypeStore.INSTANCE;
+    }
+
+    @Override
+    public Logger getLogger() {
+        return log;
     }
 
     @Override

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Deserializer.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Deserializer.java
@@ -145,8 +145,13 @@ public class Deserializer implements Consumer<CommunicationContext> {
             return;
         }
 
-        // find action class
         var typeStore = typeStoreHolder.get(context.getProtocol().getVersion());
+        if (typeStore == null) {
+            // should not happen, means impl or config error
+            throw new SteveException("Unknown protocol version: " + context.getProtocol().getVersion());
+        }
+
+        // find action class
         Class<? extends RequestType> clazz = typeStore.findRequestClass(action);
         if (clazz == null) {
             context.setOutgoingMessage(ErrorFactory.actionNotFound(messageId, action));

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Deserializer.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Deserializer.java
@@ -21,10 +21,11 @@ package de.rwth.idsg.steve.ocpp.ws.pipeline;
 import de.rwth.idsg.ocpp.jaxb.RequestType;
 import de.rwth.idsg.ocpp.jaxb.ResponseType;
 import de.rwth.idsg.steve.SteveException;
+import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.ErrorFactory;
 import de.rwth.idsg.steve.ocpp.ws.FutureResponseContextStore;
 import de.rwth.idsg.steve.ocpp.ws.JsonObjectMapper;
-import de.rwth.idsg.steve.ocpp.ws.SessionContextStore;
+import de.rwth.idsg.steve.ocpp.ws.SessionContextStoreHolder;
 import de.rwth.idsg.steve.ocpp.ws.TypeStore;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import de.rwth.idsg.steve.ocpp.ws.data.ErrorCode;
@@ -33,9 +34,9 @@ import de.rwth.idsg.steve.ocpp.ws.data.MessageType;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonCall;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonError;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonResult;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.JsonToken;
@@ -49,6 +50,9 @@ import tools.jackson.databind.node.ObjectNode;
 
 import jakarta.validation.ConstraintViolationException;
 import java.time.Instant;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -58,14 +62,24 @@ import java.util.function.Consumer;
  * @since 17.03.2015
  */
 @Slf4j
-@RequiredArgsConstructor
+@Component
 public class Deserializer implements Consumer<CommunicationContext> {
 
     private final ObjectMapper mapper = JsonObjectMapper.INSTANCE.getMapper();
+    private final Map<OcppVersion, TypeStore> typeStoreHolder = new EnumMap<>(OcppVersion.class);
 
     private final FutureResponseContextStore futureResponseContextStore;
-    private final SessionContextStore sessionContextStore;
-    private final TypeStore typeStore;
+    private final SessionContextStoreHolder sessionContextStoreHolder;
+
+    public Deserializer(FutureResponseContextStore futureResponseContextStore,
+                        SessionContextStoreHolder sessionContextStoreHolder,
+                        List<OcppCallHandler> handlers) {
+        this.futureResponseContextStore = futureResponseContextStore;
+        this.sessionContextStoreHolder = sessionContextStoreHolder;
+        for (OcppCallHandler handler : handlers) {
+            typeStoreHolder.put(handler.getVersion(), handler.getTypeStore());
+        }
+    }
 
     /**
      * Parsing with streaming API is cumbersome, but only it allows to parse the String step for step
@@ -109,6 +123,7 @@ public class Deserializer implements Consumer<CommunicationContext> {
             return;
         }
 
+        var sessionContextStore = sessionContextStoreHolder.getOrCreate(context.getProtocol().getVersion());
         Boolean success = sessionContextStore.registerIncomingCallId(context.getChargeBoxId(), context.getSession(), messageId);
         if (success == null) {
             log.warn("No session context found while registering incoming CALL messageId '{}' for sessionId '{}'", messageId, context.getSession().getId());
@@ -131,6 +146,7 @@ public class Deserializer implements Consumer<CommunicationContext> {
         }
 
         // find action class
+        var typeStore = typeStoreHolder.get(context.getProtocol().getVersion());
         Class<? extends RequestType> clazz = typeStore.findRequestClass(action);
         if (clazz == null) {
             context.setOutgoingMessage(ErrorFactory.actionNotFound(messageId, action));

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/IncomingPipeline.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/IncomingPipeline.java
@@ -20,14 +20,18 @@ package de.rwth.idsg.steve.ocpp.ws.pipeline;
 
 import de.rwth.idsg.ocpp.jaxb.ResponseType;
 import de.rwth.idsg.steve.SteveException;
+import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonCall;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonError;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonResult;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import jakarta.xml.ws.Response;
+import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -39,14 +43,23 @@ import java.util.function.Consumer;
  * @since 23.03.2015
  */
 @Slf4j
-@RequiredArgsConstructor
+@Component
 public class IncomingPipeline implements Consumer<CommunicationContext> {
 
     private final Serializer serializer = Serializer.INSTANCE;
     private final Sender sender = Sender.INSTANCE;
 
     private final Deserializer deserializer;
-    private final OcppCallHandler handler;
+    private final Map<OcppVersion, OcppCallHandler> handlerMap = new EnumMap<>(OcppVersion.class);
+
+    @Autowired
+    public IncomingPipeline(Deserializer deserializer,
+                            List<OcppCallHandler> handlers) {
+        this.deserializer = deserializer;
+        for (OcppCallHandler handler : handlers) {
+            handlerMap.put(handler.getVersion(), handler);
+        }
+    }
 
     @Override
     public void accept(CommunicationContext context) {
@@ -77,6 +90,8 @@ public class IncomingPipeline implements Consumer<CommunicationContext> {
     }
 
     private void processCall(CommunicationContext context, OcppJsonCall call) {
+        var handler = handlerMap.get(context.getProtocol().getVersion());
+
         handler.accept(context);
         serializer.accept(context);
         sender.accept(context);

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/IncomingPipeline.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/IncomingPipeline.java
@@ -91,6 +91,10 @@ public class IncomingPipeline implements Consumer<CommunicationContext> {
 
     private void processCall(CommunicationContext context, OcppJsonCall call) {
         var handler = handlerMap.get(context.getProtocol().getVersion());
+        if (handler == null) {
+            // should not happen, means impl or config error
+            throw new SteveException("Unknown protocol version: " + context.getProtocol().getVersion());
+        }
 
         handler.accept(context);
         serializer.accept(context);

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/OcppCallHandler.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/OcppCallHandler.java
@@ -20,7 +20,9 @@ package de.rwth.idsg.steve.ocpp.ws.pipeline;
 
 import de.rwth.idsg.ocpp.jaxb.RequestType;
 import de.rwth.idsg.ocpp.jaxb.ResponseType;
+import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.ErrorFactory;
+import de.rwth.idsg.steve.ocpp.ws.TypeStore;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonCall;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonResult;
@@ -53,6 +55,10 @@ public interface OcppCallHandler extends Consumer<CommunicationContext> {
         result.setMessageId(messageId);
         context.setOutgoingMessage(result);
     }
+
+    OcppVersion getVersion();
+
+    TypeStore getTypeStore();
 
     Logger getLogger();
 

--- a/src/test/java/de/rwth/idsg/steve/ocpp/ws/pipeline/DeserializerTest.java
+++ b/src/test/java/de/rwth/idsg/steve/ocpp/ws/pipeline/DeserializerTest.java
@@ -18,8 +18,10 @@
  */
 package de.rwth.idsg.steve.ocpp.ws.pipeline;
 
+import de.rwth.idsg.steve.ocpp.OcppProtocol;
 import de.rwth.idsg.steve.ocpp.ws.FutureResponseContextStoreImpl;
 import de.rwth.idsg.steve.ocpp.ws.SessionContextStore;
+import de.rwth.idsg.steve.ocpp.ws.SessionContextStoreHolder;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonCall;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonError;
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.web.socket.adapter.jetty.JettyWebSocketSession;
 
+import java.util.List;
 import java.util.UUID;
 
 import static de.rwth.idsg.steve.ocpp.ws.data.ErrorCode.FormationViolation;
@@ -49,7 +52,7 @@ public class DeserializerTest {
     public void testValidation_Ocpp16TypoInEnum() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo");
+        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
         context.setIncomingString("""
             [2, "abc1","StatusNotification",{"connectorId":1,"status":"Faultd","errorCode":"NoError","info":"","timestamp":"2026-01-01T07:00:00.000Z","vendorId":"","vendorErrorCode":""}]
             """);
@@ -69,7 +72,7 @@ public class DeserializerTest {
     public void testValidation_Ocpp16MeterValueCascade() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo");
+        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
         context.setIncomingString("""
             [2,"abc2","MeterValues",{"connectorId":1,"meterValue":[{"timestamp":"2026-02-13T15:17:02.501+01:00"}]}]
             """);
@@ -89,7 +92,7 @@ public class DeserializerTest {
     public void testValidation_Ocpp16IdTagMissing() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo");
+        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
         context.setIncomingString("""
             [2,"abc3","Authorize",{"idTag":null}]
             """);
@@ -109,7 +112,7 @@ public class DeserializerTest {
     public void testValidation_BrokenPayload() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo");
+        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
         context.setIncomingString("""
             [2,"abc4","Authorize",{"idTag":"A1B.....]
             """);
@@ -129,7 +132,7 @@ public class DeserializerTest {
     public void testValidation_DuplicateMessageId() {
         Deserializer des = createDeserializer(false);
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo");
+        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
         context.setIncomingString("""
             [2,"dup1","Heartbeat",{}]
             """);
@@ -149,7 +152,7 @@ public class DeserializerTest {
     public void testValidation_UnknownSessionContextForMessageIdStore() {
         Deserializer des = createDeserializer(null);
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo");
+        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
         context.setIncomingString("""
             [2,"unknown1","Heartbeat",{}]
             """);
@@ -169,7 +172,7 @@ public class DeserializerTest {
     public void testValidation_FirstSeenMessageIdAccepted() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo");
+        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
         context.setIncomingString("""
             [2,"ok1","Heartbeat",{}]
             """);
@@ -185,7 +188,7 @@ public class DeserializerTest {
     public void testValidation_EmptyMessageIdRejected() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo");
+        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
         context.setIncomingString("""
             [2,"","Heartbeat",{}]
             """);
@@ -205,7 +208,7 @@ public class DeserializerTest {
     public void testValidation_NullMessageIdRejected() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo");
+        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
         context.setIncomingString("""
             [2,null,"Heartbeat",{}]
             """);
@@ -231,7 +234,14 @@ public class DeserializerTest {
         SessionContextStore store = Mockito.mock(SessionContextStore.class);
         when(store.registerIncomingCallId(any(), any(), any())).thenReturn(registerIncomingCallIdResponse);
 
-        return new Deserializer(futureResponseContextStore, store, Ocpp16TypeStore.INSTANCE);
+        SessionContextStoreHolder holder = Mockito.mock(SessionContextStoreHolder.class);
+        when(holder.getOrCreate(OcppProtocol.V_16_JSON.getVersion())).thenReturn(store);
+
+        OcppCallHandler handler = Mockito.mock(OcppCallHandler.class);
+        when(handler.getVersion()).thenReturn(OcppProtocol.V_16_JSON.getVersion());
+        when(handler.getTypeStore()).thenReturn(Ocpp16TypeStore.INSTANCE);
+
+        return new Deserializer(futureResponseContextStore, holder, List.of(handler));
     }
 
     private static JettyWebSocketSession getMockSession() {

--- a/src/test/java/de/rwth/idsg/steve/utils/OcppJsonChargePoint.java
+++ b/src/test/java/de/rwth/idsg/steve/utils/OcppJsonChargePoint.java
@@ -22,6 +22,7 @@ import com.google.common.net.HttpHeaders;
 import de.rwth.idsg.ocpp.jaxb.RequestType;
 import de.rwth.idsg.ocpp.jaxb.ResponseType;
 import de.rwth.idsg.steve.ocpp.OcppSecurityProfile;
+import de.rwth.idsg.steve.ocpp.OcppTransport;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.JsonObjectMapper;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
@@ -556,7 +557,11 @@ public class OcppJsonChargePoint {
         private final CountDownLatch doneSignal = new CountDownLatch(1);
 
         public ExchangeContext(@NotNull WebSocketSession session, @NotNull String chargeBoxId) {
-            super(session, chargeBoxId);
+            super(
+                session,
+                chargeBoxId,
+                OcppVersion.fromValue(session.getAcceptedProtocol()).toProtocol(OcppTransport.JSON)
+            );
         }
 
         public REQ await() {


### PR DESCRIPTION
relates to: https://github.com/steve-community/steve/issues/2104

Before: one WebSocket endpoint + pipeline per OCPP version

After:  one shared WebSocket endpoint
          → one shared pipeline
          → version-specific OCPP handler