### PR TITLE
refactor websocket pipelines around message-oriented contexts

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/ChargePointServiceJsonInvoker.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/ChargePointServiceJsonInvoker.java
@@ -72,6 +72,7 @@ public class ChargePointServiceJsonInvoker {
         var chargeBoxId = cps.getChargeBoxId();
 
         var sessionStore = sessionContextStoreHolder.getOrCreate(cps.getOcppProtocol().getVersion());
+        var session = sessionStore.getSession(chargeBoxId);
 
         var typeStore = switch (cps.getOcppProtocol().getVersion()) {
             case V_12 -> Ocpp12TypeStore.INSTANCE;
@@ -95,15 +96,15 @@ public class ChargePointServiceJsonInvoker {
         call.setPayload(request);
         call.setAction(pair.getAction());
 
-        FutureResponseContext frc = new FutureResponseContext(task, pair.getResponseClass());
-
-        CommunicationContext context = new CommunicationContext(
-            sessionStore.getSession(chargeBoxId),
-            chargeBoxId,
-            cps.getOcppProtocol()
+        var context = new CommunicationContext.OutCall(
+            new CommunicationContext.StationRoute(
+                session.getId(),
+                chargeBoxId,
+                cps.getOcppProtocol()
+            ),
+            call,
+            new FutureResponseContext(task, pair.getResponseClass())
         );
-        context.setOutgoingMessage(call);
-        context.setFutureResponseContext(frc);
 
         outgoingCallPipeline.accept(context);
     }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/FutureResponseContextStore.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/FutureResponseContextStore.java
@@ -32,7 +32,7 @@ public interface FutureResponseContextStore {
 
     void removeSession(WebSocketSession session);
 
-    void add(WebSocketSession session, String messageId, FutureResponseContext context);
+    void add(String webSocketSessionId, String messageId, FutureResponseContext context);
 
-    @Nullable FutureResponseContext poll(WebSocketSession session, String messageId);
+    @Nullable FutureResponseContext poll(String webSocketSessionId, String messageId);
 }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/FutureResponseContextStoreImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/FutureResponseContextStoreImpl.java
@@ -39,46 +39,46 @@ import java.util.concurrent.ConcurrentHashMap;
 public class FutureResponseContextStoreImpl implements FutureResponseContextStore {
 
     // We store for each chargeBox connection, multiple pairs of (messageId, context)
-    // (session, (messageId, context))
-    private final Map<WebSocketSession, Map<String, FutureResponseContext>> lookupTable = new ConcurrentHashMap<>();
+    // (webSocketSessionId, (messageId, context))
+    private final Map<String, Map<String, FutureResponseContext>> lookupTable = new ConcurrentHashMap<>();
 
     @Override
     public void addSession(WebSocketSession session) {
-        addIfAbsent(session);
+        addIfAbsent(session.getId());
     }
 
     @Override
     public void removeSession(WebSocketSession session) {
         log.debug("Deleting the store for sessionId '{}'", session.getId());
-        lookupTable.remove(session);
+        lookupTable.remove(session.getId());
     }
 
     /**
      * Adds/updates a correlation entry and performs opportunistic stale-entry cleanup on the write path.
      */
     @Override
-    public void add(WebSocketSession session, String messageId, FutureResponseContext context) {
-        var map = addIfAbsent(session);
+    public void add(String webSocketSessionId, String messageId, FutureResponseContext context) {
+        var map = addIfAbsent(webSocketSessionId);
         evictTimedOutEntries(map);
         map.put(messageId, context);
-        log.debug("Store size for sessionId '{}': {}", session.getId(), map.size());
+        log.debug("Store size for sessionId '{}': {}", webSocketSessionId, map.size());
     }
 
     @Nullable
     @Override
-    public FutureResponseContext poll(WebSocketSession session, String messageId) {
-        var map = lookupTable.get(session);
+    public FutureResponseContext poll(String webSocketSessionId, String messageId) {
+        var map = lookupTable.get(webSocketSessionId);
         if (map == null) {
             return null;
         }
         FutureResponseContext removedContext = map.remove(messageId);
-        log.debug("Store size for sessionId '{}': {}", session.getId(), map.size());
+        log.debug("Store size for sessionId '{}': {}", webSocketSessionId, map.size());
         return removedContext;
     }
 
-    private Map<String, FutureResponseContext> addIfAbsent(WebSocketSession session) {
-        return lookupTable.computeIfAbsent(session, innerSession -> {
-            log.debug("Creating new store for sessionId '{}'", innerSession.getId());
+    private Map<String, FutureResponseContext> addIfAbsent(String webSocketSessionId) {
+        return lookupTable.computeIfAbsent(webSocketSessionId, innerSessionId -> {
+            log.debug("Creating new store for sessionId '{}'", innerSessionId);
             return new ConcurrentHashMap<>();
         });
     }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/FutureResponseContextStoreImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/FutureResponseContextStoreImpl.java
@@ -27,9 +27,15 @@ import org.springframework.web.socket.WebSocketSession;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Presumption: The responses must be sent using the same connection as the requests!
+ * Stores pending request/response correlations per WebSocket session. Responses must be handled
+ * using the same connection as their corresponding requests.
+ * <p>
+ * Updates to the outer map use {@link ConcurrentHashMap} atomic operations so additions and
+ * removals for the same session cannot interfere with each other. Empty per-session stores are
+ * removed after their final correlation entry is polled.
  *
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 21.03.2015
@@ -54,33 +60,54 @@ public class FutureResponseContextStoreImpl implements FutureResponseContextStor
     }
 
     /**
-     * Adds/updates a correlation entry and performs opportunistic stale-entry cleanup on the write path.
+     * Adds or updates a correlation entry and performs opportunistic stale-entry cleanup on the
+     * write path. The outer-map computation makes the complete update atomic for this session ID.
      */
     @Override
     public void add(String webSocketSessionId, String messageId, FutureResponseContext context) {
-        var map = addIfAbsent(webSocketSessionId);
-        evictTimedOutEntries(map);
-        map.put(messageId, context);
-        log.debug("Store size for sessionId '{}': {}", webSocketSessionId, map.size());
+        lookupTable.compute(webSocketSessionId, (sessionId, map) -> {
+            if (map == null) {
+                map = createStore(sessionId);
+            }
+
+            evictTimedOutEntries(map);
+            map.put(messageId, context);
+            log.debug("Store size for sessionId '{}': {}", sessionId, map.size());
+            return map;
+        });
     }
 
+    /**
+     * Atomically removes and returns a correlation entry. Returning {@code null} from the
+     * outer-map computation removes the per-session store when it becomes empty, preventing
+     * failed-send rollbacks from leaving empty session maps behind.
+     */
     @Nullable
     @Override
     public FutureResponseContext poll(String webSocketSessionId, String messageId) {
-        var map = lookupTable.get(webSocketSessionId);
-        if (map == null) {
-            return null;
-        }
-        FutureResponseContext removedContext = map.remove(messageId);
-        log.debug("Store size for sessionId '{}': {}", webSocketSessionId, map.size());
-        return removedContext;
+        var removedContext = new AtomicReference<FutureResponseContext>();
+        lookupTable.computeIfPresent(webSocketSessionId, (sessionId, map) -> {
+            removedContext.set(map.remove(messageId));
+            log.debug("Store size for sessionId '{}': {}", sessionId, map.size());
+            return map.isEmpty() ? null : map;
+        });
+        return removedContext.get();
+    }
+
+    /**
+     * For tests only
+     */
+    boolean containsKey(String webSocketSessionId) {
+        return lookupTable.containsKey(webSocketSessionId);
     }
 
     private Map<String, FutureResponseContext> addIfAbsent(String webSocketSessionId) {
-        return lookupTable.computeIfAbsent(webSocketSessionId, innerSessionId -> {
-            log.debug("Creating new store for sessionId '{}'", innerSessionId);
-            return new ConcurrentHashMap<>();
-        });
+        return lookupTable.computeIfAbsent(webSocketSessionId, this::createStore);
+    }
+
+    private Map<String, FutureResponseContext> createStore(String webSocketSessionId) {
+        log.debug("Creating new store for sessionId '{}'", webSocketSessionId);
+        return new ConcurrentHashMap<>();
     }
 
     /**

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/IncomingMessageIdStore.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/IncomingMessageIdStore.java
@@ -90,8 +90,8 @@ public class IncomingMessageIdStore {
         lookupBySessionId.remove(session.getId());
     }
 
-    Boolean registerIncomingCallId(WebSocketSession session, @NotNull String messageId) {
-        LongOpenHashSet set = lookupBySessionId.get(session.getId());
+    Boolean registerIncomingCallId(String webSocketSessionId, @NotNull String messageId) {
+        LongOpenHashSet set = lookupBySessionId.get(webSocketSessionId);
         if (set == null) {
             // return null in order to stop processing this message. if the set is null, we clearly don't know this
             // session. it might imply some add/remove race or some other unexpected edge case.
@@ -107,7 +107,7 @@ public class IncomingMessageIdStore {
         if (maxTrackedMessageIdsPerSession != null && set.size() > maxTrackedMessageIdsPerSession) {
             throw new SteveException(
                 "Incoming CALL messageId limit of %s exceeded for session '%s'",
-                maxTrackedMessageIdsPerSession, session.getId()
+                maxTrackedMessageIdsPerSession, webSocketSessionId
             );
         }
         return true;

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStore.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStore.java
@@ -20,6 +20,7 @@ package de.rwth.idsg.steve.ocpp.ws;
 
 import de.rwth.idsg.steve.ocpp.ws.data.SessionContext;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.util.Collection;
@@ -44,7 +45,9 @@ public interface SessionContextStore {
 
     WebSocketSession getSession(String chargeBoxId);
 
-    Boolean registerIncomingCallId(String chargeBoxId, WebSocketSession session, @NotNull String messageId);
+    @Nullable WebSocketSession getSession(String chargeBoxId, String webSocketSessionId);
+
+    Boolean registerIncomingCallId(String chargeBoxId, String webSocketSessionId, @NotNull String messageId);
 
     boolean closeSession(String chargeBoxId, String sessionId);
 

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreImpl.java
@@ -26,6 +26,7 @@ import de.rwth.idsg.steve.ocpp.ws.data.SessionContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.joda.time.DateTime;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.web.socket.WebSocketSession;
@@ -152,11 +153,32 @@ public class SessionContextStoreImpl implements SessionContextStore {
     }
 
     @Override
-    public Boolean registerIncomingCallId(String chargeBoxId, WebSocketSession session, @NotNull String messageId) {
+    @Nullable
+    public WebSocketSession getSession(String chargeBoxId, String webSocketSessionId) {
         Lock l = locks.get(chargeBoxId);
         l.lock();
         try {
-            return messageIdStore.registerIncomingCallId(session, messageId);
+            Deque<SessionContext> endpointDeque = lookupTable.get(chargeBoxId);
+            if (endpointDeque == null) {
+                return null;
+            }
+            for (SessionContext context : endpointDeque) {
+                if (context.getSession().getId().equals(webSocketSessionId)) {
+                    return context.getSession();
+                }
+            }
+            return null;
+        } finally {
+            l.unlock();
+        }
+    }
+
+    @Override
+    public Boolean registerIncomingCallId(String chargeBoxId, String webSocketSessionId, @NotNull String messageId) {
+        Lock l = locks.get(chargeBoxId);
+        l.lock();
+        try {
+            return messageIdStore.registerIncomingCallId(webSocketSessionId, messageId);
         } finally {
             l.unlock();
         }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketEndpoint.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketEndpoint.java
@@ -94,14 +94,16 @@ public class WebSocketEndpoint extends ConcurrentWebSocketHandler implements Sub
 
         WebSocketLogger.receivedText(chargeBoxId, session, incomingString);
 
-        CommunicationContext context = new CommunicationContext(
-            session,
-            chargeBoxId,
-            version.toProtocol(OcppTransport.JSON)
+        var inMsg = new CommunicationContext.In(
+            new CommunicationContext.StationRoute(
+                session.getId(),
+                chargeBoxId,
+                version.toProtocol(OcppTransport.JSON)
+            ),
+            incomingString
         );
-        context.setIncomingString(incomingString);
 
-        incomingPipeline.accept(context);
+        incomingPipeline.accept(inMsg);
     }
 
     private void handlePongMessage(WebSocketSession session) {

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketLogger.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketLogger.java
@@ -46,8 +46,8 @@ public final class WebSocketLogger {
         log.info("[chargeBoxId={}, sessionId={}] Sending: {}", chargeBoxId, session.getId(), msg);
     }
 
-    public static void willNotSend(String chargeBoxId, WebSocketSession session, String msg) {
-        log.warn("[chargeBoxId={}, sessionId={}] Attempted to send to closed session: {}", chargeBoxId, session.getId(), msg);
+    public static void willNotSend(String chargeBoxId, String webSocketSessionId, String msg) {
+        log.warn("[chargeBoxId={}, sessionId={}] Attempted to send to closed session: {}", chargeBoxId, webSocketSessionId, msg);
     }
 
     public static void sendingPing(String chargeBoxId, WebSocketSession session) {

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/CommunicationContext.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/CommunicationContext.java
@@ -20,10 +20,7 @@ package de.rwth.idsg.steve.ocpp.ws.data;
 
 import de.rwth.idsg.steve.ocpp.OcppProtocol;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import org.jetbrains.annotations.NotNull;
-import org.springframework.web.socket.WebSocketSession;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Default holder/context of incoming and outgoing messages.
@@ -31,28 +28,94 @@ import org.springframework.web.socket.WebSocketSession;
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 23.03.2015
  */
-@RequiredArgsConstructor
-@Getter
 public class CommunicationContext {
 
-    @NotNull private final WebSocketSession session;
-    @NotNull private final String chargeBoxId;
-    @NotNull private final OcppProtocol protocol;
+    // -------------------------------------------------------------------------
+    // Raw messages. These are queue-friendly and can be serialized
+    // -------------------------------------------------------------------------
 
-    @Setter private String incomingString;
-    @Setter private String outgoingString;
+    public record StationRoute(
+        String webSocketSessionId,
+        String chargeBoxId,
+        OcppProtocol protocol
+    ) {
+    }
 
-    @Setter private OcppJsonMessage incomingMessage;
-    @Setter private OcppJsonMessage outgoingMessage;
+    public record In(
+        StationRoute route,
+        String payload
+    ) {
+    }
 
-    /**
-     * This is only relevant for requests CSMS sends.
-     * During the outgoing pipeline, we create an instance of this and store it.
-     * During the incoming pipeline (response from station to request), we restore and reference it.
-     */
-    @Setter private FutureResponseContext futureResponseContext;
+    public record Out(
+        StationRoute route,
+        String payload,
+        MessageType messageType
+    ) {
+    }
 
-    public boolean isSetOutgoingError() {
-        return (outgoingMessage != null) && (outgoingMessage instanceof OcppJsonError);
+    // -------------------------------------------------------------------------
+    // In-process data holders
+    // -------------------------------------------------------------------------
+
+    public sealed interface DeserializationResult {
+
+    }
+
+    public record InCall(
+        In in,
+        OcppJsonCall call
+    ) implements DeserializationResult {
+    }
+
+    public record InResult(
+        In in,
+        OcppJsonResult result,
+        FutureResponseContext frc
+    ) implements DeserializationResult {
+    }
+
+    public record InError(
+        In in,
+        OcppJsonError error,
+        FutureResponseContext frc
+    ) implements DeserializationResult {
+    }
+
+    public record OutCall(
+        StationRoute route,
+        OcppJsonCall call,
+        FutureResponseContext frc
+    ) {
+    }
+
+    // -------------------------------------------------------------------------
+    // Custom exceptions
+    // -------------------------------------------------------------------------
+
+    public static class JsonCallParseException extends Exception {
+
+        @Getter
+        private final OcppJsonError parseError;
+
+        public JsonCallParseException(OcppJsonError parseError) {
+            this.parseError = parseError;
+        }
+    }
+
+    public static class JsonResponseInvalidException extends Exception {
+
+        @Getter
+        private final FutureResponseContext frc;
+
+        public JsonResponseInvalidException(String msg, @Nullable FutureResponseContext frc) {
+            super(msg);
+            this.frc = frc;
+        }
+
+        public JsonResponseInvalidException(String msg, Throwable cause, @Nullable FutureResponseContext frc) {
+            super(msg, cause);
+            this.frc = frc;
+        }
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Deserializer.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Deserializer.java
@@ -21,13 +21,13 @@ package de.rwth.idsg.steve.ocpp.ws.pipeline;
 import de.rwth.idsg.ocpp.jaxb.RequestType;
 import de.rwth.idsg.ocpp.jaxb.ResponseType;
 import de.rwth.idsg.steve.SteveException;
+import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.ErrorFactory;
 import de.rwth.idsg.steve.ocpp.ws.FutureResponseContextStore;
 import de.rwth.idsg.steve.ocpp.ws.JsonObjectMapper;
 import de.rwth.idsg.steve.ocpp.ws.SessionContextStoreHolder;
 import de.rwth.idsg.steve.ocpp.ws.TypeStore;
-import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import de.rwth.idsg.steve.ocpp.ws.data.ErrorCode;
 import de.rwth.idsg.steve.ocpp.ws.data.FutureResponseContext;
 import de.rwth.idsg.steve.ocpp.ws.data.MessageType;
@@ -53,7 +53,6 @@ import java.time.Instant;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 /**
  * Incoming String --> OcppJsonMessage
@@ -63,7 +62,7 @@ import java.util.function.Consumer;
  */
 @Slf4j
 @Component
-public class Deserializer implements Consumer<CommunicationContext> {
+public class Deserializer {
 
     private final ObjectMapper mapper = JsonObjectMapper.INSTANCE.getMapper();
     private final Map<OcppVersion, TypeStore> typeStoreHolder = new EnumMap<>(OcppVersion.class);
@@ -85,9 +84,8 @@ public class Deserializer implements Consumer<CommunicationContext> {
      * Parsing with streaming API is cumbersome, but only it allows to parse the String step for step
      * and build, if any, a corresponding error message.
      */
-    @Override
-    public void accept(CommunicationContext context) {
-        try (JsonParser parser = mapper.createParser(context.getIncomingString())) {
+    public CommunicationContext.DeserializationResult accept(CommunicationContext.In inMsg) throws CommunicationContext.JsonCallParseException, CommunicationContext.JsonResponseInvalidException {
+        try (JsonParser parser = mapper.createParser(inMsg.payload())) {
             parser.nextToken(); // set cursor to '['
 
             parser.nextToken();
@@ -96,13 +94,11 @@ public class Deserializer implements Consumer<CommunicationContext> {
             parser.nextToken();
             String messageId = parser.getString();
 
-            switch (MessageType.fromTypeNr(messageTypeNr)) {
-                case CALL -> handleCall(context, messageId, parser);
-                case CALL_RESULT -> handleResult(context, messageId, parser);
-                case CALL_ERROR -> handleError(context, messageId, parser);
-            }
-        } catch (Exception e) {
-            throw new SteveException("Deserialization of incoming string failed: %s", context.getIncomingString(), e);
+            return switch (MessageType.fromTypeNr(messageTypeNr)) {
+                case CALL -> handleCall(inMsg, messageId, parser);
+                case CALL_RESULT -> handleResult(inMsg, messageId, parser);
+                case CALL_ERROR -> handleError(inMsg, messageId, parser);
+            };
         }
     }
 
@@ -113,25 +109,28 @@ public class Deserializer implements Consumer<CommunicationContext> {
     /**
      * Catch exceptions and wrap them in outgoing ERRORs for incoming CALLs.
      */
-    private void handleCall(CommunicationContext context, String messageId, JsonParser parser) {
+    private CommunicationContext.InCall handleCall(CommunicationContext.In inMsg, String messageId,
+                                                   JsonParser parser) throws CommunicationContext.JsonCallParseException {
+        OcppVersion version = inMsg.route().protocol().getVersion();
+
         // Enforce OCPP CALL messageId as a non-empty JSON string.
         // messageId must be a usable request identifier, so null or empty should be treated as invalid.
         // Token-type check avoids accepting VALUE_NULL cases that can be exposed as text like "null" by streaming accessors.
         JsonToken messageIdToken = parser.currentToken();
         if (messageIdToken != JsonToken.VALUE_STRING || StringUtils.isEmpty(messageId)) {
-            context.setOutgoingMessage(ErrorFactory.invalidMessageId(messageIdToken == JsonToken.VALUE_STRING ? messageId : null));
-            return;
+            var error = ErrorFactory.invalidMessageId(messageIdToken == JsonToken.VALUE_STRING ? messageId : null);
+            throw new CommunicationContext.JsonCallParseException(error);
         }
 
-        var sessionContextStore = sessionContextStoreHolder.getOrCreate(context.getProtocol().getVersion());
-        Boolean success = sessionContextStore.registerIncomingCallId(context.getChargeBoxId(), context.getSession(), messageId);
+        var sessionContextStore = sessionContextStoreHolder.getOrCreate(version);
+        Boolean success = sessionContextStore.registerIncomingCallId(inMsg.route().chargeBoxId(), inMsg.route().webSocketSessionId(), messageId);
         if (success == null) {
-            log.warn("No session context found while registering incoming CALL messageId '{}' for sessionId '{}'", messageId, context.getSession().getId());
-            context.setOutgoingMessage(ErrorFactory.payloadProcessingError(messageId, null));
-            return;
+            log.warn("No session context found while registering incoming CALL messageId '{}' for sessionId '{}'", messageId, inMsg.route().webSocketSessionId());
+            var error = ErrorFactory.payloadProcessingError(messageId, null);
+            throw new CommunicationContext.JsonCallParseException(error);
         } else if (!success) {
-            context.setOutgoingMessage(ErrorFactory.duplicateCallMessageId(messageId));
-            return;
+            var error = ErrorFactory.duplicateCallMessageId(messageId);
+            throw new CommunicationContext.JsonCallParseException(error);
         }
 
         // parse action
@@ -141,21 +140,21 @@ public class Deserializer implements Consumer<CommunicationContext> {
             action = parser.getString();
         } catch (JacksonException e) {
             log.error("Exception occurred", e);
-            context.setOutgoingMessage(ErrorFactory.genericDeserializeError(messageId, e.getMessage()));
-            return;
+            var error = ErrorFactory.genericDeserializeError(messageId, e.getMessage());
+            throw new CommunicationContext.JsonCallParseException(error);
         }
 
-        var typeStore = typeStoreHolder.get(context.getProtocol().getVersion());
+        var typeStore = typeStoreHolder.get(version);
         if (typeStore == null) {
             // should not happen, means impl or config error
-            throw new SteveException("Unknown protocol version: " + context.getProtocol().getVersion());
+            throw new SteveException("Unknown protocol version: " + version);
         }
 
         // find action class
         Class<? extends RequestType> clazz = typeStore.findRequestClass(action);
         if (clazz == null) {
-            context.setOutgoingMessage(ErrorFactory.actionNotFound(messageId, action));
-            return;
+            var error = ErrorFactory.actionNotFound(messageId, action);
+            throw new CommunicationContext.JsonCallParseException(error);
         }
 
         // parse request payload
@@ -172,12 +171,12 @@ public class Deserializer implements Consumer<CommunicationContext> {
             req = mapper.treeToValue(requestPayload, clazz);
         } catch (ConstraintViolationException | DatabindException e) {
             log.error("Exception occurred", e);
-            context.setOutgoingMessage(ErrorFactory.propertyConstraintViolation(messageId, getDetails(e)));
-            return;
+            var error = ErrorFactory.propertyConstraintViolation(messageId, getDetails(e));
+            throw new CommunicationContext.JsonCallParseException(error);
         } catch (JacksonException e) {
             log.error("Exception occurred", e);
-            context.setOutgoingMessage(ErrorFactory.payloadDeserializeError(messageId, null));
-            return;
+            var error = ErrorFactory.payloadDeserializeError(messageId, null);
+            throw new CommunicationContext.JsonCallParseException(error);
         }
 
         OcppJsonCall call = new OcppJsonCall();
@@ -185,16 +184,17 @@ public class Deserializer implements Consumer<CommunicationContext> {
         call.setAction(action);
         call.setPayload(req);
 
-        context.setIncomingMessage(call);
+        return new CommunicationContext.InCall(inMsg, call);
     }
 
     /**
      * Do NOT catch and handle exceptions for incoming RESPONSEs. Let the processing fail.
      * There is no mechanism in OCPP to report back such erroneous messages.
      */
-    private void handleResult(CommunicationContext context, String messageId, JsonParser parser) {
-        FutureResponseContext responseContext = futureResponseContextStore.poll(context.getSession(), messageId);
-        validate(context, responseContext);
+    private CommunicationContext.InResult handleResult(CommunicationContext.In inMsg, String messageId,
+                                                       JsonParser parser) throws CommunicationContext.JsonResponseInvalidException {
+        FutureResponseContext responseContext = futureResponseContextStore.poll(inMsg.route().webSocketSessionId(), messageId);
+        validate(responseContext);
 
         ResponseType res;
         try {
@@ -202,23 +202,24 @@ public class Deserializer implements Consumer<CommunicationContext> {
             JsonNode responsePayload = parser.readValueAsTree();
             res = mapper.treeToValue(responsePayload, responseContext.getResponseClass());
         } catch (JacksonException e) {
-            throw new SteveException("Deserialization of incoming response payload failed", e);
+            throw new CommunicationContext.JsonResponseInvalidException("Deserialization of incoming response payload failed", e, responseContext);
         }
 
         OcppJsonResult result = new OcppJsonResult();
         result.setMessageId(messageId);
         result.setPayload(res);
 
-        context.setIncomingMessage(result);
+        return new CommunicationContext.InResult(inMsg, result, responseContext);
     }
 
     /**
      * Do NOT catch and handle exceptions for incoming RESPONSEs. Let the processing fail.
      * There is no mechanism in OCPP to report back such erroneous messages.
      */
-    private void handleError(CommunicationContext context, String messageId, JsonParser parser) {
-        FutureResponseContext responseContext = futureResponseContextStore.poll(context.getSession(), messageId);
-        validate(context, responseContext);
+    private CommunicationContext.InError handleError(CommunicationContext.In inMsg, String messageId,
+                                                     JsonParser parser) throws CommunicationContext.JsonResponseInvalidException {
+        FutureResponseContext responseContext = futureResponseContextStore.poll(inMsg.route().webSocketSessionId(), messageId);
+        validate(responseContext);
 
         ErrorCode code;
         String desc;
@@ -245,8 +246,8 @@ public class Deserializer implements Consumer<CommunicationContext> {
                 details = mapper.writeValueAsString(detailsNode);
             }
 
-        } catch (JacksonException e) {
-            throw new SteveException("Deserialization of incoming error message failed", e);
+        } catch (Exception e) {
+            throw new CommunicationContext.JsonResponseInvalidException("Deserialization of incoming error message failed", e, responseContext);
         }
 
         OcppJsonError error = new OcppJsonError();
@@ -255,7 +256,7 @@ public class Deserializer implements Consumer<CommunicationContext> {
         error.setErrorDescription(desc);
         error.setErrorDetails(details);
 
-        context.setIncomingMessage(error);
+        return new CommunicationContext.InError(inMsg, error, responseContext);
     }
 
     private static String getDetails(Exception e) {
@@ -272,16 +273,14 @@ public class Deserializer implements Consumer<CommunicationContext> {
      * Ensures incoming responses map only to active, non-stale calls.
      * Unknown or expired correlations are rejected to prevent accidental matching.
      */
-    private static void validate(CommunicationContext cc, FutureResponseContext frc) {
+    private static void validate(FutureResponseContext frc) throws CommunicationContext.JsonResponseInvalidException {
         if (frc == null) {
-            throw new SteveException("A response message was received to a not-sent call");
+            throw new CommunicationContext.JsonResponseInvalidException("A response message was received to a not-sent call", null);
         }
 
-        // set this before throwing the next exception, because IncomingPipeline will need it to handle and propagate.
-        cc.setFutureResponseContext(frc);
-
         if (frc.hasTimedOut(Instant.now())) {
-            throw new SteveException("A response message was received to an expired call");
+            // carry frc with this exception, because IncomingPipeline will need it to handle and propagate.
+            throw new CommunicationContext.JsonResponseInvalidException("A response message was received to an expired call", frc);
         }
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/IncomingPipeline.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/IncomingPipeline.java
@@ -20,11 +20,8 @@ package de.rwth.idsg.steve.ocpp.ws.pipeline;
 
 import de.rwth.idsg.ocpp.jaxb.ResponseType;
 import de.rwth.idsg.steve.SteveException;
-import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
-import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonCall;
-import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonError;
-import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonResult;
+import de.rwth.idsg.steve.ocpp.OcppVersion;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -34,7 +31,6 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 /**
  * For all incoming message types.
@@ -44,75 +40,79 @@ import java.util.function.Consumer;
  */
 @Slf4j
 @Component
-public class IncomingPipeline implements Consumer<CommunicationContext> {
+public class IncomingPipeline {
 
     private final Serializer serializer = Serializer.INSTANCE;
-    private final Sender sender = Sender.INSTANCE;
 
+    private final Sender sender;
     private final Deserializer deserializer;
     private final Map<OcppVersion, OcppCallHandler> handlerMap = new EnumMap<>(OcppVersion.class);
 
     @Autowired
-    public IncomingPipeline(Deserializer deserializer,
+    public IncomingPipeline(Sender sender,
+                            Deserializer deserializer,
                             List<OcppCallHandler> handlers) {
+        this.sender = sender;
         this.deserializer = deserializer;
         for (OcppCallHandler handler : handlers) {
             handlerMap.put(handler.getVersion(), handler);
         }
     }
 
-    @Override
-    public void accept(CommunicationContext context) {
+    public void accept(CommunicationContext.In inMsg) {
+        CommunicationContext.DeserializationResult inMsgData;
         try {
-            deserializer.accept(context);
-        } catch (SteveException e) {
-            // do not let OcppCallbacks hang. try to inform them when the response from the station cannot be parsed.
-            var frc = context.getFutureResponseContext();
-            if (frc != null) {
-                frc.getTask().failed(context.getChargeBoxId(), e);
-            }
-            throw e;
-        }
+            inMsgData = deserializer.accept(inMsg);
 
-        // When the incoming could not be deserialized
-        if (context.isSetOutgoingError()) {
-            serializer.accept(context);
-            sender.accept(context);
+        } catch (CommunicationContext.JsonCallParseException e) {
+            var parseError = e.getParseError();
+            var parseErrorStr = serializer.accept(parseError);
+            sender.accept(new CommunicationContext.Out(inMsg.route(), parseErrorStr, parseError.getMessageType()));
             return;
+
+        } catch (CommunicationContext.JsonResponseInvalidException e) {
+            var frc = e.getFrc();
+            if (frc != null) {
+                frc.getTask().failed(inMsg.route().chargeBoxId(), e);
+            }
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new SteveException("Deserialization of incoming string failed: %s", inMsg.payload(), e);
         }
 
-        switch (context.getIncomingMessage()) {
-            case OcppJsonCall call -> processCall(context, call);
-            case OcppJsonResult result -> processResult(context, result);
-            case OcppJsonError error -> processError(context, error);
-            default -> log.warn("Unexpected value: {}", context.getIncomingMessage());
+        switch (inMsgData) {
+            case CommunicationContext.InCall call -> processCall(call);
+            case CommunicationContext.InResult result -> processResult(result);
+            case CommunicationContext.InError error -> processError(error);
         }
     }
 
-    private void processCall(CommunicationContext context, OcppJsonCall call) {
-        var handler = handlerMap.get(context.getProtocol().getVersion());
+    private void processCall(CommunicationContext.InCall data) {
+        var version = data.in().route().protocol().getVersion();
+
+        var handler = handlerMap.get(version);
         if (handler == null) {
             // should not happen, means impl or config error
-            throw new SteveException("Unknown protocol version: " + context.getProtocol().getVersion());
+            throw new SteveException("Unknown protocol version: " + version);
         }
 
-        handler.accept(context);
-        serializer.accept(context);
-        sender.accept(context);
+        var response = handler.accept(data);
+        var responseStr = serializer.accept(response);
+        sender.accept(new CommunicationContext.Out(data.in().route(), responseStr, response.getMessageType()));
     }
 
     @SuppressWarnings("unchecked")
-    private void processResult(CommunicationContext context, OcppJsonResult result) {
-        context.getFutureResponseContext()
+    private void processResult(CommunicationContext.InResult data) {
+        data.frc()
             .getTask()
-            .getHandler(context.getChargeBoxId())
-            .handleResponse(new DummyResponse(result.getPayload()));
+            .getHandler(data.in().route().chargeBoxId())
+            .handleResponse(new DummyResponse(data.result().getPayload()));
     }
 
-    private void processError(CommunicationContext context, OcppJsonError error) {
-        context.getFutureResponseContext()
+    private void processError(CommunicationContext.InError data) {
+        data.frc()
             .getTask()
-            .success(context.getChargeBoxId(), error);
+            .success(data.in().route().chargeBoxId(), data.error());
     }
 
     private record DummyResponse(ResponseType payload) implements Response<ResponseType> {

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/OcppCallHandler.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/OcppCallHandler.java
@@ -20,40 +20,37 @@ package de.rwth.idsg.steve.ocpp.ws.pipeline;
 
 import de.rwth.idsg.ocpp.jaxb.RequestType;
 import de.rwth.idsg.ocpp.jaxb.ResponseType;
+import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.ErrorFactory;
 import de.rwth.idsg.steve.ocpp.ws.TypeStore;
-import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonCall;
+import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonResponse;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonResult;
 import org.slf4j.Logger;
-
-import java.util.function.Consumer;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 17.03.2015
  */
-public interface OcppCallHandler extends Consumer<CommunicationContext> {
+public interface OcppCallHandler {
 
-    @Override
-    default void accept(CommunicationContext context) {
-        OcppJsonCall call = (OcppJsonCall) context.getIncomingMessage();
+    default OcppJsonResponse accept(CommunicationContext.InCall data) {
+        OcppJsonCall call = data.call();
         String messageId = call.getMessageId();
 
         ResponseType response;
         try {
-            response = dispatch(call.getPayload(), context.getChargeBoxId());
+            response = dispatch(call.getPayload(), data.in().route().chargeBoxId());
         } catch (Exception e) {
             getLogger().error("Exception occurred", e);
-            context.setOutgoingMessage(ErrorFactory.payloadProcessingError(messageId, null));
-            return;
+            return ErrorFactory.payloadProcessingError(messageId, null);
         }
 
         OcppJsonResult result = new OcppJsonResult();
         result.setPayload(response);
         result.setMessageId(messageId);
-        context.setOutgoingMessage(result);
+        return result;
     }
 
     OcppVersion getVersion();

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/OutgoingCallPipeline.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/OutgoingCallPipeline.java
@@ -18,12 +18,10 @@
  */
 package de.rwth.idsg.steve.ocpp.ws.pipeline;
 
-import de.rwth.idsg.steve.ocpp.ws.FutureResponseContextStore;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
+import de.rwth.idsg.steve.ocpp.ws.FutureResponseContextStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import java.util.function.Consumer;
 
 /**
  * For outgoing CALLs, triggered by the user.
@@ -33,34 +31,44 @@ import java.util.function.Consumer;
  */
 @RequiredArgsConstructor
 @Component
-public class OutgoingCallPipeline implements Consumer<CommunicationContext> {
+public class OutgoingCallPipeline {
 
+    private final Sender sender;
     private final FutureResponseContextStore store;
 
     /**
      * Uses a store-before-send strategy to close response-correlation races.
      * If transport sending fails, the stored context is rolled back immediately.
      */
-    @Override
-    public void accept(CommunicationContext ctx) {
+    public void accept(CommunicationContext.OutCall outWithCall) {
         // 1. Create the payload to send
-        Serializer.INSTANCE.accept(ctx);
+        String outMsg = Serializer.INSTANCE.accept(outWithCall.call());
 
         // 2. Store the response context for later lookup.
         store.add(
-            ctx.getSession(),
-            ctx.getOutgoingMessage().getMessageId(),
-            ctx.getFutureResponseContext()
+            outWithCall.route().webSocketSessionId(),
+            outWithCall.call().getMessageId(),
+            outWithCall.frc()
         );
 
         // 3. Send the payload via WebSocket
         try {
-            if (!Sender.INSTANCE.accept(ctx)) {
-                store.poll(ctx.getSession(), ctx.getOutgoingMessage().getMessageId());
+            var out = new CommunicationContext.Out(
+                outWithCall.route(),
+                outMsg,
+                outWithCall.call().getMessageType()
+            );
+
+            if (!sender.accept(out)) {
+                poll(outWithCall);
             }
         } catch (Exception e) {
-            store.poll(ctx.getSession(), ctx.getOutgoingMessage().getMessageId());
+            poll(outWithCall);
             throw e;
         }
+    }
+
+    private void poll(CommunicationContext.OutCall outWithCall) {
+        store.poll(outWithCall.route().webSocketSessionId(), outWithCall.call().getMessageId());
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Sender.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Sender.java
@@ -19,24 +19,27 @@
 package de.rwth.idsg.steve.ocpp.ws.pipeline;
 
 import de.rwth.idsg.steve.SteveException;
-import de.rwth.idsg.steve.ocpp.ws.WebSocketLogger;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
-import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonCall;
+import de.rwth.idsg.steve.ocpp.ws.SessionContextStoreHolder;
+import de.rwth.idsg.steve.ocpp.ws.WebSocketLogger;
+import de.rwth.idsg.steve.ocpp.ws.data.MessageType;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 import org.springframework.web.socket.TextMessage;
-import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
 
 /**
- * This class should remain stateless.
- *
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 12.03.2015
  */
 @Slf4j
-public enum Sender {
-    INSTANCE;
+@Component
+@RequiredArgsConstructor
+public class Sender {
+
+    private final SessionContextStoreHolder sessionContextStoreHolder;
 
     /**
      * Return value is used by callers to decide whether they must rollback any pre-send bookkeeping.
@@ -44,14 +47,17 @@ public enum Sender {
      *
      * @return whether the message was actually sent or not
      */
-    public boolean accept(CommunicationContext context) {
-        String outgoingString = context.getOutgoingString();
-        String chargeBoxId = context.getChargeBoxId();
-        WebSocketSession session = context.getSession();
+    public boolean accept(CommunicationContext.Out outMsg) {
+        String outgoingString = outMsg.payload();
+        String chargeBoxId = outMsg.route().chargeBoxId();
+        String webSocketSessionId = outMsg.route().webSocketSessionId();
+
+        var sessionStore = sessionContextStoreHolder.getOrCreate(outMsg.route().protocol().getVersion());
+        var session = sessionStore.getSession(chargeBoxId, webSocketSessionId);
 
         // https://github.com/steve-community/steve/issues/1914
-        if (!session.isOpen()) {
-            WebSocketLogger.willNotSend(chargeBoxId, session, outgoingString);
+        if (session == null || !session.isOpen()) {
+            WebSocketLogger.willNotSend(chargeBoxId, webSocketSessionId, outgoingString);
             return false;
         }
 
@@ -62,7 +68,7 @@ public enum Sender {
             return true;
         } catch (IOException e) {
             // Do NOT swallow exceptions for outgoing CALLs. For others just log.
-            if (context.getOutgoingMessage() instanceof OcppJsonCall) {
+            if (outMsg.messageType() == MessageType.CALL) {
                 throw new SteveException("OCPP CALL failed", e);
             } else {
                 log.error("Could not send the outgoing message", e);

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Serializer.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Serializer.java
@@ -21,8 +21,6 @@ package de.rwth.idsg.steve.ocpp.ws.pipeline;
 import de.rwth.idsg.steve.SteveException;
 import de.rwth.idsg.steve.ocpp.ws.ErrorFactory;
 import de.rwth.idsg.steve.ocpp.ws.JsonObjectMapper;
-import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
-import de.rwth.idsg.steve.ocpp.ws.data.MessageType;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonCall;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonError;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonMessage;
@@ -34,8 +32,6 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
 
-import java.util.function.Consumer;
-
 /**
  * Outgoing OcppJsonMessage --> String.
  *
@@ -45,15 +41,12 @@ import java.util.function.Consumer;
  * @since 17.03.2015
  */
 @Slf4j
-public enum Serializer implements Consumer<CommunicationContext> {
+public enum Serializer {
     INSTANCE;
 
     private final ObjectMapper mapper = JsonObjectMapper.INSTANCE.getMapper();
 
-    @Override
-    public void accept(CommunicationContext context) {
-        OcppJsonMessage message = context.getOutgoingMessage();
-
+    public String accept(OcppJsonMessage message) {
         ArrayNode str = switch (message) {
             case OcppJsonCall call -> handleCall(call);
             case OcppJsonResult result -> handleResult(result);
@@ -62,8 +55,7 @@ public enum Serializer implements Consumer<CommunicationContext> {
         };
 
         try {
-            String result = mapper.writeValueAsString(str);
-            context.setOutgoingString(result);
+            return mapper.writeValueAsString(str);
         } catch (JacksonException e) {
             throw new SteveException("The outgoing message could not be serialized", e);
         }

--- a/src/test/java/de/rwth/idsg/steve/ocpp/ws/FutureResponseContextStoreImplTest.java
+++ b/src/test/java/de/rwth/idsg/steve/ocpp/ws/FutureResponseContextStoreImplTest.java
@@ -1,0 +1,56 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.ocpp.ws;
+
+import de.rwth.idsg.steve.ocpp.ws.data.FutureResponseContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class FutureResponseContextStoreImplTest {
+
+    @Test
+    public void pollRemovesEmptySessionStore() {
+        var store = new FutureResponseContextStoreImpl();
+        var context = mock(FutureResponseContext.class);
+
+        store.add("session", "message", context);
+
+        assertSame(context, store.poll("session", "message"));
+        assertFalse(store.containsKey("session"));
+    }
+
+    @Test
+    public void pollKeepsSessionStoreWhileItContainsOtherEntries() {
+        var store = new FutureResponseContextStoreImpl();
+        var firstContext = mock(FutureResponseContext.class);
+        var secondContext = mock(FutureResponseContext.class);
+
+        store.add("session", "first", firstContext);
+        store.add("session", "second", secondContext);
+
+        assertSame(firstContext, store.poll("session", "first"));
+        assertTrue(store.containsKey("session"));
+        assertSame(secondContext, store.poll("session", "second"));
+        assertFalse(store.containsKey("session"));
+    }
+}

--- a/src/test/java/de/rwth/idsg/steve/ocpp/ws/pipeline/DeserializerTest.java
+++ b/src/test/java/de/rwth/idsg/steve/ocpp/ws/pipeline/DeserializerTest.java
@@ -25,12 +25,10 @@ import de.rwth.idsg.steve.ocpp.ws.SessionContextStoreHolder;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonCall;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonError;
-import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonMessage;
 import de.rwth.idsg.steve.ocpp.ws.ocpp16.Ocpp16TypeStore;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.springframework.web.socket.adapter.jetty.JettyWebSocketSession;
 
 import java.util.List;
 import java.util.UUID;
@@ -52,18 +50,10 @@ public class DeserializerTest {
     public void testValidation_Ocpp16TypoInEnum() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
-        context.setIncomingString("""
+        OcppJsonError error = deserializeError(des, """
             [2, "abc1","StatusNotification",{"connectorId":1,"status":"Faultd","errorCode":"NoError","info":"","timestamp":"2026-01-01T07:00:00.000Z","vendorId":"","vendorErrorCode":""}]
             """);
 
-        des.accept(context);
-
-        OcppJsonMessage outgoingMessage = context.getOutgoingMessage();
-        Assertions.assertNotNull(outgoingMessage);
-        Assertions.assertInstanceOf(OcppJsonError.class, outgoingMessage);
-
-        OcppJsonError error = (OcppJsonError) outgoingMessage;
         Assertions.assertEquals(PropertyConstraintViolation, error.getErrorCode());
         Assertions.assertEquals("Invalid payload value (cannot understand one field)", error.getErrorDetails());
     }
@@ -72,18 +62,10 @@ public class DeserializerTest {
     public void testValidation_Ocpp16MeterValueCascade() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
-        context.setIncomingString("""
+        OcppJsonError error = deserializeError(des, """
             [2,"abc2","MeterValues",{"connectorId":1,"meterValue":[{"timestamp":"2026-02-13T15:17:02.501+01:00"}]}]
             """);
 
-        des.accept(context);
-
-        OcppJsonMessage outgoingMessage = context.getOutgoingMessage();
-        Assertions.assertNotNull(outgoingMessage);
-        Assertions.assertInstanceOf(OcppJsonError.class, outgoingMessage);
-
-        OcppJsonError error = (OcppJsonError) outgoingMessage;
         Assertions.assertEquals(PropertyConstraintViolation, error.getErrorCode());
         Assertions.assertEquals("Violation of field constraints", error.getErrorDetails());
     }
@@ -92,18 +74,10 @@ public class DeserializerTest {
     public void testValidation_Ocpp16IdTagMissing() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
-        context.setIncomingString("""
+        OcppJsonError error = deserializeError(des, """
             [2,"abc3","Authorize",{"idTag":null}]
             """);
 
-        des.accept(context);
-
-        OcppJsonMessage outgoingMessage = context.getOutgoingMessage();
-        Assertions.assertNotNull(outgoingMessage);
-        Assertions.assertInstanceOf(OcppJsonError.class, outgoingMessage);
-
-        OcppJsonError error = (OcppJsonError) outgoingMessage;
         Assertions.assertEquals(PropertyConstraintViolation, error.getErrorCode());
         Assertions.assertEquals("Violation of field constraints", error.getErrorDetails());
     }
@@ -112,18 +86,10 @@ public class DeserializerTest {
     public void testValidation_BrokenPayload() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
-        context.setIncomingString("""
+        OcppJsonError error = deserializeError(des, """
             [2,"abc4","Authorize",{"idTag":"A1B.....]
             """);
 
-        des.accept(context);
-
-        OcppJsonMessage outgoingMessage = context.getOutgoingMessage();
-        Assertions.assertNotNull(outgoingMessage);
-        Assertions.assertInstanceOf(OcppJsonError.class, outgoingMessage);
-
-        OcppJsonError error = (OcppJsonError) outgoingMessage;
         Assertions.assertEquals(FormationViolation, error.getErrorCode());
         Assertions.assertNull(error.getErrorDetails());
     }
@@ -132,18 +98,10 @@ public class DeserializerTest {
     public void testValidation_DuplicateMessageId() {
         Deserializer des = createDeserializer(false);
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
-        context.setIncomingString("""
+        OcppJsonError error = deserializeError(des, """
             [2,"dup1","Heartbeat",{}]
             """);
 
-        des.accept(context);
-
-        OcppJsonMessage outgoingMessage = context.getOutgoingMessage();
-        Assertions.assertNotNull(outgoingMessage);
-        Assertions.assertInstanceOf(OcppJsonError.class, outgoingMessage);
-
-        OcppJsonError error = (OcppJsonError) outgoingMessage;
         Assertions.assertEquals(ProtocolError, error.getErrorCode());
         Assertions.assertEquals("dup1", error.getMessageId());
     }
@@ -152,18 +110,10 @@ public class DeserializerTest {
     public void testValidation_UnknownSessionContextForMessageIdStore() {
         Deserializer des = createDeserializer(null);
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
-        context.setIncomingString("""
+        OcppJsonError error = deserializeError(des, """
             [2,"unknown1","Heartbeat",{}]
             """);
 
-        des.accept(context);
-
-        OcppJsonMessage outgoingMessage = context.getOutgoingMessage();
-        Assertions.assertNotNull(outgoingMessage);
-        Assertions.assertInstanceOf(OcppJsonError.class, outgoingMessage);
-
-        OcppJsonError error = (OcppJsonError) outgoingMessage;
         Assertions.assertEquals(InternalError, error.getErrorCode());
         Assertions.assertEquals("unknown1", error.getMessageId());
     }
@@ -172,34 +122,22 @@ public class DeserializerTest {
     public void testValidation_FirstSeenMessageIdAccepted() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
-        context.setIncomingString("""
+        CommunicationContext.DeserializationResult result = Assertions.assertDoesNotThrow(() -> des.accept(inbound("""
             [2,"ok1","Heartbeat",{}]
-            """);
+            """)));
 
-        des.accept(context);
-
-        Assertions.assertNull(context.getOutgoingMessage());
-        Assertions.assertNotNull(context.getIncomingMessage());
-        Assertions.assertInstanceOf(OcppJsonCall.class, context.getIncomingMessage());
+        CommunicationContext.InCall call = Assertions.assertInstanceOf(CommunicationContext.InCall.class, result);
+        Assertions.assertInstanceOf(OcppJsonCall.class, call.call());
     }
 
     @Test
     public void testValidation_EmptyMessageIdRejected() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
-        context.setIncomingString("""
+        OcppJsonError error = deserializeError(des, """
             [2,"","Heartbeat",{}]
             """);
 
-        des.accept(context);
-
-        OcppJsonMessage outgoingMessage = context.getOutgoingMessage();
-        Assertions.assertNotNull(outgoingMessage);
-        Assertions.assertInstanceOf(OcppJsonError.class, outgoingMessage);
-
-        OcppJsonError error = (OcppJsonError) outgoingMessage;
         Assertions.assertEquals(FormationViolation, error.getErrorCode());
         Assertions.assertEquals("", error.getMessageId());
     }
@@ -208,20 +146,29 @@ public class DeserializerTest {
     public void testValidation_NullMessageIdRejected() {
         Deserializer des = createDeserializer();
 
-        CommunicationContext context = new CommunicationContext(getMockSession(), "foo", OcppProtocol.V_16_JSON);
-        context.setIncomingString("""
+        OcppJsonError error = deserializeError(des, """
             [2,null,"Heartbeat",{}]
             """);
 
-        des.accept(context);
-
-        OcppJsonMessage outgoingMessage = context.getOutgoingMessage();
-        Assertions.assertNotNull(outgoingMessage);
-        Assertions.assertInstanceOf(OcppJsonError.class, outgoingMessage);
-
-        OcppJsonError error = (OcppJsonError) outgoingMessage;
         Assertions.assertEquals(FormationViolation, error.getErrorCode());
         Assertions.assertNull(error.getMessageId());
+    }
+
+    private static OcppJsonError deserializeError(Deserializer deserializer, String payload) {
+        var exception = Assertions.assertThrows(
+            CommunicationContext.JsonCallParseException.class,
+            () -> deserializer.accept(inbound(payload))
+        );
+        return exception.getParseError();
+    }
+
+    private static CommunicationContext.In inbound(String payload) {
+        var route = new CommunicationContext.StationRoute(
+            UUID.randomUUID().toString(),
+            "foo",
+            OcppProtocol.V_16_JSON
+        );
+        return new CommunicationContext.In(route, payload);
     }
 
     private static Deserializer createDeserializer() {
@@ -242,13 +189,6 @@ public class DeserializerTest {
         when(handler.getTypeStore()).thenReturn(Ocpp16TypeStore.INSTANCE);
 
         return new Deserializer(futureResponseContextStore, holder, List.of(handler));
-    }
-
-    private static JettyWebSocketSession getMockSession() {
-        JettyWebSocketSession session = Mockito.mock(JettyWebSocketSession.class);
-        when(session.isOpen()).thenReturn(true);
-        when(session.getId()).thenReturn(UUID.randomUUID().toString());
-        return session;
     }
 
 }

--- a/src/test/java/de/rwth/idsg/steve/utils/OcppJsonChargePoint.java
+++ b/src/test/java/de/rwth/idsg/steve/utils/OcppJsonChargePoint.java
@@ -22,10 +22,8 @@ import com.google.common.net.HttpHeaders;
 import de.rwth.idsg.ocpp.jaxb.RequestType;
 import de.rwth.idsg.ocpp.jaxb.ResponseType;
 import de.rwth.idsg.steve.ocpp.OcppSecurityProfile;
-import de.rwth.idsg.steve.ocpp.OcppTransport;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.JsonObjectMapper;
-import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import de.rwth.idsg.steve.ocpp.ws.data.ErrorCode;
 import de.rwth.idsg.steve.ocpp.ws.data.MessageType;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonCall;
@@ -54,8 +52,6 @@ import org.jetbrains.annotations.Nullable;
 import org.opentest4j.AssertionFailedError;
 import org.springframework.boot.web.server.Ssl;
 import org.springframework.util.CollectionUtils;
-import org.springframework.web.socket.WebSocketSession;
-import org.springframework.web.socket.adapter.jetty.JettyWebSocketSession;
 import tools.jackson.core.JsonParser;
 import tools.jackson.core.TreeNode;
 import tools.jackson.databind.JsonNode;
@@ -69,7 +65,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Deque;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -270,15 +265,12 @@ public class OcppJsonChargePoint {
         call.setPayload(payload);
         call.setAction(action);
 
-        JettyWebSocketSession webSocketSession = new JettyWebSocketSession(Map.of());
-        webSocketSession.initializeNativeSession(session);
-
-        ExchangeContext<REQ, RES> ctx = new ExchangeContext<>(webSocketSession, chargeBoxId);
+        ExchangeContext<REQ, RES> ctx = new ExchangeContext<>();
         ctx.setOutgoingMessage(call);
         ctx.setResponseClass(responseClass);
         exchangeQueue.add(ctx);
 
-        Serializer.INSTANCE.accept(ctx);
+        ctx.setOutgoingString(Serializer.INSTANCE.accept(call));
 
         try {
             session.sendText(ctx.getOutgoingString(), NOOP);
@@ -310,10 +302,7 @@ public class OcppJsonChargePoint {
         call.setAction(getOperationName(requestClass));
         call.setPayload(expectedRequest);
 
-        JettyWebSocketSession webSocketSession = new JettyWebSocketSession(Map.of());
-        webSocketSession.initializeNativeSession(session);
-
-        ExchangeContext<REQ, RES> ctx = new ExchangeContext<>(webSocketSession, chargeBoxId);
+        ExchangeContext<REQ, RES> ctx = new ExchangeContext<>();
         ctx.setIncomingMessage(call);
         ctx.setOutgoingMessage(preparedResponse);
         ctx.setRequestClass(requestClass);
@@ -490,7 +479,7 @@ public class OcppJsonChargePoint {
         var outgoing = exchangeContext.getOutgoingMessage();
         outgoing.setMessageId(messageId);
 
-        Serializer.INSTANCE.accept(exchangeContext);
+        exchangeContext.setOutgoingString(Serializer.INSTANCE.accept(outgoing));
 
         try {
             session.sendText(exchangeContext.getOutgoingString(), NOOP);
@@ -550,19 +539,14 @@ public class OcppJsonChargePoint {
 
     @Getter(AccessLevel.PRIVATE)
     @Setter(AccessLevel.PRIVATE)
-    public final class ExchangeContext<REQ extends RequestType, RES extends ResponseType> extends CommunicationContext {
+    public final class ExchangeContext<REQ extends RequestType, RES extends ResponseType> {
 
         private Class<REQ> requestClass;
         private Class<RES> responseClass;
+        private OcppJsonMessage incomingMessage;
+        private OcppJsonMessage outgoingMessage;
+        private String outgoingString;
         private final CountDownLatch doneSignal = new CountDownLatch(1);
-
-        public ExchangeContext(@NotNull WebSocketSession session, @NotNull String chargeBoxId) {
-            super(
-                session,
-                chargeBoxId,
-                OcppVersion.fromValue(session.getAcceptedProtocol()).toProtocol(OcppTransport.JSON)
-            );
-        }
 
         public REQ await() {
             // wait for the call to arrive and be responded with


### PR DESCRIPTION
relates to: https://github.com/steve-community/steve/issues/2104

Split and replace the mutable CommunicationContext with queue-friendly records for inbound and outbound OCPP messages.

- separate raw transport messages from in-process deserialization results
- identify WebSocket sessions by route and session ID
- make deserialization return explicit call, result, or error values
- carry response correlation context through processing failures
- make serialization return payload strings directly
- resolve live WebSocket sessions only when sending
- adapt incoming and outgoing pipelines to the new message contracts
- update tests and the JSON charge point test client