### PR TITLE
feat(api): expose reservation resource operations

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/repository/impl/ReservationRepositoryImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/ReservationRepositoryImpl.java
@@ -283,7 +283,13 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     }
 
     private void processType(SelectQuery selectQuery, ReservationQueryForm form) {
+        if (form.getPeriodType() == null) {
+            return;
+        }
         switch (form.getPeriodType()) {
+            case ALL:
+                break;
+
             case ACTIVE:
                 selectQuery.addConditions(RESERVATION.EXPIRY_DATETIME.greaterThan(DateTime.now()));
                 break;

--- a/src/main/java/de/rwth/idsg/steve/web/api/ReservationsRestController.java
+++ b/src/main/java/de/rwth/idsg/steve/web/api/ReservationsRestController.java
@@ -1,0 +1,139 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.web.api;
+
+import de.rwth.idsg.steve.SteveException;
+import de.rwth.idsg.steve.repository.ReservationRepository;
+import de.rwth.idsg.steve.repository.dto.Reservation;
+import de.rwth.idsg.steve.service.OcppOperationsService;
+import de.rwth.idsg.steve.web.api.ApiControllerAdvice.ApiErrorResponse;
+import de.rwth.idsg.steve.web.dto.OcppOperationResponse;
+import de.rwth.idsg.steve.web.dto.ReservationQueryForm;
+import de.rwth.idsg.steve.web.dto.ocpp.CancelReservationParams;
+import de.rwth.idsg.steve.web.dto.ocpp.ReserveNowParams;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import ocpp.cp._2015._10.CancelReservationStatus;
+import ocpp.cp._2015._10.ReservationStatus;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import java.util.List;
+
+/**
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 21.08.2026
+ */
+@Tag(name = "reservation-controller",
+    description = """
+        Operations related to querying and managing reservations.
+        """
+)
+@Slf4j
+@RestController
+@RequestMapping(value = "/api/v1/reservations", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+public class ReservationsRestController {
+
+    private final ReservationRepository reservationRepository;
+    private final OcppOperationsService operationsService;
+
+    @Operation(description = """
+        Returns a list of reservations based on the query parameters.
+        The query parameters can be used to filter the reservations.
+        """)
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "Bad Request", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class))}),
+        @ApiResponse(responseCode = "401", description = "Unauthorized", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class))}),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class))})}
+    )
+    @GetMapping(value = "")
+    public List<Reservation> get(@Valid @ParameterObject ReservationQueryForm.ReservationQueryFormForApi params) {
+        log.debug("Read request for query: {}", params);
+
+        var response = reservationRepository.getReservations(params);
+        log.debug("Read response for query: {}", response);
+        return response;
+    }
+
+    @Operation(description = """
+        Returns a single reservation based on the reservationPk.
+        """)
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "Bad Request", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class))}),
+        @ApiResponse(responseCode = "401", description = "Unauthorized", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class))}),
+        @ApiResponse(responseCode = "404", description = "Not Found", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class))}),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ApiErrorResponse.class))})}
+    )
+    @GetMapping("/{reservationPk}")
+    public Reservation getOne(@PathVariable("reservationPk") Integer reservationPk) {
+        log.debug("Read request for reservationPk: {}", reservationPk);
+
+        var response = getOneInternal(reservationPk);
+        log.debug("Read response: {}", response);
+        return response;
+    }
+
+    @Operation(description = """
+        Triggers OCPP ReserveNow operation at the charge point.
+        Only 1 charge point can be selected.
+        """)
+    @PostMapping(value = "/reserve-now")
+    public OcppOperationResponse<ReservationStatus> reserveNow(@RequestBody @Valid ReserveNowParams params) throws Exception {
+        var callback = operationsService.reserveNow(params);
+        return OcppOperationResponse.from(callback);
+    }
+
+    @Operation(description = """
+        Triggers OCPP CancelReservation operation at the charge point.
+        Only 1 charge point can be selected.
+        """)
+    @PostMapping(value = "/cancel")
+    public OcppOperationResponse<CancelReservationStatus> cancelReservation(@RequestBody @Valid CancelReservationParams params) throws Exception {
+        var callback = operationsService.cancelReservation(params);
+        return OcppOperationResponse.from(callback);
+    }
+
+    private Reservation getOneInternal(int reservationPk) {
+        ReservationQueryForm.ReservationQueryFormForApi params = new ReservationQueryForm.ReservationQueryFormForApi();
+        params.setReservationId(List.of(reservationPk));
+        params.setPeriodType(ReservationQueryForm.QueryPeriodType.ALL);
+
+        List<Reservation> results = reservationRepository.getReservations(params);
+        if (results.isEmpty()) {
+            throw new SteveException.NotFound("Could not find this reservation");
+        }
+        return results.get(0);
+    }
+}

--- a/src/main/java/de/rwth/idsg/steve/web/dto/ReservationQueryForm.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ReservationQueryForm.java
@@ -83,6 +83,7 @@ public class ReservationQueryForm extends QueryForm {
 
     @RequiredArgsConstructor
     public enum QueryPeriodType {
+        ALL("All"),
         ACTIVE("Active"),
         FROM_TO("From/To");
 
@@ -95,6 +96,15 @@ public class ReservationQueryForm extends QueryForm {
                 }
             }
             throw new IllegalArgumentException(v);
+        }
+    }
+
+    @ToString(callSuper = true)
+    public static class ReservationQueryFormForApi extends ReservationQueryForm {
+
+        public ReservationQueryFormForApi() {
+            super();
+            setPeriodType(QueryPeriodType.ALL);
         }
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/web/dto/ReservationQueryForm.java
+++ b/src/main/java/de/rwth/idsg/steve/web/dto/ReservationQueryForm.java
@@ -50,11 +50,8 @@ public class ReservationQueryForm extends QueryForm {
 
     private QueryPeriodType periodType;
 
-    /**
-     * Init with sensible default values
-     */
-    public ReservationQueryForm() {
-        periodType = QueryPeriodType.ACTIVE;
+    public QueryPeriodType getPeriodType() {
+        return java.util.Objects.requireNonNullElse(periodType, QueryPeriodType.ACTIVE);
     }
 
     @Schema(hidden = true)
@@ -101,10 +98,9 @@ public class ReservationQueryForm extends QueryForm {
 
     @ToString(callSuper = true)
     public static class ReservationQueryFormForApi extends ReservationQueryForm {
-
-        public ReservationQueryFormForApi() {
-            super();
-            setPeriodType(QueryPeriodType.ALL);
+        @Override
+        public QueryPeriodType getPeriodType() {
+            return java.util.Objects.requireNonNullElse(super.getPeriodType(), QueryPeriodType.ALL);
         }
     }
 }

--- a/src/test/java/de/rwth/idsg/steve/web/api/ReservationsRestControllerTest.java
+++ b/src/test/java/de/rwth/idsg/steve/web/api/ReservationsRestControllerTest.java
@@ -1,0 +1,233 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.web.api;
+
+import de.rwth.idsg.steve.repository.ReservationRepository;
+import de.rwth.idsg.steve.repository.dto.Reservation;
+import de.rwth.idsg.steve.service.OcppOperationsService;
+import de.rwth.idsg.steve.web.dto.RestCallback;
+import de.rwth.idsg.steve.web.dto.ocpp.CancelReservationParams;
+import de.rwth.idsg.steve.web.dto.ocpp.ReserveNowParams;
+import ocpp.cp._2015._10.CancelReservationStatus;
+import ocpp.cp._2015._10.ReservationStatus;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 21.08.2026
+ */
+@ExtendWith(MockitoExtension.class)
+public class ReservationsRestControllerTest extends AbstractControllerTest {
+
+    private static final String CONTENT_TYPE = "application/json";
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private OcppOperationsService operationsService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new ReservationsRestController(reservationRepository, operationsService))
+            .setControllerAdvice(new ApiControllerAdvice())
+            .setMessageConverters(new JacksonJsonHttpMessageConverter(objectMapper))
+            .alwaysExpect(content().contentType(CONTENT_TYPE))
+            .build();
+    }
+
+    @Test
+    @DisplayName("GET all: Test with empty results, expected 200")
+    public void test1() throws Exception {
+        when(reservationRepository.getReservations(any())).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/v1/reservations"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET all: Test with one result, expected 200")
+    public void test2() throws Exception {
+        Reservation res = Reservation.builder()
+            .id(42)
+            .chargeBoxId("CP001")
+            .connectorId(1)
+            .ocppIdTag("TAG-001")
+            .status("ACCEPTED")
+            .build();
+
+        when(reservationRepository.getReservations(any())).thenReturn(List.of(res));
+
+        mockMvc.perform(get("/api/v1/reservations"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(1)))
+            .andExpect(jsonPath("$[0].id").value(42))
+            .andExpect(jsonPath("$[0].chargeBoxId").value("CP001"))
+            .andExpect(jsonPath("$[0].connectorId").value(1))
+            .andExpect(jsonPath("$[0].ocppIdTag").value("TAG-001"))
+            .andExpect(jsonPath("$[0].status").value("ACCEPTED"));
+    }
+
+    @Test
+    @DisplayName("GET one: Entity found, expected 200")
+    public void test3() throws Exception {
+        Reservation res = Reservation.builder()
+            .id(42)
+            .chargeBoxId("CP001")
+            .connectorId(1)
+            .ocppIdTag("TAG-001")
+            .status("ACCEPTED")
+            .build();
+
+        when(reservationRepository.getReservations(any())).thenReturn(List.of(res));
+
+        mockMvc.perform(get("/api/v1/reservations/42"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(42))
+            .andExpect(jsonPath("$.chargeBoxId").value("CP001"));
+    }
+
+    @Test
+    @DisplayName("GET one: Entity not found, expected 404")
+    public void test4() throws Exception {
+        when(reservationRepository.getReservations(any())).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/v1/reservations/999"))
+            .andExpect(status().isNotFound())
+            .andExpectAll(errorJsonMatchers());
+    }
+
+    @Test
+    @DisplayName("POST reserve-now: Valid params, expected 200")
+    public void test5() throws Exception {
+        ReserveNowParams params = new ReserveNowParams();
+        params.setChargeBoxIdList(List.of("CP001"));
+        params.setConnectorId(1);
+        params.setIdTag("TAG-001");
+        params.setExpiry(DateTime.now().plusHours(2));
+
+        RestCallback<ReservationStatus> callback = new RestCallback<>(Duration.ofSeconds(1), new CountDownLatch(0));
+        callback.setTaskId(101);
+        when(operationsService.reserveNow(any())).thenReturn(callback);
+
+        mockMvc.perform(
+                post("/api/v1/reservations/reserve-now")
+                    .content(objectMapper.writeValueAsString(params))
+                    .contentType(CONTENT_TYPE)
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.taskId").value(101));
+    }
+
+    @Test
+    @DisplayName("POST reserve-now: Expiry in past, expected 400")
+    public void test6() throws Exception {
+        ReserveNowParams params = new ReserveNowParams();
+        params.setChargeBoxIdList(List.of("CP001"));
+        params.setConnectorId(1);
+        params.setIdTag("TAG-001");
+        params.setExpiry(DateTime.now().minusHours(2));
+
+        mockMvc.perform(
+                post("/api/v1/reservations/reserve-now")
+                    .content(objectMapper.writeValueAsString(params))
+                    .contentType(CONTENT_TYPE)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpectAll(errorJsonMatchers());
+
+        verifyNoInteractions(operationsService);
+    }
+
+    @Test
+    @DisplayName("POST cancel: Valid params, expected 200")
+    public void test7() throws Exception {
+        CancelReservationParams params = new CancelReservationParams();
+        params.setChargeBoxIdList(List.of("CP001"));
+        params.setReservationId(42);
+
+        RestCallback<CancelReservationStatus> callback = new RestCallback<>(Duration.ofSeconds(1), new CountDownLatch(0));
+        callback.setTaskId(102);
+        when(operationsService.cancelReservation(any())).thenReturn(callback);
+
+        mockMvc.perform(
+                post("/api/v1/reservations/cancel")
+                    .content(objectMapper.writeValueAsString(params))
+                    .contentType(CONTENT_TYPE)
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.taskId").value(102));
+    }
+
+    @Test
+    @DisplayName("POST cancel: Missing reservationId, expected 400")
+    public void test8() throws Exception {
+        CancelReservationParams params = new CancelReservationParams();
+        params.setChargeBoxIdList(List.of("CP001"));
+        params.setReservationId(null);
+
+        mockMvc.perform(
+                post("/api/v1/reservations/cancel")
+                    .content(objectMapper.writeValueAsString(params))
+                    .contentType(CONTENT_TYPE)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpectAll(errorJsonMatchers());
+
+        verifyNoInteractions(operationsService);
+    }
+
+    private static ResultMatcher[] errorJsonMatchers() {
+        return new ResultMatcher[]{
+            jsonPath("$.timestamp").exists(),
+            jsonPath("$.status").exists(),
+            jsonPath("$.error").exists(),
+            jsonPath("$.message").exists(),
+            jsonPath("$.path").exists()
+        };
+    }
+}


### PR DESCRIPTION
Fixes #2074

### Motivation
The REST API can trigger `ReserveNow` and `CancelReservation` operations to a charging station via `/api/v1/operations/`, but it did not expose SteVe's persisted reservation state or allow external systems to query and manage active reservations directly via REST resources.

### Summary of Changes
1. **`ReservationsRestController`** (`/api/v1/reservations`):
   - `GET /api/v1/reservations`: Lists and filters persisted reservations with parameters (`chargeBoxId`, `ocppIdTag`, `status`, `periodType`, `reservationId`, pagination).
   - `GET /api/v1/reservations/{reservationPk}`: Retrieves single reservation details by primary key.
   - `POST /api/v1/reservations/reserve-now`: Triggers OCPP `ReserveNow` message to charge box.
   - `POST /api/v1/reservations/cancel`: Triggers OCPP `CancelReservation` message to charge box.
2. **`ReservationQueryFormForApi`**: Added API query model supporting comma-separated filter parsing for REST clients.
3. **Repository & Controller Tests**: Added test cases for query execution and REST controller endpoints.