### PR TITLE
Switch to use maintained nv-i18n package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -615,11 +615,11 @@
         </dependency>
 
         <!-- Codes according to ISO standards
-             https://github.com/TakahikoKawasaki/nv-i18n -->
+             https://github.com/foundationsedge/nv-i18n -->
         <dependency>
-            <groupId>com.neovisionaries</groupId>
+            <groupId>uk.co.foundationsedge</groupId>
             <artifactId>nv-i18n</artifactId>
-            <version>1.29</version>
+            <version>1.33</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The original nv-i18n is no longer being maintained. Our company app relies on it, and needed newly created entries. A colleague and I have forked and published a new version of it. Due to our reliance on it we will be continuing to maintain it.