### PR TITLE
feat(ocpp): make the WebSocket ping interval configurable

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/config/SteveProperties.java
+++ b/src/main/java/de/rwth/idsg/steve/config/SteveProperties.java
@@ -24,6 +24,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.Duration;
+
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 19.08.2014
@@ -69,6 +71,7 @@ public class SteveProperties {
         String chargeBoxIdValidationRegex;
         Protocols enabledProtocols;
         boolean octtQuirksEnabled;
+        Duration wsPingInterval = Duration.ofMinutes(15);
         Security security = new Security();
 
         @Data

--- a/src/main/java/de/rwth/idsg/steve/config/WebSocketConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/WebSocketConfiguration.java
@@ -53,7 +53,6 @@ public class WebSocketConfiguration implements WebSocketConfigurer {
     private final WebSocketEndpoint webSocketEndpoint;
 
     public static final String PATH_INFIX = "/websocket/CentralSystemService/";
-    public static final Duration PING_INTERVAL = Duration.ofMinutes(15);
     public static final Duration IDLE_TIMEOUT = Duration.ofHours(2);
     public static final int MAX_MSG_SIZE = 8_388_608; // 8 MB for max message size
 

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreHolder.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreHolder.java
@@ -24,6 +24,7 @@ import de.rwth.idsg.steve.ocpp.ws.custom.WsSessionSelectStrategy;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
+import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -36,6 +37,7 @@ public class SessionContextStoreHolder {
     private final ConcurrentHashMap<OcppVersion, SessionContextStore> storesPerVersion = new ConcurrentHashMap<>();
 
     private final WsSessionSelectStrategy wsSessionSelectStrategy;
+    private final Duration pingInterval;
     private final TaskScheduler taskScheduler;
     private final FutureResponseContextStore futureResponseContextStore;
 
@@ -43,11 +45,16 @@ public class SessionContextStoreHolder {
                                      TaskScheduler taskScheduler,
                                      FutureResponseContextStore futureResponseContextStore) {
         wsSessionSelectStrategy = steveProperties.getOcpp().getWsSessionSelectStrategy();
+        pingInterval = steveProperties.getOcpp().getWsPingInterval();
         this.taskScheduler = taskScheduler;
         this.futureResponseContextStore = futureResponseContextStore;
     }
 
     public SessionContextStore getOrCreate(OcppVersion version) {
-        return storesPerVersion.computeIfAbsent(version, k -> new SessionContextStoreImpl(wsSessionSelectStrategy, taskScheduler, futureResponseContextStore));
+        return storesPerVersion.computeIfAbsent(
+            version,
+            k -> new SessionContextStoreImpl(
+                wsSessionSelectStrategy, pingInterval, taskScheduler, futureResponseContextStore)
+        );
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreImpl.java
@@ -20,10 +20,8 @@ package de.rwth.idsg.steve.ocpp.ws;
 
 import com.google.common.util.concurrent.Striped;
 import de.rwth.idsg.steve.SteveException;
-import de.rwth.idsg.steve.config.WebSocketConfiguration;
 import de.rwth.idsg.steve.ocpp.ws.custom.WsSessionSelectStrategy;
 import de.rwth.idsg.steve.ocpp.ws.data.SessionContext;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -32,6 +30,7 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Collection;
@@ -49,7 +48,6 @@ import java.util.concurrent.locks.Lock;
  * @since 17.03.2015
  */
 @Slf4j
-@RequiredArgsConstructor
 public class SessionContextStoreImpl implements SessionContextStore {
 
     /**
@@ -61,9 +59,31 @@ public class SessionContextStoreImpl implements SessionContextStore {
 
     private final Striped<Lock> locks = Striped.lock(128);
 
+    /**
+     * A sub-second server-side ping is not a keep-alive, it is a flood. {@link Duration#ZERO} disables
+     * pinging altogether.
+     */
+    private static final Duration MIN_PING_INTERVAL = Duration.ofSeconds(1);
+
     private final WsSessionSelectStrategy wsSessionSelectStrategy;
+    private final Duration pingInterval;
     private final TaskScheduler taskScheduler;
     private final FutureResponseContextStore futureResponseContextStore;
+
+    public SessionContextStoreImpl(WsSessionSelectStrategy wsSessionSelectStrategy,
+                                   Duration pingInterval,
+                                   TaskScheduler taskScheduler,
+                                   FutureResponseContextStore futureResponseContextStore) {
+        if (!pingInterval.isZero() && pingInterval.compareTo(MIN_PING_INTERVAL) < 0) {
+            throw new IllegalArgumentException(
+                "Ping interval must be at least " + MIN_PING_INTERVAL + ", or 0 to disable, but was " + pingInterval);
+        }
+
+        this.wsSessionSelectStrategy = wsSessionSelectStrategy;
+        this.pingInterval = pingInterval;
+        this.taskScheduler = taskScheduler;
+        this.futureResponseContextStore = futureResponseContextStore;
+    }
 
     @Override
     public boolean add(String chargeBoxId, WebSocketSession session) {
@@ -75,15 +95,7 @@ public class SessionContextStoreImpl implements SessionContextStore {
                 return false; // we dont want to trigger any action based on this 'bad' session which we did not process anyway
             }
 
-            // Just to keep the connection alive, such that the servers do not close
-            // the connection because of a idle timeout, we ping-pong at fixed intervals.
-            ScheduledFuture<?> pingSchedule = taskScheduler.scheduleAtFixedRate(
-                new PingTask(chargeBoxId, session),
-                Instant.now().plus(WebSocketConfiguration.PING_INTERVAL),
-                WebSocketConfiguration.PING_INTERVAL
-            );
-
-            SessionContext context = new SessionContext(session, pingSchedule, DateTime.now());
+            SessionContext context = new SessionContext(session, schedulePing(chargeBoxId, session), DateTime.now());
 
             Deque<SessionContext> endpointDeque = lookupTable.computeIfAbsent(chargeBoxId, str -> new ArrayDeque<>());
             endpointDeque.addLast(context); // Adding at the end
@@ -113,7 +125,7 @@ public class SessionContextStoreImpl implements SessionContextStore {
             for (var it = endpointDeque.iterator(); it.hasNext();) {
                 SessionContext context = it.next();
                 if (context.getSession().getId().equals(session.getId())) {
-                    context.getPingSchedule().cancel(true);
+                    cancelPing(context);
                     it.remove();
                     log.debug("A SessionContext is removed for chargeBoxId '{}'. Store size: {}", chargeBoxId, endpointDeque.size());
                     break;
@@ -132,6 +144,30 @@ public class SessionContextStoreImpl implements SessionContextStore {
             return endpointDeque.isEmpty();
         } finally {
             l.unlock();
+        }
+    }
+
+    /**
+     * Just to keep the connection alive, such that the servers do not close the connection because of a
+     * idle timeout, we ping-pong at fixed intervals. Returns null when the operator disabled pinging.
+     */
+    @Nullable
+    private ScheduledFuture<?> schedulePing(String chargeBoxId, WebSocketSession session) {
+        if (pingInterval.isZero()) {
+            return null;
+        }
+
+        return taskScheduler.scheduleAtFixedRate(
+            new PingTask(chargeBoxId, session),
+            Instant.now().plus(pingInterval),
+            pingInterval
+        );
+    }
+
+    private static void cancelPing(SessionContext context) {
+        ScheduledFuture<?> pingSchedule = context.getPingSchedule();
+        if (pingSchedule != null) {
+            pingSchedule.cancel(true);
         }
     }
 

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/SessionContext.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/SessionContext.java
@@ -19,6 +19,7 @@
 package de.rwth.idsg.steve.ocpp.ws.data;
 
 import lombok.Getter;
+import org.jetbrains.annotations.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.joda.time.DateTime;
 import org.springframework.web.socket.WebSocketSession;
@@ -33,6 +34,8 @@ import java.util.concurrent.ScheduledFuture;
 @RequiredArgsConstructor
 public class SessionContext {
     private final WebSocketSession session;
-    private final ScheduledFuture pingSchedule;
+    /** Null when the operator disabled server-side pinging. */
+    @Nullable
+    private final ScheduledFuture<?> pingSchedule;
     private final DateTime openSince;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,12 @@ steve:
       v15: { soap: true, json: true }
       v16: { soap: true, json: true }
 
+    # SteVe pings every open WebSocket session at this interval, so that connections which are idle on the
+    # OCPP level are not dropped by the station, or by an intermediary such as a proxy, a load balancer or
+    # a NAT gateway. Managed proxies often close idle WebSockets after 60 to 100 seconds, which is well
+    # below our default. Keep it under the Jetty idle timeout, minimum 1s, or 0 to disable pings entirely.
+    ws-ping-interval: 15m
+
     # OCPP 1.6 security config.
     # Note: security profile (0..3) is a per-charge-point state in DB, not a global application property.
     security:

--- a/src/test/java/de/rwth/idsg/steve/issues/Issue3IT.java
+++ b/src/test/java/de/rwth/idsg/steve/issues/Issue3IT.java
@@ -1,0 +1,143 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.issues;
+
+import de.rwth.idsg.steve.config.WebSocketConfiguration;
+import de.rwth.idsg.steve.ocpp.OcppVersion;
+import de.rwth.idsg.steve.utils.Helpers;
+import de.rwth.idsg.steve.utils.OcppJsonChargePoint;
+import lombok.extern.slf4j.Slf4j;
+import org.joda.time.DateTime;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.web.server.autoconfigure.ServerProperties;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.UUID;
+
+import static jooq.steve.db.tables.ChargeBox.CHARGE_BOX;
+
+/**
+ * Issue 3: the server-side WebSocket keep-alive used to be a hardcoded 15 minutes, which is longer than
+ * the idle timeout of most managed reverse proxies. It is now {@code steve.ocpp.ws-ping-interval}.
+ *
+ * <p>This is the wire-level statement of what the property is for: a station that sends no OCPP message
+ * at all still exchanges ping/pong, and only a ping can move its last heartbeat here — nothing else in
+ * this test talks to the server after the upgrade.
+ *
+ * @see <a href="https://github.com/steve-community/steve/issues/3">Issue 3</a>
+ */
+@Slf4j
+@ActiveProfiles(profiles = "test")
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    properties = "steve.ocpp.ws-ping-interval=1s"
+)
+public class Issue3IT {
+
+    private static final long TIMEOUT_IN_MILLIS = 30_000;
+
+    @Autowired
+    private DSLContext dslContext;
+
+    @Autowired
+    private ServerProperties serverProperties;
+
+    @LocalServerPort
+    private int port;
+
+    private String chargeBoxId;
+
+    @AfterEach
+    public void cleanUp() {
+        if (chargeBoxId != null) {
+            dslContext.deleteFrom(CHARGE_BOX).where(CHARGE_BOX.CHARGE_BOX_ID.equal(chargeBoxId)).execute();
+        }
+    }
+
+    @Test
+    public void idleSessionIsPinged() throws Exception {
+        chargeBoxId = registerStation();
+
+        OcppJsonChargePoint chargePoint = new OcppJsonChargePoint(OcppVersion.V_16, chargeBoxId, jsonPath()).start();
+        try {
+            Assertions.assertNull(lastHeartbeat(chargeBoxId), "precondition: the station never reported yet");
+
+            DateTime heartbeat = awaitHeartbeat(chargeBoxId);
+
+            Assertions.assertNotNull(
+                heartbeat,
+                "an idle session should have been pinged, and the pong should have moved the heartbeat"
+            );
+        } finally {
+            chargePoint.close();
+        }
+    }
+
+    /**
+     * The pong is handled asynchronously, so we poll instead of sleeping for a fixed multiple of the
+     * interval.
+     */
+    private DateTime awaitHeartbeat(String chargeBoxId) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TIMEOUT_IN_MILLIS;
+
+        while (System.currentTimeMillis() < deadline) {
+            DateTime heartbeat = lastHeartbeat(chargeBoxId);
+            if (heartbeat != null) {
+                return heartbeat;
+            }
+            Thread.sleep(250);
+        }
+        return null;
+    }
+
+    private DateTime lastHeartbeat(String chargeBoxId) {
+        return dslContext.select(CHARGE_BOX.LAST_HEARTBEAT_TIMESTAMP)
+            .from(CHARGE_BOX)
+            .where(CHARGE_BOX.CHARGE_BOX_ID.equal(chargeBoxId))
+            .fetchOne(CHARGE_BOX.LAST_HEARTBEAT_TIMESTAMP);
+    }
+
+    private String registerStation() {
+        String id = "issue3_" + UUID.randomUUID().toString().replace("-", "");
+        dslContext.insertInto(CHARGE_BOX)
+            .set(CHARGE_BOX.CHARGE_BOX_ID, id)
+            .execute();
+        return id;
+    }
+
+    /**
+     * Same shape as {@link Helpers#getJsonPath(ServerProperties)}, with the port the server bound rather
+     * than the one it was configured with — the latter is 0 under {@code RANDOM_PORT}.
+     */
+    private String jsonPath() {
+        return "ws:/"
+            + serverProperties.getAddress()
+            + ":"
+            + port
+            + serverProperties.getServlet().getContextPath()
+            + WebSocketConfiguration.PATH_INFIX;
+    }
+}

--- a/src/test/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreTest.java
+++ b/src/test/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreTest.java
@@ -22,21 +22,30 @@ import de.rwth.idsg.steve.ocpp.ws.custom.WsSessionSelectStrategyEnum;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.support.NoOpTaskScheduler;
 import org.springframework.web.socket.adapter.jetty.JettyWebSocketSession;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.UUID;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class SessionContextStoreTest {
+
+    private static final Duration PING_INTERVAL = Duration.ofMinutes(15);
 
     @Test
     public void testAdd() {
         var store = new SessionContextStoreImpl(
             WsSessionSelectStrategyEnum.ALWAYS_LAST,
+            PING_INTERVAL,
             new NoOpTaskScheduler(),
             new FutureResponseContextStoreImpl()
         );
@@ -63,6 +72,7 @@ public class SessionContextStoreTest {
     public void testRemove() {
         var store = new SessionContextStoreImpl(
             WsSessionSelectStrategyEnum.ALWAYS_LAST,
+            PING_INTERVAL,
             new NoOpTaskScheduler(),
             new FutureResponseContextStoreImpl()
         );
@@ -110,6 +120,7 @@ public class SessionContextStoreTest {
     public void testCloseSession() throws Exception {
         var store = new SessionContextStoreImpl(
             WsSessionSelectStrategyEnum.ALWAYS_LAST,
+            PING_INTERVAL,
             new NoOpTaskScheduler(),
             new FutureResponseContextStoreImpl()
         );
@@ -131,6 +142,7 @@ public class SessionContextStoreTest {
     public void testCloseSession_doesNotScanOtherChargeBoxIds() throws Exception {
         var store = new SessionContextStoreImpl(
             WsSessionSelectStrategyEnum.ALWAYS_LAST,
+            PING_INTERVAL,
             new NoOpTaskScheduler(),
             new FutureResponseContextStoreImpl()
         );
@@ -149,6 +161,7 @@ public class SessionContextStoreTest {
     public void testCloseSession_unknownSession() {
         var store = new SessionContextStoreImpl(
             WsSessionSelectStrategyEnum.ALWAYS_LAST,
+            PING_INTERVAL,
             new NoOpTaskScheduler(),
             new FutureResponseContextStoreImpl()
         );
@@ -156,6 +169,52 @@ public class SessionContextStoreTest {
         boolean closed = store.closeSession("foo", "unknown-session");
 
         Assertions.assertFalse(closed);
+    }
+
+    @Test
+    public void testSessionIsPingedAtTheConfiguredInterval() {
+        var taskScheduler = Mockito.mock(TaskScheduler.class);
+        var store = new SessionContextStoreImpl(
+            WsSessionSelectStrategyEnum.ALWAYS_LAST,
+            Duration.ofSeconds(30),
+            taskScheduler,
+            new FutureResponseContextStoreImpl()
+        );
+
+        store.add("foo", getMockSession());
+
+        verify(taskScheduler).scheduleAtFixedRate(any(PingTask.class), any(Instant.class), eq(Duration.ofSeconds(30)));
+    }
+
+    /**
+     * A session added while pinging is disabled has no schedule to cancel on the way out.
+     */
+    @Test
+    public void testZeroIntervalDisablesPings() {
+        var taskScheduler = Mockito.mock(TaskScheduler.class);
+        var store = new SessionContextStoreImpl(
+            WsSessionSelectStrategyEnum.ALWAYS_LAST,
+            Duration.ZERO,
+            taskScheduler,
+            new FutureResponseContextStoreImpl()
+        );
+
+        var session = getMockSession();
+        store.add("foo", session);
+        store.remove("foo", session);
+
+        Assertions.assertEquals(0, store.getSize("foo"));
+        verifyNoInteractions(taskScheduler);
+    }
+
+    @Test
+    public void testRejectsSubSecondInterval() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new SessionContextStoreImpl(
+            WsSessionSelectStrategyEnum.ALWAYS_LAST,
+            Duration.ofMillis(500),
+            new NoOpTaskScheduler(),
+            new FutureResponseContextStoreImpl()
+        ));
     }
 
     private static JettyWebSocketSession getMockSession() {


### PR DESCRIPTION
Closes #3

## Why

The server-side keep-alive is hardcoded to 15 minutes. Behind a managed reverse proxy (Cloudflare, cloud
load balancers, ingresses), idle WebSockets are dropped well before that, and the timeout is often not
tunable. The workaround left to operators is to lower the OCPP `HeartbeatInterval`, which is global to the
installation: every station pays for a constraint that applies to one network path, including the metered
mobile ones @lategoodbye wanted to spare.

## What

One property, `steve.ocpp.ws-ping-interval`, next to the `ws-session-select-strategy` it belongs with.
`0` disables server-side pings entirely; anything below one second is refused, since that is a flood
rather than a keep-alive.

The scheduling stays where it was, in `SessionContextStoreImpl`, and the `ScheduledFuture` stays on
`SessionContext` — null when pinging is disabled, which is the only new case to handle.

`Issue3IT` states it on the wire: a station connects, sends no OCPP message at all, and its last heartbeat
still moves. Only a ping/pong can do that.

8 files, +272/-16, of which 202 lines are the two tests.

## Deliberately left out

- **The idle timeout and the maximum message size.** They were adjacent constants in the same class, not
  something anyone asked for.
- **Virtual-thread execution of the ping**, which answers a different question — what happens when a send
  blocks one of the ten scheduler threads — and is parked in #2122.

## Open points

1. **No jitter.** A fleet reconnecting within seconds of a restart stays aligned forever, so one firing per
   interval pings everybody at once. A random offset at registration is a one-liner if you want it.
2. **This is not #1191.** It does not explain the 45s observed there.

The wiki *Configuration* page would need a line for the new property.

---
*Drafted by Claude under @juherr's supervision.*
