### PR TITLE
perf(ocpp): send WebSocket pings from virtual threads

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/config/BeanConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/BeanConfiguration.java
@@ -40,6 +40,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -167,6 +168,20 @@ public class BeanConfiguration implements WebMvcConfigurer {
         scheduler.setWaitForTasksToCompleteOnShutdown(true);
         scheduler.setAwaitTerminationSeconds(30);
         scheduler.initialize();
+
+        return scheduler;
+    }
+
+    /**
+     * The WebSocket pings are scheduled here rather than on the scheduler above, which they would share
+     * with every other periodic job of SteVe. This one runs each ping on its own virtual thread, so a
+     * station whose send blocks costs a virtual thread instead of a tenth of that pool.
+     */
+    @Bean
+    public SimpleAsyncTaskScheduler webSocketPingScheduler() {
+        SimpleAsyncTaskScheduler scheduler = new SimpleAsyncTaskScheduler();
+        scheduler.setThreadNamePrefix("SteVe-WebSocketPing-");
+        scheduler.setVirtualThreads(true);
 
         return scheduler;
     }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreHolder.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/SessionContextStoreHolder.java
@@ -21,6 +21,7 @@ package de.rwth.idsg.steve.ocpp.ws;
 import de.rwth.idsg.steve.config.SteveProperties;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.custom.WsSessionSelectStrategy;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 
@@ -42,7 +43,7 @@ public class SessionContextStoreHolder {
     private final FutureResponseContextStore futureResponseContextStore;
 
     public SessionContextStoreHolder(SteveProperties steveProperties,
-                                     TaskScheduler taskScheduler,
+                                     @Qualifier("webSocketPingScheduler") TaskScheduler taskScheduler,
                                      FutureResponseContextStore futureResponseContextStore) {
         wsSessionSelectStrategy = steveProperties.getOcpp().getWsSessionSelectStrategy();
         pingInterval = steveProperties.getOcpp().getWsPingInterval();


### PR DESCRIPTION
Rebased on master now that #2121 is merged, and reduced to what @goekay asked for: a virtual-thread
scheduler and the wiring that hands it to the session store. 2 files, +17/-1.

## Why

The pings run on the shared `TaskScheduler`, a pool of ten threads that every other periodic job of SteVe
also uses. A station whose send blocks holds one of them for up to the ten second send limit. Now that
the interval is configurable (#3), an operator who lowers it to work around a proxy timeout also
multiplies the pressure on that pool.

Holding N schedules is not the problem: `ThreadPoolTaskScheduler` is backed by a
`ScheduledThreadPoolExecutor`, whose delay queue is a binary heap, so ten thousand due dates cost
`O(log N)` per firing and the thread sleeps in between. Where the ping *runs* is the problem.

## What

`webSocketPingScheduler`, a `SimpleAsyncTaskScheduler` with virtual threads enabled, sits next to
`taskScheduler()` in `BeanConfiguration`, and `SessionContextStoreHolder` asks for it by qualifier. One
thread keeps the due dates; each ping runs on its own virtual thread. `PingTask`, `SessionContextStoreImpl`
and `SessionContext` are untouched.

One consequence worth knowing: `SimpleAsyncTaskScheduler` dispatches every execution to a new thread
rather than running it on the scheduler thread, so `scheduleAtFixedRate` no longer guarantees that two
executions of the same task never overlap. A session whose send blocks for longer than the ping interval
can have more than one ping in flight. `ConcurrentWebSocketSessionDecorator` already bounds that case: it
closes a session whose send exceeds its 10s limit or whose buffer fills up.

## Tests

No new test — what is left is a bean definition, and the behaviour under it is Spring's. It is covered end
to end by `Issue3IT`, where the ping now goes out on `SteVe-WebSocketPing-2` instead of
`SteVe-TaskScheduler-*`.

---
*Drafted by Claude under @juherr's supervision.*
