### PR TITLE
switch to UUID-based ids in CommunicationTask

### DIFF
--- a/src/main/java/de/rwth/idsg/steve/ocpp/CommunicationTask.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/CommunicationTask.java
@@ -20,7 +20,6 @@ package de.rwth.idsg.steve.ocpp;
 
 import de.rwth.idsg.ocpp.jaxb.RequestType;
 import de.rwth.idsg.ocpp.jaxb.ResponseType;
-import de.rwth.idsg.steve.SteveException;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonError;
 import de.rwth.idsg.steve.repository.dto.ChargePointSelect;
 import de.rwth.idsg.steve.utils.StringUtils;
@@ -37,6 +36,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -48,16 +48,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Getter
 public abstract class CommunicationTask<S extends ChargePointSelection, RESPONSE> {
 
-    private static final AtomicInteger TASK_ID_SEQUENCE = new AtomicInteger(0);
-
-    /**
-     * Process-local identifier allocated as part of task construction. It is unique for the
-     * lifetime of this application process, but is not stable across application restarts.
-     */
-    private final int taskId = nextTaskId();
-
     private final Logger log = LoggerFactory.getLogger(getClass());
 
+    private final UUID taskUuid = UUID.randomUUID();
     private final String operationName;
     private final TaskOrigin origin;
     private final String caller;
@@ -109,15 +102,6 @@ public abstract class CommunicationTask<S extends ChargePointSelection, RESPONSE
 
         callbackList.add(defaultCallback());
         operationName = StringUtils.getOperationName(this);
-    }
-
-    private static int nextTaskId() {
-        return TASK_ID_SEQUENCE.updateAndGet(current -> {
-            if (current == Integer.MAX_VALUE) {
-                throw new SteveException("Task ID space exhausted");
-            }
-            return current + 1;
-        });
     }
 
     public void addCallback(OcppCallback<RESPONSE> cb) {

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/ChargePointServiceJsonInvoker.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/ChargePointServiceJsonInvoker.java
@@ -83,7 +83,7 @@ public class ChargePointServiceJsonInvoker {
         var context = new CommunicationContext.OutCall(
             chargeBoxId,
             cps.getOcppProtocol(),
-            task.getTaskId(),
+            task.getTaskUuid(),
             callPayload,
             call.getAction(),
             call.getMessageId()

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/CommunicationContext.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/CommunicationContext.java
@@ -22,6 +22,8 @@ import de.rwth.idsg.steve.ocpp.OcppProtocol;
 import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.UUID;
+
 /**
  * Default holder/context of incoming and outgoing messages.
  *
@@ -61,7 +63,7 @@ public class CommunicationContext {
     public record OutCall(
         String chargeBoxId,
         OcppProtocol protocol,
-        int taskId,
+        UUID taskUuid,
 
         String ocppPayload, // full and raw JSON array payload
         String ocppAction,

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/OutgoingPipeline.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/OutgoingPipeline.java
@@ -72,9 +72,9 @@ public class OutgoingPipeline {
         var sessionStore = sessionContextStoreHolder.getOrCreate(version);
         var session = sessionStore.getSession(outWithCall.chargeBoxId());
 
-        // Reconstruct CommunicationTask from its id
+        // Reconstruct CommunicationTask from its UUID
         var typeStore = TypeStore.getTypeStore(version);
-        var task = taskStore.get(outWithCall.taskId());
+        var task = taskStore.get(outWithCall.taskUuid());
 
         // Construct a response context before send
         var responseClass = typeStore.findResponseClass(outWithCall.ocppAction());

--- a/src/main/java/de/rwth/idsg/steve/repository/TaskStore.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/TaskStore.java
@@ -22,6 +22,7 @@ import de.rwth.idsg.steve.ocpp.CommunicationTask;
 import de.rwth.idsg.steve.repository.dto.TaskOverview;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * @author Sevket Goekay <sevketgokay@gmail.com>
@@ -30,8 +31,9 @@ import java.util.List;
 public interface TaskStore {
     List<TaskOverview> getOverview();
     CommunicationTask get(Integer taskId);
+    CommunicationTask get(UUID taskUuid);
     Integer add(CommunicationTask task);
-    boolean remove(CommunicationTask task);
+    boolean remove(Integer taskId, CommunicationTask task);
     List<CommunicationTask> getFinished();
     List<CommunicationTask> getUnfinished();
     void clearFinished();

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/TaskStoreImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/TaskStoreImpl.java
@@ -27,11 +27,16 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
+ * Current implementation does double bookkeeping of tasks by numeric and UUID.
+ * Deprecate numeric taskId bookkeeping later and base all operations on {@link CommunicationTask#taskUuid}.
+ *
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 29.12.2014
  */
@@ -39,7 +44,9 @@ import java.util.stream.Collectors;
 @Repository
 public class TaskStoreImpl implements TaskStore {
 
+    private final AtomicInteger atomicInteger = new AtomicInteger(0);
     private final ConcurrentHashMap<Integer, CommunicationTask> lookupTable = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, Integer> taskIdByUuid = new ConcurrentHashMap<>();
 
     @Override
     public List<TaskOverview> getOverview() {
@@ -71,18 +78,36 @@ public class TaskStoreImpl implements TaskStore {
     }
 
     @Override
+    public CommunicationTask get(UUID taskUuid) {
+        Integer taskId = taskIdByUuid.get(taskUuid);
+        if (taskId == null) {
+            throw new SteveException("There is no task with taskUuid '%s'", taskUuid);
+        }
+        return get(taskId);
+    }
+
+    @Override
     public Integer add(CommunicationTask task) {
-        int taskId = task.getTaskId();
-        var existing = lookupTable.putIfAbsent(taskId, task);
-        if (existing != null && existing != task) {
+        int taskId = atomicInteger.incrementAndGet();
+        var existingTask = lookupTable.putIfAbsent(taskId, task);
+        if (existingTask != null) {
             throw new SteveException("There is already a task with taskId '%s'", taskId);
         }
+
+        var existingTaskId = taskIdByUuid.putIfAbsent(task.getTaskUuid(), taskId);
+        if (existingTaskId != null) {
+            lookupTable.remove(taskId, task);
+            throw new SteveException("There is already a task with taskUuid '%s'", task.getTaskUuid());
+        }
+
         return taskId;
     }
 
     @Override
-    public boolean remove(CommunicationTask task) {
-        return lookupTable.remove(task.getTaskId(), task);
+    public boolean remove(Integer taskId, CommunicationTask task) {
+        boolean success = lookupTable.remove(taskId, task);
+        taskIdByUuid.remove(task.getTaskUuid(), taskId);
+        return success;
     }
 
     @Override
@@ -115,6 +140,6 @@ public class TaskStoreImpl implements TaskStore {
         lookupTable.entrySet()
                    .stream()
                    .filter(filterPredicate)
-                   .forEach(entry -> lookupTable.remove(entry.getKey()));
+                   .forEach(entry -> remove(entry.getKey(), entry.getValue()));
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/repository/impl/TaskStoreImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/repository/impl/TaskStoreImpl.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 /**
  * Current implementation does double bookkeeping of tasks by numeric and UUID.
  * Deprecate numeric taskId bookkeeping later and base all operations on {@link CommunicationTask#taskUuid}.
+ * Afterwards, we can delete modificationLock and synchronized blocks.
  *
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 29.12.2014
@@ -44,6 +45,7 @@ import java.util.stream.Collectors;
 @Repository
 public class TaskStoreImpl implements TaskStore {
 
+    private final Object modificationLock = new Object();
     private final AtomicInteger atomicInteger = new AtomicInteger(0);
     private final ConcurrentHashMap<Integer, CommunicationTask> lookupTable = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<UUID, Integer> taskIdByUuid = new ConcurrentHashMap<>();
@@ -88,26 +90,32 @@ public class TaskStoreImpl implements TaskStore {
 
     @Override
     public Integer add(CommunicationTask task) {
-        int taskId = atomicInteger.incrementAndGet();
-        var existingTask = lookupTable.putIfAbsent(taskId, task);
-        if (existingTask != null) {
-            throw new SteveException("There is already a task with taskId '%s'", taskId);
-        }
+        synchronized (modificationLock) {
+            int taskId = atomicInteger.incrementAndGet();
+            var existingTask = lookupTable.putIfAbsent(taskId, task);
+            if (existingTask != null) {
+                throw new SteveException("There is already a task with taskId '%s'", taskId);
+            }
 
-        var existingTaskId = taskIdByUuid.putIfAbsent(task.getTaskUuid(), taskId);
-        if (existingTaskId != null) {
-            lookupTable.remove(taskId, task);
-            throw new SteveException("There is already a task with taskUuid '%s'", task.getTaskUuid());
-        }
+            var existingTaskId = taskIdByUuid.putIfAbsent(task.getTaskUuid(), taskId);
+            if (existingTaskId != null) {
+                lookupTable.remove(taskId, task);
+                throw new SteveException("There is already a task with taskUuid '%s'", task.getTaskUuid());
+            }
 
-        return taskId;
+            return taskId;
+        }
     }
 
     @Override
     public boolean remove(Integer taskId, CommunicationTask task) {
-        boolean success = lookupTable.remove(taskId, task);
-        taskIdByUuid.remove(task.getTaskUuid(), taskId);
-        return success;
+        synchronized (modificationLock) {
+            if (!lookupTable.remove(taskId, task)) {
+                return false;
+            }
+            taskIdByUuid.remove(task.getTaskUuid(), taskId);
+            return true;
+        }
     }
 
     @Override
@@ -128,12 +136,16 @@ public class TaskStoreImpl implements TaskStore {
 
     @Override
     public void clearFinished() {
-        removeTasks(entry -> entry.getValue().isFinished());
+        synchronized (modificationLock) {
+            removeTasks(entry -> entry.getValue().isFinished());
+        }
     }
 
     @Override
     public void clearUnfinished() {
-        removeTasks(entry -> !entry.getValue().isFinished());
+        synchronized (modificationLock) {
+            removeTasks(entry -> !entry.getValue().isFinished());
+        }
     }
 
     private void removeTasks(Predicate<Map.Entry<Integer, CommunicationTask>> filterPredicate) {

--- a/src/main/java/de/rwth/idsg/steve/service/ChargePointServiceClient.java
+++ b/src/main/java/de/rwth/idsg/steve/service/ChargePointServiceClient.java
@@ -203,8 +203,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.changeAvailability(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.changeAvailability(c, task));
     }
 
     @SafeVarargs
@@ -251,8 +250,7 @@ public class ChargePointServiceClient {
             });
         }
 
-        executeForEach(task, c -> invoker.changeConfiguration(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.changeConfiguration(c, task));
     }
 
     @SafeVarargs
@@ -265,8 +263,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.clearCache(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.clearCache(c, task));
     }
 
     @SafeVarargs
@@ -279,8 +276,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.getDiagnostics(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.getDiagnostics(c, task));
     }
 
     @SafeVarargs
@@ -293,8 +289,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.reset(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.reset(c, task));
     }
 
     @SafeVarargs
@@ -307,8 +302,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.updateFirmware(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.updateFirmware(c, task));
     }
 
     // -------------------------------------------------------------------------
@@ -336,8 +330,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForFirst(task, c -> invoker.remoteStartTransaction(c, task));
-        return task.getTaskId();
+        return executeForFirst(task, c -> invoker.remoteStartTransaction(c, task));
     }
 
     @SafeVarargs
@@ -350,8 +343,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForFirst(task, c -> invoker.remoteStopTransaction(c, task));
-        return task.getTaskId();
+        return executeForFirst(task, c -> invoker.remoteStopTransaction(c, task));
     }
 
     @SafeVarargs
@@ -364,8 +356,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForFirst(task, c -> invoker.unlockConnector(c, task));
-        return task.getTaskId();
+        return executeForFirst(task, c -> invoker.unlockConnector(c, task));
     }
 
     // -------------------------------------------------------------------------
@@ -382,8 +373,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.dataTransfer(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.dataTransfer(c, task));
     }
 
     @SafeVarargs
@@ -396,8 +386,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.getConfiguration(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.getConfiguration(c, task));
     }
 
     @SafeVarargs
@@ -410,8 +399,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.getLocalListVersion(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.getLocalListVersion(c, task));
     }
 
     @SafeVarargs
@@ -424,8 +412,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.sendLocalList(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.sendLocalList(c, task));
     }
 
     // -------------------------------------------------------------------------
@@ -455,8 +442,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForFirst(task, c -> invoker.reserveNow(c, task));
-        return task.getTaskId();
+        return executeForFirst(task, c -> invoker.reserveNow(c, task));
     }
 
     @SafeVarargs
@@ -469,8 +455,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForFirst(task, c -> invoker.cancelReservation(c, task));
-        return task.getTaskId();
+        return executeForFirst(task, c -> invoker.cancelReservation(c, task));
     }
 
     // -------------------------------------------------------------------------
@@ -487,8 +472,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.triggerMessage(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.triggerMessage(c, task));
     }
 
     @SafeVarargs
@@ -500,8 +484,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.setChargingProfile(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.setChargingProfile(c, task));
     }
 
     @SafeVarargs
@@ -524,8 +507,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.clearChargingProfile(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.clearChargingProfile(c, task));
     }
 
     @SafeVarargs
@@ -538,8 +520,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.getCompositeSchedule(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.getCompositeSchedule(c, task));
     }
 
     // -------------------------------------------------------------------------
@@ -556,8 +537,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.extendedTriggerMessage(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.extendedTriggerMessage(c, task));
     }
 
     @SafeVarargs
@@ -572,8 +552,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.getLog(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.getLog(c, task));
     }
 
     @SafeVarargs
@@ -588,8 +567,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.signedUpdateFirmware(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.signedUpdateFirmware(c, task));
     }
 
     @SafeVarargs
@@ -602,8 +580,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.installCertificate(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.installCertificate(c, task));
     }
 
     @SafeVarargs
@@ -616,8 +593,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForFirst(task, c -> invoker.deleteCertificate(c, task));
-        return task.getTaskId();
+        return executeForFirst(task, c -> invoker.deleteCertificate(c, task));
     }
 
     @SafeVarargs
@@ -630,8 +606,7 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.certificateSigned(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.certificateSigned(c, task));
     }
 
     @SafeVarargs
@@ -644,28 +619,28 @@ public class ChargePointServiceClient {
             task.addCallback(callback);
         }
 
-        executeForEach(task, c -> invoker.getInstalledCertificateIds(c, task));
-        return task.getTaskId();
+        return executeForEach(task, c -> invoker.getInstalledCertificateIds(c, task));
     }
 
     // -------------------------------------------------------------------------
     // Private helpers
     // -------------------------------------------------------------------------
 
-    private void executeForFirst(CommunicationTask<?, ?> task, Consumer<ChargePointSelect> consumer) {
+    private int executeForFirst(CommunicationTask<?, ?> task, Consumer<ChargePointSelect> consumer) {
         if (task.getParams().getChargePointSelectList().size() != 1) {
             throw new SteveException.BadRequest("This operation is for one station only");
         }
-        executeForEach(task, consumer);
+        return executeForEach(task, consumer);
     }
 
-    private void executeForEach(CommunicationTask<?, ?> task, Consumer<ChargePointSelect> consumer) {
-        taskStore.add(task);
+    private int executeForEach(CommunicationTask<?, ?> task, Consumer<ChargePointSelect> consumer) {
+        int taskId = taskStore.add(task);
         try {
             taskExecutor.execute(() -> task.getParams().getChargePointSelectList().forEach(consumer));
         } catch (RejectedExecutionException e) {
-            taskStore.remove(task);
+            taskStore.remove(taskId, task);
             throw e;
         }
+        return taskId;
     }
 }

--- a/src/test/java/de/rwth/idsg/steve/ocpp/CommunicationTaskTest.java
+++ b/src/test/java/de/rwth/idsg/steve/ocpp/CommunicationTaskTest.java
@@ -23,17 +23,17 @@ import de.rwth.idsg.steve.web.dto.ocpp.MultipleChargePointSelect;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class CommunicationTaskTest {
 
     @Test
-    public void assignsUniquePositiveIdsDuringConstruction() {
+    public void assignsUniqueUuidsDuringConstruction() {
         var first = new ClearCacheTask(new MultipleChargePointSelect());
         var second = new ClearCacheTask(new MultipleChargePointSelect());
 
-        assertTrue(first.getTaskId() > 0);
-        assertTrue(second.getTaskId() > 0);
-        assertNotEquals(first.getTaskId(), second.getTaskId());
+        assertNotNull(first.getTaskUuid());
+        assertNotNull(second.getTaskUuid());
+        assertNotEquals(first.getTaskUuid(), second.getTaskUuid());
     }
 }

--- a/src/test/java/de/rwth/idsg/steve/repository/impl/TaskStoreImplIT.java
+++ b/src/test/java/de/rwth/idsg/steve/repository/impl/TaskStoreImplIT.java
@@ -59,38 +59,49 @@ public class TaskStoreImplIT extends AbstractRepositoryITBase {
 
     @Test
     public void get() {
-        Integer taskId = repository.add(task(false));
-        var task = assertNoDatabaseException(() -> repository.get(taskId));
-        Assertions.assertNotNull(task);
+        var expectedTask = task(false);
+        Integer taskId = repository.add(expectedTask);
+        var taskById = assertNoDatabaseException(() -> repository.get(taskId));
+        var taskByUuid = assertNoDatabaseException(() -> repository.get(expectedTask.getTaskUuid()));
+        Assertions.assertSame(expectedTask, taskById);
+        Assertions.assertSame(expectedTask, taskByUuid);
     }
 
     @Test
     public void add() {
         var task = task(false);
         Integer taskId = assertNoDatabaseException(() -> repository.add(task));
-        Assertions.assertEquals(task.getTaskId(), taskId);
+        Assertions.assertTrue(taskId > 0);
     }
 
     @Test
     public void clearFinished() {
-        Integer finishedId = repository.add(task(true));
-        Integer unfinishedId = repository.add(task(false));
+        var finishedTask = task(true);
+        var unfinishedTask = task(false);
+        Integer finishedId = repository.add(finishedTask);
+        Integer unfinishedId = repository.add(unfinishedTask);
 
         assertNoDatabaseException(repository::clearFinished);
 
         Assertions.assertThrows(SteveException.class, () -> repository.get(finishedId));
+        Assertions.assertThrows(SteveException.class, () -> repository.get(finishedTask.getTaskUuid()));
         Assertions.assertNotNull(repository.get(unfinishedId));
+        Assertions.assertNotNull(repository.get(unfinishedTask.getTaskUuid()));
     }
 
     @Test
     public void clearUnfinished() {
-        Integer finishedId = repository.add(task(true));
-        Integer unfinishedId = repository.add(task(false));
+        var finishedTask = task(true);
+        var unfinishedTask = task(false);
+        Integer finishedId = repository.add(finishedTask);
+        Integer unfinishedId = repository.add(unfinishedTask);
 
         assertNoDatabaseException(repository::clearUnfinished);
 
         Assertions.assertNotNull(repository.get(finishedId));
+        Assertions.assertNotNull(repository.get(finishedTask.getTaskUuid()));
         Assertions.assertThrows(SteveException.class, () -> repository.get(unfinishedId));
+        Assertions.assertThrows(SteveException.class, () -> repository.get(unfinishedTask.getTaskUuid()));
     }
 
     private static de.rwth.idsg.steve.ocpp.CommunicationTask task(boolean finished) {

--- a/src/test/java/de/rwth/idsg/steve/repository/impl/TaskStoreImplTest.java
+++ b/src/test/java/de/rwth/idsg/steve/repository/impl/TaskStoreImplTest.java
@@ -18,23 +18,38 @@
  */
 package de.rwth.idsg.steve.repository.impl;
 
+import de.rwth.idsg.steve.SteveException;
 import de.rwth.idsg.steve.ocpp.task.ClearCacheTask;
 import de.rwth.idsg.steve.web.dto.ocpp.MultipleChargePointSelect;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TaskStoreImplTest {
 
     @Test
-    public void storesTaskUsingItsConstructionTimeId() {
+    public void storesTaskByNumericIdAndUuid() {
         var store = new TaskStoreImpl();
         var task = new ClearCacheTask(new MultipleChargePointSelect());
 
         var storedId = store.add(task);
 
-        assertEquals(task.getTaskId(), storedId);
-        assertSame(task, store.get(task.getTaskId()));
+        assertTrue(storedId > 0);
+        assertSame(task, store.get(storedId));
+        assertSame(task, store.get(task.getTaskUuid()));
+    }
+
+    @Test
+    public void removeDeletesNumericIdAndUuidIndexEntries() {
+        var store = new TaskStoreImpl();
+        var task = new ClearCacheTask(new MultipleChargePointSelect());
+        var storedId = store.add(task);
+
+        assertTrue(store.remove(storedId, task));
+
+        assertThrows(SteveException.class, () -> store.get(storedId));
+        assertThrows(SteveException.class, () -> store.get(task.getTaskUuid()));
     }
 }

--- a/src/test/java/de/rwth/idsg/steve/service/ChargePointServiceClientTest.java
+++ b/src/test/java/de/rwth/idsg/steve/service/ChargePointServiceClientTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ChargePointServiceClientTest {
@@ -75,6 +76,7 @@ public class ChargePointServiceClientTest {
     public void clearCache_storesTaskBeforeSchedulingIt() {
         var params = new MultipleChargePointSelect();
         params.setChargePointSelectList(List.of(new ChargePointSelect(OcppProtocol.V_16_JSON, "station")));
+        when(taskStore.add(any(CommunicationTask.class))).thenReturn(42);
 
         int taskId = client.clearCache(params);
 
@@ -82,6 +84,6 @@ public class ChargePointServiceClientTest {
         InOrder order = inOrder(taskStore, taskExecutor);
         order.verify(taskStore).add(taskCaptor.capture());
         order.verify(taskExecutor).execute(any(Runnable.class));
-        assertEquals(taskCaptor.getValue().getTaskId(), taskId);
+        assertEquals(42, taskId);
     }
 }


### PR DESCRIPTION
relates to: https://github.com/steve-community/steve/issues/2104

i was unhappy with global static AtomicInteger generator. these changes undo ee73acf4c438f9ac0f118f92146fb6b256cda01a and introduce a second bookkeeping and access by taskUuid in addition to existing numeric taskId