### PR TITLE
migrate to in-memory message queue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,6 +466,10 @@
             <artifactId>spring-boot-starter-websocket</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>

--- a/src/main/java/de/rwth/idsg/steve/config/MessagingConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/MessagingConfiguration.java
@@ -43,6 +43,7 @@ public class MessagingConfiguration {
     public static final String POLL_INTERVAL_MILLIS = "100";
 
     private static final int QUEUE_CAPACITY = 10_000;
+    private static final long SEND_TIMEOUT_MILLIS = 2_000;
 
     @Bean(name = IN_CHANNEL)
     public QueueChannel ocppInChannel() {
@@ -75,7 +76,7 @@ public class MessagingConfiguration {
     }
 
     private static void send(MessageChannel channel, Message<?> message, String errorMessage) {
-        if (!channel.send(message, 0)) {
+        if (!channel.send(message, SEND_TIMEOUT_MILLIS)) {
             throw new MessageDeliveryException(message, errorMessage);
         }
     }

--- a/src/main/java/de/rwth/idsg/steve/config/MessagingConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/MessagingConfiguration.java
@@ -22,13 +22,18 @@ import de.rwth.idsg.steve.messaging.Messaging;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.integration.channel.QueueChannel;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.integration.channel.ExecutorChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 /**
+ * Asynchronous in-memory OCPP JSON channels. Each channel has an isolated, bounded executor queue
+ * and a dedicated worker thread pool so producers never run consumers on their own threads.
+ *
  * @author Sevket Goekay <sevketgokay@gmail.com>
  * @since 27.08.2026
  */
@@ -40,24 +45,40 @@ public class MessagingConfiguration {
     public static final String OUT_CHANNEL = "ocppOutChannel";
     public static final String OUT_CALL_CHANNEL = "ocppOutCallChannel";
 
-    public static final String POLL_INTERVAL_MILLIS = "100";
+    private static final String IN_EXECUTOR = "ocppInExecutor";
+    private static final String OUT_EXECUTOR = "ocppOutExecutor";
+    private static final String OUT_CALL_EXECUTOR = "ocppOutCallExecutor";
 
     private static final int QUEUE_CAPACITY = 10_000;
-    private static final long SEND_TIMEOUT_MILLIS = 2_000;
+
+    @Bean(name = IN_EXECUTOR)
+    public ThreadPoolTaskExecutor ocppInExecutor() {
+        return executor(IN_EXECUTOR, 4);
+    }
+
+    @Bean(name = OUT_EXECUTOR)
+    public ThreadPoolTaskExecutor ocppOutExecutor() {
+        return executor(OUT_EXECUTOR, 4);
+    }
+
+    @Bean(name = OUT_CALL_EXECUTOR)
+    public ThreadPoolTaskExecutor ocppOutCallExecutor() {
+        return executor(OUT_CALL_EXECUTOR, 4);
+    }
 
     @Bean(name = IN_CHANNEL)
-    public QueueChannel ocppInChannel() {
-        return new QueueChannel(QUEUE_CAPACITY);
+    public ExecutorChannel ocppInChannel(@Qualifier(IN_EXECUTOR) TaskExecutor executor) {
+        return new ExecutorChannel(executor);
     }
 
     @Bean(name = OUT_CHANNEL)
-    public QueueChannel ocppOutChannel() {
-        return new QueueChannel(QUEUE_CAPACITY);
+    public ExecutorChannel ocppOutChannel(@Qualifier(OUT_EXECUTOR) TaskExecutor executor) {
+        return new ExecutorChannel(executor);
     }
 
     @Bean(name = OUT_CALL_CHANNEL)
-    public QueueChannel ocppOutCallChannel() {
-        return new QueueChannel(QUEUE_CAPACITY);
+    public ExecutorChannel ocppOutCallChannel(@Qualifier(OUT_CALL_EXECUTOR) TaskExecutor executor) {
+        return new ExecutorChannel(executor);
     }
 
     @Bean
@@ -76,8 +97,18 @@ public class MessagingConfiguration {
     }
 
     private static void send(MessageChannel channel, Message<?> message, String errorMessage) {
-        if (!channel.send(message, SEND_TIMEOUT_MILLIS)) {
+        if (!channel.send(message)) {
             throw new MessageDeliveryException(message, errorMessage);
         }
+    }
+
+    private static ThreadPoolTaskExecutor executor(String executorName, int consumerPoolSize) {
+        var executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(consumerPoolSize);
+        executor.setMaxPoolSize(consumerPoolSize);
+        executor.setQueueCapacity(QUEUE_CAPACITY);
+        executor.setThreadNamePrefix(executorName + "-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        return executor;
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/config/MessagingConfiguration.java
+++ b/src/main/java/de/rwth/idsg/steve/config/MessagingConfiguration.java
@@ -1,0 +1,82 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.config;
+
+import de.rwth.idsg.steve.messaging.Messaging;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+
+/**
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 27.08.2026
+ */
+@Configuration
+@EnableIntegration
+public class MessagingConfiguration {
+
+    public static final String IN_CHANNEL = "ocppInChannel";
+    public static final String OUT_CHANNEL = "ocppOutChannel";
+    public static final String OUT_CALL_CHANNEL = "ocppOutCallChannel";
+
+    public static final String POLL_INTERVAL_MILLIS = "100";
+
+    private static final int QUEUE_CAPACITY = 10_000;
+
+    @Bean(name = IN_CHANNEL)
+    public QueueChannel ocppInChannel() {
+        return new QueueChannel(QUEUE_CAPACITY);
+    }
+
+    @Bean(name = OUT_CHANNEL)
+    public QueueChannel ocppOutChannel() {
+        return new QueueChannel(QUEUE_CAPACITY);
+    }
+
+    @Bean(name = OUT_CALL_CHANNEL)
+    public QueueChannel ocppOutCallChannel() {
+        return new QueueChannel(QUEUE_CAPACITY);
+    }
+
+    @Bean
+    public Messaging.In.Producer inProducer(@Qualifier(IN_CHANNEL) MessageChannel channel) {
+        return message -> send(channel, message, "Could not send to incoming OCPP JSON message queue");
+    }
+
+    @Bean
+    public Messaging.Out.Producer outProducer(@Qualifier(OUT_CHANNEL) MessageChannel channel) {
+        return message -> send(channel, message, "Could not send to outgoing OCPP JSON message queue");
+    }
+
+    @Bean
+    public Messaging.OutCall.Producer outCallProducer(@Qualifier(OUT_CALL_CHANNEL) MessageChannel channel) {
+        return message -> send(channel, message, "Could not send to outgoing OCPP JSON call queue");
+    }
+
+    private static void send(MessageChannel channel, Message<?> message, String errorMessage) {
+        if (!channel.send(message, 0)) {
+            throw new MessageDeliveryException(message, errorMessage);
+        }
+    }
+}

--- a/src/main/java/de/rwth/idsg/steve/messaging/Messaging.java
+++ b/src/main/java/de/rwth/idsg/steve/messaging/Messaging.java
@@ -1,0 +1,64 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.messaging;
+
+import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
+import org.springframework.messaging.Message;
+
+/**
+ * Typed boundaries around OCPP JSON messaging.
+ *
+ * @author Sevket Goekay <sevketgokay@gmail.com>
+ * @since 27.08.2026
+ */
+public interface Messaging {
+
+    interface In {
+
+        interface Producer {
+            void send(Message<CommunicationContext.In> message);
+        }
+
+        interface Consumer {
+            void processIn(Message<CommunicationContext.In> message);
+        }
+    }
+
+    interface Out {
+
+        interface Producer {
+            void send(Message<CommunicationContext.Out> message);
+        }
+
+        interface Consumer {
+            void processOut(Message<CommunicationContext.Out> message);
+        }
+    }
+
+    interface OutCall {
+
+        interface Producer {
+            void send(Message<CommunicationContext.OutCall> message);
+        }
+
+        interface Consumer {
+            void processOutCall(Message<CommunicationContext.OutCall> message);
+        }
+    }
+}

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/ChargePointServiceJsonInvoker.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/ChargePointServiceJsonInvoker.java
@@ -19,14 +19,15 @@
 package de.rwth.idsg.steve.ocpp.ws;
 
 import de.rwth.idsg.steve.SteveException;
+import de.rwth.idsg.steve.messaging.Messaging;
 import de.rwth.idsg.steve.ocpp.CommunicationTask;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonCall;
-import de.rwth.idsg.steve.ocpp.ws.pipeline.OutgoingPipeline;
 import de.rwth.idsg.steve.ocpp.ws.pipeline.Serializer;
 import de.rwth.idsg.steve.repository.dto.ChargePointSelect;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -40,7 +41,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ChargePointServiceJsonInvoker {
 
-    private final OutgoingPipeline outgoingPipeline;
+    private final Messaging.OutCall.Producer outCallProducer;
 
     /**
      * Just a wrapper to make try-catch block and exception handling stand out
@@ -89,6 +90,6 @@ public class ChargePointServiceJsonInvoker {
             call.getMessageId()
         );
 
-        outgoingPipeline.accept(context);
+        outCallProducer.send(MessageBuilder.withPayload(context).build());
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/FutureResponseContextStoreImpl.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/FutureResponseContextStoreImpl.java
@@ -112,9 +112,10 @@ public class FutureResponseContextStoreImpl implements FutureResponseContextStor
 
     /**
      * Removes stale correlation entries to keep the lookup bounded when peers stop responding.
+     * The retention period is longer than the response timeout to account for queueing delays.
      */
     private static void evictTimedOutEntries(Map<String, FutureResponseContext> map) {
         Instant now = Instant.now();
-        map.entrySet().removeIf(entry -> entry.getValue().hasTimedOut(now));
+        map.entrySet().removeIf(entry -> entry.getValue().hasExceededRetentionPeriod(now));
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketEndpoint.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketEndpoint.java
@@ -40,6 +40,7 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
 
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -99,7 +100,7 @@ public class WebSocketEndpoint extends ConcurrentWebSocketHandler implements Sub
             chargeBoxId,
             version.toProtocol(OcppTransport.JSON),
             session.getId(),
-            System.currentTimeMillis(),
+            Instant.now(),
             incomingString
         );
 

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketEndpoint.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketEndpoint.java
@@ -19,10 +19,10 @@
 package de.rwth.idsg.steve.ocpp.ws;
 
 import com.google.common.base.Strings;
+import de.rwth.idsg.steve.messaging.Messaging;
 import de.rwth.idsg.steve.ocpp.OcppTransport;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
-import de.rwth.idsg.steve.ocpp.ws.pipeline.IncomingPipeline;
 import de.rwth.idsg.steve.ocpp.ws.pipeline.OcppCallHandler;
 import de.rwth.idsg.steve.repository.OcppServerRepository;
 import de.rwth.idsg.steve.service.notification.OcppStationWebSocketConnected;
@@ -30,6 +30,7 @@ import de.rwth.idsg.steve.service.notification.OcppStationWebSocketDisconnected;
 import lombok.RequiredArgsConstructor;
 import org.joda.time.DateTime;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
@@ -55,7 +56,7 @@ public class WebSocketEndpoint extends ConcurrentWebSocketHandler implements Sub
     private final OcppServerRepository ocppServerRepository;
     private final SessionContextStoreHolder sessionContextStoreHolder;
     private final ApplicationEventPublisher applicationEventPublisher;
-    private final IncomingPipeline incomingPipeline;
+    private final Messaging.In.Producer inProducer;
 
     @Override
     public List<String> getSubProtocols() {
@@ -101,7 +102,7 @@ public class WebSocketEndpoint extends ConcurrentWebSocketHandler implements Sub
             incomingString
         );
 
-        incomingPipeline.accept(inMsg);
+        inProducer.send(MessageBuilder.withPayload(inMsg).build());
     }
 
     private void handlePongMessage(WebSocketSession session) {

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketEndpoint.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/WebSocketEndpoint.java
@@ -99,6 +99,7 @@ public class WebSocketEndpoint extends ConcurrentWebSocketHandler implements Sub
             chargeBoxId,
             version.toProtocol(OcppTransport.JSON),
             session.getId(),
+            System.currentTimeMillis(),
             incomingString
         );
 

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/CommunicationContext.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/CommunicationContext.java
@@ -22,6 +22,7 @@ import de.rwth.idsg.steve.ocpp.OcppProtocol;
 import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -40,7 +41,7 @@ public class CommunicationContext {
         String chargeBoxId,
         OcppProtocol protocol,
         String webSocketSessionId,
-        long arrivedAtMillis,
+        Instant receivedAt,
 
         String ocppPayload // full and raw JSON array payload
     ) {

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/CommunicationContext.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/CommunicationContext.java
@@ -40,6 +40,7 @@ public class CommunicationContext {
         String chargeBoxId,
         OcppProtocol protocol,
         String webSocketSessionId,
+        long arrivedAtMillis,
 
         String ocppPayload // full and raw JSON array payload
     ) {

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/FutureResponseContext.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/data/FutureResponseContext.java
@@ -41,6 +41,12 @@ public class FutureResponseContext {
      */
     public static final int TIMEOUT_IN_SECONDS = 30;
 
+    /**
+     * Physical retention window for correlation entries. This is deliberately longer than the
+     * response timeout so an on-time response can still be correlated after waiting in the queue.
+     */
+    public static final int RETENTION_IN_SECONDS = 2 * TIMEOUT_IN_SECONDS;
+
     private final CommunicationTask task;
     private final Class<? extends ResponseType> responseClass;
 
@@ -48,9 +54,13 @@ public class FutureResponseContext {
      * Timestamp used to detect stale response contexts and prevent late responses
      * from being correlated as if they were still active.
      */
-    private final Instant createdAt = Instant.now();
+    private final Instant sentAt = Instant.now();
 
     public boolean hasTimedOut(Instant now) {
-        return createdAt.plusSeconds(TIMEOUT_IN_SECONDS).isBefore(now);
+        return sentAt.plusSeconds(TIMEOUT_IN_SECONDS).isBefore(now);
+    }
+
+    public boolean hasExceededRetentionPeriod(Instant now) {
+        return sentAt.plusSeconds(RETENTION_IN_SECONDS).isBefore(now);
     }
 }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Deserializer.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Deserializer.java
@@ -194,7 +194,7 @@ public class Deserializer {
     private CommunicationContext.InResult handleResult(CommunicationContext.In inMsg, String messageId,
                                                        JsonParser parser) throws CommunicationContext.JsonResponseInvalidException {
         FutureResponseContext responseContext = futureResponseContextStore.poll(inMsg.webSocketSessionId(), messageId);
-        validate(responseContext, inMsg.arrivedAtMillis());
+        validate(responseContext, inMsg.receivedAt());
 
         ResponseType res;
         try {
@@ -219,7 +219,7 @@ public class Deserializer {
     private CommunicationContext.InError handleError(CommunicationContext.In inMsg, String messageId,
                                                      JsonParser parser) throws CommunicationContext.JsonResponseInvalidException {
         FutureResponseContext responseContext = futureResponseContextStore.poll(inMsg.webSocketSessionId(), messageId);
-        validate(responseContext, inMsg.arrivedAtMillis());
+        validate(responseContext, inMsg.receivedAt());
 
         ErrorCode code;
         String desc;
@@ -273,12 +273,12 @@ public class Deserializer {
      * Ensures incoming responses map only to active, non-stale calls.
      * Unknown or expired correlations are rejected to prevent accidental matching.
      */
-    private static void validate(FutureResponseContext frc, long responseArrivedAtMillis) throws CommunicationContext.JsonResponseInvalidException {
+    private static void validate(FutureResponseContext frc, Instant receivedAt) throws CommunicationContext.JsonResponseInvalidException {
         if (frc == null) {
             throw new CommunicationContext.JsonResponseInvalidException("A response message was received to a not-sent call", null);
         }
 
-        if (frc.hasTimedOut(Instant.ofEpochMilli(responseArrivedAtMillis))) {
+        if (frc.hasTimedOut(receivedAt)) {
             // carry frc with this exception, because IncomingPipeline will need it to handle and propagate.
             throw new CommunicationContext.JsonResponseInvalidException("A response message was received to an expired call", frc);
         }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Deserializer.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/Deserializer.java
@@ -194,7 +194,7 @@ public class Deserializer {
     private CommunicationContext.InResult handleResult(CommunicationContext.In inMsg, String messageId,
                                                        JsonParser parser) throws CommunicationContext.JsonResponseInvalidException {
         FutureResponseContext responseContext = futureResponseContextStore.poll(inMsg.webSocketSessionId(), messageId);
-        validate(responseContext);
+        validate(responseContext, inMsg.arrivedAtMillis());
 
         ResponseType res;
         try {
@@ -219,7 +219,7 @@ public class Deserializer {
     private CommunicationContext.InError handleError(CommunicationContext.In inMsg, String messageId,
                                                      JsonParser parser) throws CommunicationContext.JsonResponseInvalidException {
         FutureResponseContext responseContext = futureResponseContextStore.poll(inMsg.webSocketSessionId(), messageId);
-        validate(responseContext);
+        validate(responseContext, inMsg.arrivedAtMillis());
 
         ErrorCode code;
         String desc;
@@ -273,12 +273,12 @@ public class Deserializer {
      * Ensures incoming responses map only to active, non-stale calls.
      * Unknown or expired correlations are rejected to prevent accidental matching.
      */
-    private static void validate(FutureResponseContext frc) throws CommunicationContext.JsonResponseInvalidException {
+    private static void validate(FutureResponseContext frc, long responseArrivedAtMillis) throws CommunicationContext.JsonResponseInvalidException {
         if (frc == null) {
             throw new CommunicationContext.JsonResponseInvalidException("A response message was received to a not-sent call", null);
         }
 
-        if (frc.hasTimedOut(Instant.now())) {
+        if (frc.hasTimedOut(Instant.ofEpochMilli(responseArrivedAtMillis))) {
             // carry frc with this exception, because IncomingPipeline will need it to handle and propagate.
             throw new CommunicationContext.JsonResponseInvalidException("A response message was received to an expired call", frc);
         }

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/IncomingPipeline.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/IncomingPipeline.java
@@ -24,6 +24,7 @@ import de.rwth.idsg.steve.config.MessagingConfiguration;
 import de.rwth.idsg.steve.messaging.Messaging;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
+import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -74,8 +75,7 @@ public class IncomingPipeline implements Messaging.In.Consumer {
 
         } catch (CommunicationContext.JsonCallParseException e) {
             var parseError = e.getParseError();
-            var parseErrorStr = serializer.accept(parseError);
-            sendOut(message, parseErrorStr);
+            sendOut(message, parseError);
             return;
 
         } catch (CommunicationContext.JsonResponseInvalidException e) {
@@ -105,11 +105,12 @@ public class IncomingPipeline implements Messaging.In.Consumer {
         }
 
         var response = handler.accept(data);
-        var responseStr = serializer.accept(response);
-        sendOut(message, responseStr);
+        sendOut(message, response);
     }
 
-    private void sendOut(Message<CommunicationContext.In> inMsg, String ocppPayload) {
+    private void sendOut(Message<CommunicationContext.In> inMsg, OcppJsonResponse responseMsg) {
+        var ocppPayload = serializer.accept(responseMsg);
+
         var out = CommunicationContext.outFrom(inMsg.getPayload(), ocppPayload);
         var outMsg = MessageBuilder.withPayload(out).copyHeaders(inMsg.getHeaders()).build();
         outProducer.send(outMsg);

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/IncomingPipeline.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/IncomingPipeline.java
@@ -20,10 +20,16 @@ package de.rwth.idsg.steve.ocpp.ws.pipeline;
 
 import de.rwth.idsg.ocpp.jaxb.ResponseType;
 import de.rwth.idsg.steve.SteveException;
+import de.rwth.idsg.steve.config.MessagingConfiguration;
+import de.rwth.idsg.steve.messaging.Messaging;
 import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.annotation.Poller;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
 
 import jakarta.xml.ws.Response;
@@ -40,26 +46,36 @@ import java.util.concurrent.TimeUnit;
  */
 @Slf4j
 @Component
-public class IncomingPipeline {
+public class IncomingPipeline implements Messaging.In.Consumer {
 
     private final Serializer serializer = Serializer.INSTANCE;
 
-    private final OutgoingPipeline outgoingPipeline;
+    private final Messaging.Out.Producer outProducer;
     private final Deserializer deserializer;
     private final Map<OcppVersion, OcppCallHandler> handlerMap = new EnumMap<>(OcppVersion.class);
 
     @Autowired
-    public IncomingPipeline(OutgoingPipeline outgoingPipeline,
+    public IncomingPipeline(Messaging.Out.Producer outProducer,
                             Deserializer deserializer,
                             List<OcppCallHandler> handlers) {
-        this.outgoingPipeline = outgoingPipeline;
+        this.outProducer = outProducer;
         this.deserializer = deserializer;
         for (OcppCallHandler handler : handlers) {
             handlerMap.put(handler.getVersion(), handler);
         }
     }
 
-    public void accept(CommunicationContext.In inMsg) {
+    @ServiceActivator(
+        inputChannel = MessagingConfiguration.IN_CHANNEL,
+        poller = @Poller(
+            fixedDelay = MessagingConfiguration.POLL_INTERVAL_MILLIS,
+            maxMessagesPerPoll = "-1",
+            receiveTimeout = "0"
+        )
+    )
+    @Override
+    public void processIn(Message<CommunicationContext.In> message) {
+        var inMsg = message.getPayload();
         CommunicationContext.DeserializationResult inMsgData;
         try {
             inMsgData = deserializer.accept(inMsg);
@@ -67,7 +83,7 @@ public class IncomingPipeline {
         } catch (CommunicationContext.JsonCallParseException e) {
             var parseError = e.getParseError();
             var parseErrorStr = serializer.accept(parseError);
-            outgoingPipeline.accept(CommunicationContext.outFrom(inMsg, parseErrorStr));
+            sendOut(message, parseErrorStr);
             return;
 
         } catch (CommunicationContext.JsonResponseInvalidException e) {
@@ -81,13 +97,13 @@ public class IncomingPipeline {
         }
 
         switch (inMsgData) {
-            case CommunicationContext.InCall call -> processCall(call);
+            case CommunicationContext.InCall call -> processCall(message, call);
             case CommunicationContext.InResult result -> processResult(result);
             case CommunicationContext.InError error -> processError(error);
         }
     }
 
-    private void processCall(CommunicationContext.InCall data) {
+    private void processCall(Message<CommunicationContext.In> message, CommunicationContext.InCall data) {
         var version = data.in().protocol().getVersion();
 
         var handler = handlerMap.get(version);
@@ -98,7 +114,13 @@ public class IncomingPipeline {
 
         var response = handler.accept(data);
         var responseStr = serializer.accept(response);
-        outgoingPipeline.accept(CommunicationContext.outFrom(data.in(), responseStr));
+        sendOut(message, responseStr);
+    }
+
+    private void sendOut(Message<CommunicationContext.In> inMsg, String ocppPayload) {
+        var out = CommunicationContext.outFrom(inMsg.getPayload(), ocppPayload);
+        var outMsg = MessageBuilder.withPayload(out).copyHeaders(inMsg.getHeaders()).build();
+        outProducer.send(outMsg);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/IncomingPipeline.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/IncomingPipeline.java
@@ -26,7 +26,6 @@ import de.rwth.idsg.steve.ocpp.OcppVersion;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.integration.annotation.Poller;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
@@ -65,14 +64,7 @@ public class IncomingPipeline implements Messaging.In.Consumer {
         }
     }
 
-    @ServiceActivator(
-        inputChannel = MessagingConfiguration.IN_CHANNEL,
-        poller = @Poller(
-            fixedDelay = MessagingConfiguration.POLL_INTERVAL_MILLIS,
-            maxMessagesPerPoll = "-1",
-            receiveTimeout = "0"
-        )
-    )
+    @ServiceActivator(inputChannel = MessagingConfiguration.IN_CHANNEL)
     @Override
     public void processIn(Message<CommunicationContext.In> message) {
         var inMsg = message.getPayload();

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/OutgoingPipeline.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/OutgoingPipeline.java
@@ -31,7 +31,6 @@ import de.rwth.idsg.steve.repository.TaskStore;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
-import org.springframework.integration.annotation.Poller;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
@@ -53,14 +52,7 @@ public class OutgoingPipeline implements Messaging.Out.Consumer, Messaging.OutCa
     private final SessionContextStoreHolder sessionContextStoreHolder;
     private final FutureResponseContextStore futureResponseContextStore;
 
-    @ServiceActivator(
-        inputChannel = MessagingConfiguration.OUT_CHANNEL,
-        poller = @Poller(
-            fixedDelay = MessagingConfiguration.POLL_INTERVAL_MILLIS,
-            maxMessagesPerPoll = "-1",
-            receiveTimeout = "0"
-        )
-    )
+    @ServiceActivator(inputChannel = MessagingConfiguration.OUT_CHANNEL)
     @Override
     public void processOut(Message<CommunicationContext.Out> message) {
         var outMsg = message.getPayload();
@@ -80,14 +72,7 @@ public class OutgoingPipeline implements Messaging.Out.Consumer, Messaging.OutCa
      * Uses a store-before-send strategy to close response-correlation races.
      * If transport sending fails, the stored context is rolled back immediately.
      */
-    @ServiceActivator(
-        inputChannel = MessagingConfiguration.OUT_CALL_CHANNEL,
-        poller = @Poller(
-            fixedDelay = MessagingConfiguration.POLL_INTERVAL_MILLIS,
-            maxMessagesPerPoll = "-1",
-            receiveTimeout = "0"
-        )
-    )
+    @ServiceActivator(inputChannel = MessagingConfiguration.OUT_CALL_CHANNEL)
     @Override
     public void processOutCall(Message<CommunicationContext.OutCall> message) {
         var outWithCall = message.getPayload();

--- a/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/OutgoingPipeline.java
+++ b/src/main/java/de/rwth/idsg/steve/ocpp/ws/pipeline/OutgoingPipeline.java
@@ -19,6 +19,8 @@
 package de.rwth.idsg.steve.ocpp.ws.pipeline;
 
 import de.rwth.idsg.steve.SteveException;
+import de.rwth.idsg.steve.config.MessagingConfiguration;
+import de.rwth.idsg.steve.messaging.Messaging;
 import de.rwth.idsg.steve.ocpp.ws.FutureResponseContextStore;
 import de.rwth.idsg.steve.ocpp.ws.SessionContextStoreHolder;
 import de.rwth.idsg.steve.ocpp.ws.TypeStore;
@@ -29,6 +31,9 @@ import de.rwth.idsg.steve.repository.TaskStore;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
+import org.springframework.integration.annotation.Poller;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -42,13 +47,23 @@ import java.io.IOException;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class OutgoingPipeline {
+public class OutgoingPipeline implements Messaging.Out.Consumer, Messaging.OutCall.Consumer {
 
     private final TaskStore taskStore;
     private final SessionContextStoreHolder sessionContextStoreHolder;
     private final FutureResponseContextStore futureResponseContextStore;
 
-    public void accept(CommunicationContext.Out outMsg) {
+    @ServiceActivator(
+        inputChannel = MessagingConfiguration.OUT_CHANNEL,
+        poller = @Poller(
+            fixedDelay = MessagingConfiguration.POLL_INTERVAL_MILLIS,
+            maxMessagesPerPoll = "-1",
+            receiveTimeout = "0"
+        )
+    )
+    @Override
+    public void processOut(Message<CommunicationContext.Out> message) {
+        var outMsg = message.getPayload();
         var version = outMsg.protocol().getVersion();
         var chargeBoxId = outMsg.chargeBoxId();
         var webSocketSessionId = outMsg.webSocketSessionId();
@@ -65,44 +80,54 @@ public class OutgoingPipeline {
      * Uses a store-before-send strategy to close response-correlation races.
      * If transport sending fails, the stored context is rolled back immediately.
      */
-    public void accept(CommunicationContext.OutCall outWithCall) {
-        var version = outWithCall.protocol().getVersion();
-
-        // Pick a session to send
-        var sessionStore = sessionContextStoreHolder.getOrCreate(version);
-        var session = sessionStore.getSession(outWithCall.chargeBoxId());
+    @ServiceActivator(
+        inputChannel = MessagingConfiguration.OUT_CALL_CHANNEL,
+        poller = @Poller(
+            fixedDelay = MessagingConfiguration.POLL_INTERVAL_MILLIS,
+            maxMessagesPerPoll = "-1",
+            receiveTimeout = "0"
+        )
+    )
+    @Override
+    public void processOutCall(Message<CommunicationContext.OutCall> message) {
+        var outWithCall = message.getPayload();
 
         // Reconstruct CommunicationTask from its UUID
-        var typeStore = TypeStore.getTypeStore(version);
         var task = taskStore.get(outWithCall.taskUuid());
 
-        // Construct a response context before send
-        var responseClass = typeStore.findResponseClass(outWithCall.ocppAction());
-        var frc = new FutureResponseContext(task, responseClass);
+        String webSocketSessionId = null;
+        boolean responseContextStored = false;
 
-        // 1. Store the response context for later lookup.
-        futureResponseContextStore.add(
-            session.getId(),
-            outWithCall.ocppMessageId(),
-            frc
-        );
-
-        // 2. Send the payload via WebSocket
         try {
+            // Pick a session to send
+            var sessionStore = sessionContextStoreHolder.getOrCreate(outWithCall.protocol().getVersion());
+            var session = sessionStore.getSession(outWithCall.chargeBoxId());
+            webSocketSessionId = session.getId();
+
+            // Construct a response context before send
+            var typeStore = TypeStore.getTypeStore(outWithCall.protocol().getVersion());
+            var responseClass = typeStore.findResponseClass(outWithCall.ocppAction());
+            var frc = new FutureResponseContext(task, responseClass);
+
+            // 1. Store the response context for later lookup.
+            futureResponseContextStore.add(
+                webSocketSessionId,
+                outWithCall.ocppMessageId(),
+                frc
+            );
+            responseContextStored = true;
+
+            // 2. Send the payload via WebSocket
             if (!sendOutCall(outWithCall, session)) {
-                poll(outWithCall, session);
+                throw new SteveException("OCPP CALL failed");
             }
-        } catch (Exception e) {
-            poll(outWithCall, session);
+        } catch (RuntimeException e) {
+            if (responseContextStored) {
+                futureResponseContextStore.poll(webSocketSessionId, outWithCall.ocppMessageId());
+            }
+            task.failed(outWithCall.chargeBoxId(), e);
             throw e;
         }
-    }
-
-    /**
-     * 3. In case of failure, rollback aka remove the FutureResponseContext
-     */
-    private void poll(CommunicationContext.OutCall outWithCall, WebSocketSession session) {
-        futureResponseContextStore.poll(session.getId(), outWithCall.ocppMessageId());
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/de/rwth/idsg/steve/messaging/InMemoryMessageQueueTest.java
+++ b/src/test/java/de/rwth/idsg/steve/messaging/InMemoryMessageQueueTest.java
@@ -78,7 +78,7 @@ public class InMemoryMessageQueueTest {
     }
 
     @Test
-    public void producersFailFastWhenTheirQueueIsFull() {
+    public void producersFailWhenTheirQueueRemainsFull() {
         var inChannel = new QueueChannel(1);
         var outChannel = new QueueChannel(1);
         var outCallChannel = new QueueChannel(1);

--- a/src/test/java/de/rwth/idsg/steve/messaging/InMemoryMessageQueueTest.java
+++ b/src/test/java/de/rwth/idsg/steve/messaging/InMemoryMessageQueueTest.java
@@ -1,0 +1,259 @@
+/*
+ * SteVe - SteckdosenVerwaltung - https://github.com/steve-community/steve
+ * Copyright (C) 2013-2026 SteVe Community Team
+ * All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.rwth.idsg.steve.messaging;
+
+import de.rwth.idsg.steve.config.MessagingConfiguration;
+import de.rwth.idsg.steve.ocpp.CommunicationTask;
+import de.rwth.idsg.steve.ocpp.OcppProtocol;
+import de.rwth.idsg.steve.ocpp.ws.FutureResponseContextStore;
+import de.rwth.idsg.steve.ocpp.ws.SessionContextStore;
+import de.rwth.idsg.steve.ocpp.ws.SessionContextStoreHolder;
+import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
+import de.rwth.idsg.steve.ocpp.ws.data.ErrorCode;
+import de.rwth.idsg.steve.ocpp.ws.data.FutureResponseContext;
+import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonError;
+import de.rwth.idsg.steve.ocpp.ws.pipeline.Deserializer;
+import de.rwth.idsg.steve.ocpp.ws.pipeline.IncomingPipeline;
+import de.rwth.idsg.steve.ocpp.ws.pipeline.OutgoingPipeline;
+import de.rwth.idsg.steve.repository.TaskStore;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class InMemoryMessageQueueTest {
+
+    private final MessagingConfiguration configuration = new MessagingConfiguration();
+
+    @Test
+    public void producersEnqueueTheirMessages() {
+        var inChannel = configuration.ocppInChannel();
+        var outChannel = configuration.ocppOutChannel();
+        var outCallChannel = configuration.ocppOutCallChannel();
+        var in = inMessage();
+        var out = outMessage();
+        var outCall = outCallMessage();
+
+        configuration.inProducer(inChannel).send(in);
+        configuration.outProducer(outChannel).send(out);
+        configuration.outCallProducer(outCallChannel).send(outCall);
+
+        assertSame(in, inChannel.receive(0));
+        assertSame(out, outChannel.receive(0));
+        assertSame(outCall, outCallChannel.receive(0));
+    }
+
+    @Test
+    public void producersFailFastWhenTheirQueueIsFull() {
+        var inChannel = new QueueChannel(1);
+        var outChannel = new QueueChannel(1);
+        var outCallChannel = new QueueChannel(1);
+        var inProducer = configuration.inProducer(inChannel);
+        var outProducer = configuration.outProducer(outChannel);
+        var outCallProducer = configuration.outCallProducer(outCallChannel);
+        var in = inMessage();
+        var out = outMessage();
+        var outCall = outCallMessage();
+
+        inProducer.send(in);
+        outProducer.send(out);
+        outCallProducer.send(outCall);
+
+        assertThrows(MessageDeliveryException.class, () -> inProducer.send(in));
+        assertThrows(MessageDeliveryException.class, () -> outProducer.send(out));
+        assertThrows(MessageDeliveryException.class, () -> outCallProducer.send(outCall));
+    }
+
+    @Test
+    public void queuesRouteMessagesToTheirConsumers() throws Exception {
+        var deserializer = mock(Deserializer.class);
+        var sessionContextStoreHolder = mock(SessionContextStoreHolder.class);
+        var sessionContextStore = mock(SessionContextStore.class);
+        var session = mock(WebSocketSession.class);
+        var taskStore = mock(TaskStore.class);
+        var task = mock(CommunicationTask.class);
+        var futureResponseContextStore = mock(FutureResponseContextStore.class);
+        var inboundFutureResponseContext = mock(FutureResponseContext.class);
+        var error = mock(OcppJsonError.class);
+        var in = inMessage();
+        var out = outMessage();
+        var outCall = outCallMessage();
+
+        when(deserializer.accept(in.getPayload())).thenReturn(new CommunicationContext.InError(
+            in.getPayload(),
+            error,
+            inboundFutureResponseContext
+        ));
+        when(inboundFutureResponseContext.getTask()).thenReturn(task);
+        when(sessionContextStoreHolder.getOrCreate(OcppProtocol.V_16_JSON.getVersion()))
+            .thenReturn(sessionContextStore);
+        when(sessionContextStore.getSession("station", "session")).thenReturn(session);
+        when(sessionContextStore.getSession("station")).thenReturn(session);
+        when(session.getId()).thenReturn("session");
+        when(session.isOpen()).thenReturn(true);
+        when(taskStore.get(outCall.getPayload().taskUuid())).thenReturn(task);
+
+        try (var context = new AnnotationConfigApplicationContext()) {
+            context.register(MessagingConfiguration.class);
+            context.registerBean(Deserializer.class, () -> deserializer);
+            context.registerBean(SessionContextStoreHolder.class, () -> sessionContextStoreHolder);
+            context.registerBean(TaskStore.class, () -> taskStore);
+            context.registerBean(FutureResponseContextStore.class, () -> futureResponseContextStore);
+            context.register(IncomingPipeline.class, OutgoingPipeline.class);
+            context.refresh();
+
+            context.getBean(Messaging.In.Producer.class).send(in);
+            context.getBean(Messaging.Out.Producer.class).send(out);
+            context.getBean(Messaging.OutCall.Producer.class).send(outCall);
+
+            verify(task, timeout(2_000)).success("station", error);
+            verify(session, timeout(2_000).times(2)).sendMessage(any());
+            verify(futureResponseContextStore, timeout(2_000)).add(eq("session"), eq("message"), any());
+        }
+    }
+
+    @Test
+    public void incomingPipelinePreservesHeadersOnItsOutgoingMessage() throws Exception {
+        var outProducer = mock(Messaging.Out.Producer.class);
+        var deserializer = mock(Deserializer.class);
+        var in = inMessage();
+        var parseError = new OcppJsonError();
+        parseError.setMessageId("message");
+        parseError.setErrorCode(ErrorCode.FormationViolation);
+        when(deserializer.accept(in.getPayload()))
+            .thenThrow(new CommunicationContext.JsonCallParseException(parseError));
+        var pipeline = new IncomingPipeline(outProducer, deserializer, List.of());
+
+        pipeline.processIn(in);
+
+        var captor = forClass(Message.class);
+        verify(outProducer).send(captor.capture());
+        assertEquals("testValue", captor.getValue().getHeaders().get("testHeader"));
+    }
+
+    @Test
+    public void outgoingCallConsumerReportsAsynchronousSendFailureToTask() {
+        var taskStore = mock(TaskStore.class);
+        var task = mock(CommunicationTask.class);
+        var sessionContextStoreHolder = mock(SessionContextStoreHolder.class);
+        var sessionContextStore = mock(SessionContextStore.class);
+        var session = mock(WebSocketSession.class);
+        var futureResponseContextStore = mock(FutureResponseContextStore.class);
+        var outCall = outCallMessage();
+
+        when(taskStore.get(outCall.getPayload().taskUuid())).thenReturn(task);
+        when(sessionContextStoreHolder.getOrCreate(OcppProtocol.V_16_JSON.getVersion()))
+            .thenReturn(sessionContextStore);
+        when(sessionContextStore.getSession("station")).thenReturn(session);
+        when(session.getId()).thenReturn("session");
+        when(session.isOpen()).thenReturn(false);
+        var pipeline = new OutgoingPipeline(
+            taskStore,
+            sessionContextStoreHolder,
+            futureResponseContextStore
+        );
+
+        assertThrows(RuntimeException.class, () -> pipeline.processOutCall(outCall));
+
+        verify(futureResponseContextStore).poll("session", "message");
+        verify(task).failed(eq("station"), any(RuntimeException.class));
+    }
+
+    @Test
+    public void outgoingCallConsumerStoresCorrelationBeforeSending() throws Exception {
+        var taskStore = mock(TaskStore.class);
+        var task = mock(CommunicationTask.class);
+        var sessionContextStoreHolder = mock(SessionContextStoreHolder.class);
+        var sessionContextStore = mock(SessionContextStore.class);
+        var session = mock(WebSocketSession.class);
+        var futureResponseContextStore = mock(FutureResponseContextStore.class);
+        var outCall = outCallMessage();
+
+        when(taskStore.get(outCall.getPayload().taskUuid())).thenReturn(task);
+        when(sessionContextStoreHolder.getOrCreate(OcppProtocol.V_16_JSON.getVersion()))
+            .thenReturn(sessionContextStore);
+        when(sessionContextStore.getSession("station")).thenReturn(session);
+        when(session.getId()).thenReturn("session");
+        when(session.isOpen()).thenReturn(true);
+        var pipeline = new OutgoingPipeline(
+            taskStore,
+            sessionContextStoreHolder,
+            futureResponseContextStore
+        );
+
+        pipeline.processOutCall(outCall);
+
+        var inOrder = inOrder(futureResponseContextStore, session);
+        inOrder.verify(futureResponseContextStore).add(eq("session"), eq("message"), any());
+        inOrder.verify(session).sendMessage(any());
+    }
+
+    private static Message<CommunicationContext.In> inMessage() {
+        return message(new CommunicationContext.In(
+            "station",
+            OcppProtocol.V_16_JSON,
+            "session",
+            "in"
+        ));
+    }
+
+    private static Message<CommunicationContext.Out> outMessage() {
+        return message(new CommunicationContext.Out(
+            "station",
+            OcppProtocol.V_16_JSON,
+            "session",
+            "out"
+        ));
+    }
+
+    private static Message<CommunicationContext.OutCall> outCallMessage() {
+        return message(new CommunicationContext.OutCall(
+            "station",
+            OcppProtocol.V_16_JSON,
+            UUID.randomUUID(),
+            "call",
+            "Heartbeat",
+            "message"
+        ));
+    }
+
+    private static <T> Message<T> message(T payload) {
+        return MessageBuilder.withPayload(payload)
+            .setHeader("testHeader", "testValue")
+            .build();
+    }
+}

--- a/src/test/java/de/rwth/idsg/steve/messaging/InMemoryMessageQueueTest.java
+++ b/src/test/java/de/rwth/idsg/steve/messaging/InMemoryMessageQueueTest.java
@@ -34,18 +34,23 @@ import de.rwth.idsg.steve.ocpp.ws.pipeline.OutgoingPipeline;
 import de.rwth.idsg.steve.repository.TaskStore;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.integration.channel.ExecutorChannel;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.endpoint.EventDrivenConsumer;
+import org.springframework.integration.endpoint.PollingConsumer;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentCaptor.forClass;
@@ -60,10 +65,10 @@ public class InMemoryMessageQueueTest {
     private final MessagingConfiguration configuration = new MessagingConfiguration();
 
     @Test
-    public void producersEnqueueTheirMessages() {
-        var inChannel = configuration.ocppInChannel();
-        var outChannel = configuration.ocppOutChannel();
-        var outCallChannel = configuration.ocppOutCallChannel();
+    public void producersSendMessagesToTheirChannels() {
+        var inChannel = new QueueChannel(1);
+        var outChannel = new QueueChannel(1);
+        var outCallChannel = new QueueChannel(1);
         var in = inMessage();
         var out = outMessage();
         var outCall = outCallMessage();
@@ -75,27 +80,6 @@ public class InMemoryMessageQueueTest {
         assertSame(in, inChannel.receive(0));
         assertSame(out, outChannel.receive(0));
         assertSame(outCall, outCallChannel.receive(0));
-    }
-
-    @Test
-    public void producersFailWhenTheirQueueRemainsFull() {
-        var inChannel = new QueueChannel(1);
-        var outChannel = new QueueChannel(1);
-        var outCallChannel = new QueueChannel(1);
-        var inProducer = configuration.inProducer(inChannel);
-        var outProducer = configuration.outProducer(outChannel);
-        var outCallProducer = configuration.outCallProducer(outCallChannel);
-        var in = inMessage();
-        var out = outMessage();
-        var outCall = outCallMessage();
-
-        inProducer.send(in);
-        outProducer.send(out);
-        outCallProducer.send(outCall);
-
-        assertThrows(MessageDeliveryException.class, () -> inProducer.send(in));
-        assertThrows(MessageDeliveryException.class, () -> outProducer.send(out));
-        assertThrows(MessageDeliveryException.class, () -> outCallProducer.send(outCall));
     }
 
     @Test
@@ -112,12 +96,16 @@ public class InMemoryMessageQueueTest {
         var in = inMessage();
         var out = outMessage();
         var outCall = outCallMessage();
+        var inboundThreadName = new AtomicReference<String>();
 
-        when(deserializer.accept(in.getPayload())).thenReturn(new CommunicationContext.InError(
-            in.getPayload(),
-            error,
-            inboundFutureResponseContext
-        ));
+        when(deserializer.accept(in.getPayload())).thenAnswer(invocation -> {
+            inboundThreadName.set(Thread.currentThread().getName());
+            return new CommunicationContext.InError(
+                in.getPayload(),
+                error,
+                inboundFutureResponseContext
+            );
+        });
         when(inboundFutureResponseContext.getTask()).thenReturn(task);
         when(sessionContextStoreHolder.getOrCreate(OcppProtocol.V_16_JSON.getVersion()))
             .thenReturn(sessionContextStore);
@@ -136,6 +124,17 @@ public class InMemoryMessageQueueTest {
             context.register(IncomingPipeline.class, OutgoingPipeline.class);
             context.refresh();
 
+            assertInstanceOf(ExecutorChannel.class, context.getBean(MessagingConfiguration.IN_CHANNEL));
+            assertInstanceOf(ExecutorChannel.class, context.getBean(MessagingConfiguration.OUT_CHANNEL));
+            assertInstanceOf(ExecutorChannel.class, context.getBean(MessagingConfiguration.OUT_CALL_CHANNEL));
+            assertInstanceOf(EventDrivenConsumer.class,
+                context.getBean("incomingPipeline.processIn.serviceActivator"));
+            assertInstanceOf(EventDrivenConsumer.class,
+                context.getBean("outgoingPipeline.processOut.serviceActivator"));
+            assertInstanceOf(EventDrivenConsumer.class,
+                context.getBean("outgoingPipeline.processOutCall.serviceActivator"));
+            assertTrue(context.getBeansOfType(PollingConsumer.class).isEmpty());
+
             context.getBean(Messaging.In.Producer.class).send(in);
             context.getBean(Messaging.Out.Producer.class).send(out);
             context.getBean(Messaging.OutCall.Producer.class).send(outCall);
@@ -143,6 +142,7 @@ public class InMemoryMessageQueueTest {
             verify(task, timeout(2_000)).success("station", error);
             verify(session, timeout(2_000).times(2)).sendMessage(any());
             verify(futureResponseContextStore, timeout(2_000)).add(eq("session"), eq("message"), any());
+            assertTrue(inboundThreadName.get().startsWith("ocppInExecutor-"));
         }
     }
 

--- a/src/test/java/de/rwth/idsg/steve/messaging/InMemoryMessageQueueTest.java
+++ b/src/test/java/de/rwth/idsg/steve/messaging/InMemoryMessageQueueTest.java
@@ -42,6 +42,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.web.socket.WebSocketSession;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -227,7 +228,7 @@ public class InMemoryMessageQueueTest {
             "station",
             OcppProtocol.V_16_JSON,
             "session",
-            System.currentTimeMillis(),
+            Instant.now(),
             "in"
         ));
     }

--- a/src/test/java/de/rwth/idsg/steve/messaging/InMemoryMessageQueueTest.java
+++ b/src/test/java/de/rwth/idsg/steve/messaging/InMemoryMessageQueueTest.java
@@ -227,6 +227,7 @@ public class InMemoryMessageQueueTest {
             "station",
             OcppProtocol.V_16_JSON,
             "session",
+            System.currentTimeMillis(),
             "in"
         ));
     }

--- a/src/test/java/de/rwth/idsg/steve/ocpp/ws/FutureResponseContextStoreImplTest.java
+++ b/src/test/java/de/rwth/idsg/steve/ocpp/ws/FutureResponseContextStoreImplTest.java
@@ -22,9 +22,12 @@ import de.rwth.idsg.steve.ocpp.ws.data.FutureResponseContext;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class FutureResponseContextStoreImplTest {
 
@@ -52,5 +55,35 @@ public class FutureResponseContextStoreImplTest {
         assertTrue(store.containsKey("session"));
         assertSame(secondContext, store.poll("session", "second"));
         assertFalse(store.containsKey("session"));
+    }
+
+    @Test
+    public void addRetainsContextUntilRetentionPeriodIsExceeded() {
+        var store = new FutureResponseContextStoreImpl();
+        var retainedContext = mock(FutureResponseContext.class);
+        var newContext = mock(FutureResponseContext.class);
+
+        when(retainedContext.hasTimedOut(any())).thenReturn(true);
+        when(retainedContext.hasExceededRetentionPeriod(any())).thenReturn(false);
+
+        store.add("session", "retained", retainedContext);
+        store.add("session", "new", newContext);
+
+        assertSame(retainedContext, store.poll("session", "retained"));
+    }
+
+    @Test
+    public void addEvictsContextAfterRetentionPeriodIsExceeded() {
+        var store = new FutureResponseContextStoreImpl();
+        var expiredContext = mock(FutureResponseContext.class);
+        var newContext = mock(FutureResponseContext.class);
+
+        when(expiredContext.hasExceededRetentionPeriod(any())).thenReturn(true);
+
+        store.add("session", "expired", expiredContext);
+        store.add("session", "new", newContext);
+
+        assertNull(store.poll("session", "expired"));
+        assertSame(newContext, store.poll("session", "new"));
     }
 }

--- a/src/test/java/de/rwth/idsg/steve/ocpp/ws/pipeline/DeserializerTest.java
+++ b/src/test/java/de/rwth/idsg/steve/ocpp/ws/pipeline/DeserializerTest.java
@@ -19,17 +19,21 @@
 package de.rwth.idsg.steve.ocpp.ws.pipeline;
 
 import de.rwth.idsg.steve.ocpp.OcppProtocol;
+import de.rwth.idsg.steve.ocpp.ws.FutureResponseContextStore;
 import de.rwth.idsg.steve.ocpp.ws.FutureResponseContextStoreImpl;
 import de.rwth.idsg.steve.ocpp.ws.SessionContextStore;
 import de.rwth.idsg.steve.ocpp.ws.SessionContextStoreHolder;
 import de.rwth.idsg.steve.ocpp.ws.data.CommunicationContext;
+import de.rwth.idsg.steve.ocpp.ws.data.FutureResponseContext;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonCall;
 import de.rwth.idsg.steve.ocpp.ws.data.OcppJsonError;
 import de.rwth.idsg.steve.ocpp.ws.ocpp16.Ocpp16TypeStore;
+import ocpp.cp._2015._10.UpdateFirmwareResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -154,6 +158,71 @@ public class DeserializerTest {
         Assertions.assertNull(error.getMessageId());
     }
 
+    @Test
+    public void testCallResultArrivedBeforeDeadlineIsAcceptedAfterDeadline() throws Exception {
+        String sessionId = UUID.randomUUID().toString();
+        String messageId = "result-before-deadline";
+        Instant deadline = Instant.parse("2026-01-01T00:00:30Z");
+        Instant arrivedAt = deadline.minusMillis(1);
+        FutureResponseContext responseContext = responseContextExpiringAt(deadline);
+        Deserializer deserializer = createDeserializerWith(storeReturning(sessionId, messageId, responseContext));
+
+        CommunicationContext.DeserializationResult result = deserializer.accept(inbound(
+            sessionId,
+            arrivedAt,
+            "[3,\"" + messageId + "\",{}]"
+        ));
+
+        CommunicationContext.InResult inResult = Assertions.assertInstanceOf(CommunicationContext.InResult.class, result);
+        Assertions.assertSame(responseContext, inResult.frc());
+        Assertions.assertInstanceOf(UpdateFirmwareResponse.class, inResult.result().getPayload());
+        Mockito.verify(responseContext).hasTimedOut(arrivedAt);
+    }
+
+    @Test
+    public void testCallErrorArrivedBeforeDeadlineIsAcceptedAfterDeadline() throws Exception {
+        String sessionId = UUID.randomUUID().toString();
+        String messageId = "error-before-deadline";
+        Instant deadline = Instant.parse("2026-01-01T00:00:30Z");
+        Instant arrivedAt = deadline.minusMillis(1);
+        FutureResponseContext responseContext = responseContextExpiringAt(deadline);
+        Deserializer deserializer = createDeserializerWith(storeReturning(sessionId, messageId, responseContext));
+
+        CommunicationContext.DeserializationResult result = deserializer.accept(inbound(
+            sessionId,
+            arrivedAt,
+            "[4,\"" + messageId + "\",\"InternalError\",\"\",{}]"
+        ));
+
+        CommunicationContext.InError inError = Assertions.assertInstanceOf(CommunicationContext.InError.class, result);
+        Assertions.assertSame(responseContext, inError.frc());
+        Assertions.assertEquals(InternalError, inError.error().getErrorCode());
+        Mockito.verify(responseContext).hasTimedOut(arrivedAt);
+    }
+
+    @Test
+    public void testResponseArrivedAfterDeadlineIsRejected() {
+        String sessionId = UUID.randomUUID().toString();
+        String messageId = "result-after-deadline";
+        Instant deadline = Instant.parse("2026-01-01T00:00:30Z");
+        Instant arrivedAt = deadline.plusMillis(1);
+        FutureResponseContext responseContext = responseContextExpiringAt(deadline);
+        Deserializer deserializer = createDeserializerWith(storeReturning(sessionId, messageId, responseContext));
+
+        var exception = Assertions.assertThrows(
+            CommunicationContext.JsonResponseInvalidException.class,
+            () -> deserializer.accept(inbound(
+                sessionId,
+                arrivedAt,
+                "[3,\"" + messageId + "\",{}]"
+            ))
+        );
+
+        Assertions.assertEquals("A response message was received to an expired call", exception.getMessage());
+        Assertions.assertSame(responseContext, exception.getFrc());
+        Mockito.verify(responseContext).hasTimedOut(arrivedAt);
+    }
+
     private static OcppJsonError deserializeError(Deserializer deserializer, String payload) {
         var exception = Assertions.assertThrows(
             CommunicationContext.JsonCallParseException.class,
@@ -163,10 +232,15 @@ public class DeserializerTest {
     }
 
     private static CommunicationContext.In inbound(String payload) {
+        return inbound(UUID.randomUUID().toString(), Instant.now(), payload);
+    }
+
+    private static CommunicationContext.In inbound(String sessionId, Instant arrivedAt, String payload) {
         return new CommunicationContext.In(
             "foo",
             OcppProtocol.V_16_JSON,
-            UUID.randomUUID().toString(),
+            sessionId,
+            arrivedAt.toEpochMilli(),
             payload);
     }
 
@@ -175,7 +249,15 @@ public class DeserializerTest {
     }
 
     private static Deserializer createDeserializer(Boolean registerIncomingCallIdResponse) {
-        var futureResponseContextStore = new FutureResponseContextStoreImpl();
+        return createDeserializer(new FutureResponseContextStoreImpl(), registerIncomingCallIdResponse);
+    }
+
+    private static Deserializer createDeserializerWith(FutureResponseContextStore futureResponseContextStore) {
+        return createDeserializer(futureResponseContextStore, true);
+    }
+
+    private static Deserializer createDeserializer(FutureResponseContextStore futureResponseContextStore,
+                                                   Boolean registerIncomingCallIdResponse) {
 
         SessionContextStore store = Mockito.mock(SessionContextStore.class);
         when(store.registerIncomingCallId(any(), any(), any())).thenReturn(registerIncomingCallIdResponse);
@@ -188,6 +270,23 @@ public class DeserializerTest {
         when(handler.getTypeStore()).thenReturn(Ocpp16TypeStore.INSTANCE);
 
         return new Deserializer(futureResponseContextStore, holder, List.of(handler));
+    }
+
+    private static FutureResponseContextStore storeReturning(String sessionId, String messageId,
+                                                              FutureResponseContext responseContext) {
+        FutureResponseContextStore store = Mockito.mock(FutureResponseContextStore.class);
+        when(store.poll(sessionId, messageId)).thenReturn(responseContext);
+        return store;
+    }
+
+    private static FutureResponseContext responseContextExpiringAt(Instant deadline) {
+        FutureResponseContext responseContext = Mockito.mock(FutureResponseContext.class);
+        Mockito.doReturn(UpdateFirmwareResponse.class).when(responseContext).getResponseClass();
+        when(responseContext.hasTimedOut(any())).thenAnswer(invocation -> {
+            Instant time = invocation.getArgument(0);
+            return deadline.isBefore(time);
+        });
+        return responseContext;
     }
 
 }

--- a/src/test/java/de/rwth/idsg/steve/ocpp/ws/pipeline/DeserializerTest.java
+++ b/src/test/java/de/rwth/idsg/steve/ocpp/ws/pipeline/DeserializerTest.java
@@ -240,7 +240,7 @@ public class DeserializerTest {
             "foo",
             OcppProtocol.V_16_JSON,
             sessionId,
-            arrivedAt.toEpochMilli(),
+            arrivedAt,
             payload);
     }
 


### PR DESCRIPTION
Message flow is now:
- all incoming: WebSocketEndpoint → inbound queue  → IncomingPipeline
- outgoing responses: IncomingPipeline  → outbound queue → OutgoingPipeline
- outgoing calls: ChargePointServiceJsonInvoker → outbound-call queue → OutgoingPipeline